### PR TITLE
Fix bug in python snipmate conversion script, to avoid skipping every other snippet

### DIFF
--- a/utils/convert_snipmate_snippets.py
+++ b/utils/convert_snipmate_snippets.py
@@ -48,7 +48,15 @@ def convert_snippet_file(source):
             # In snippet: Check if indentation level is the same. If not, snippet has ended
             if line[:len(whitespace)] != whitespace:
                 retval += convert_snippet_contents(snippet) + "endsnippet\n\n"
-                state = 0
+                # Copy-paste the section from state=0 so that we don't skip every other snippet
+                if line[:8] == "snippet ":
+                    snippet_info = re.match("(\S+)\s*(.*)", line[8:])
+                    if not snippet_info:
+                        print >> sys.stderr, "Warning: Malformed snippet\n %s\n" % line
+                        continue
+                    retval += 'snippet %s "%s"' % (snippet_info.group(1), snippet_info.group(2) if snippet_info.group(2) else snippet_info.group(1)) + "\n"
+                    state = 1
+                    snippet = ""
             else:
                 snippet += line[len(whitespace):]
     if state == 2:


### PR DESCRIPTION
I found out that the python script used to convert from the snipmate format to the UltiSnips one has a bug: it skips every other snippet.
This commit fixes the python script, in a very inelegant way, i.e. by copying the code from the state=0 section to the bottom of the state=2 section. I honestly don't know python so I'm sure there's a better way to _retry_ the loop. In the meanwhile, this is a good enough working solution.
