### PR TITLE
Also unset the 'a' flag in formatoptions.

### DIFF
--- a/plugin/UltiSnips/__init__.py
+++ b/plugin/UltiSnips/__init__.py
@@ -1108,9 +1108,9 @@ class SnippetManager(object):
         # Care for textwrapping
         if not snippet.keep_formatoptions_unchanged:
             self._cached_offending_vim_options["fo"] = ''.join(
-                c for c in vim.eval("&fo") if c in "ct"
+                c for c in vim.eval("&fo") if c in "cta"
             )
-            for c in "ct": vim.command("set fo-=%s" % c)
+            for c in "cta": vim.command("set fo-=%s" % c)
 
     def _reset_offending_vim_options(self):
         # Textwrapping


### PR DESCRIPTION
Hi!

I've had a problem invoking snippets in TeX files because I was doing formatoptions+=a. Luckily you already had the code to disable offending formatoptions. :-)

With this little change, UltiSnips works 100% perfect for me.

Thanks!

PS: This is the first time I do a pull request. Feel free to correct me if anything is wrong.
