### PR TITLE
Added Support for CSS style comment boxes

### DIFF
--- a/UltiSnips/all.snippets
+++ b/UltiSnips/all.snippets
@@ -10,6 +10,9 @@ def cs(snip):
     cs = snip.opt("&commentstring")
     if len(cs) == 3:
         c = cs[0]
+        if len(cs) == 6:
+    	c = cs[1]
+
     return c
 endglobal
 
@@ -17,29 +20,37 @@ snippet box "A nice box with the current comment symbol" b
 `!p
 c = cs(snip)
 
-snip.rv = (len(t[1])+4)*c
-bar = snip.rv
+pre = ''
+if (c =='*'):
+    pre = '/'
+bar = (len(t[1])+ (4 - len(pre)))*c
+snip.rv = pre + bar
 snip += c + ' '`${1:content}`!p
-
 snip.rv = ' ' + c
-snip += bar`
+snip += bar +pre`
 $0
 endsnippet
 
 snippet bbox "A nice box over the full width" b
 `!p
 c = cs(snip)
-bar = 75*c 
 
-snip.rv = bar
+pre = ''
+if (c =='*'):
+    pre = '/'
+
+bar = 75*c
+
+snip.rv = pre + bar
 snip += c + " " + (71-len(t[1]))/2*' '
 `${1:content}`!p
 
 a = 71-len(t[1])
 snip.rv = (a/2 + a%2) * " " + " " + c 
-snip += bar`
+snip += bar + pre`
 $0
 endsnippet
+
 
 ##########################
 # LOREM IPSUM GENERATORS #


### PR DESCRIPTION
I wanted to use the comment box snippet in my css but I was getting # as the comment character. I modified the snippet to check for the css comment string and if so return \* as the comment char and pre/append '/' to the comment box.
