### PR TITLE
Allow Sphinx info field list-formatted docstrings.

### DIFF
--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -27,6 +27,7 @@ global !p
 
 NORMAL  = 0x1
 DOXYGEN = 0x2
+SPHINX  = 0x3
 
 def get_args(arglist):
     args = [arg.split('=')[0].strip() for arg in arglist.split(',') if arg]
@@ -39,12 +40,15 @@ def get_style(snip):
     style = snip.opt("g:ultisnips_python_style", "normal")
 
     if    style == "doxygen": return DOXYGEN
+    elif  style == "sphinx": return SPHINX
     else: return NORMAL
 
 
 def format_arg(arg, style):
     if style == DOXYGEN:
         return "@param %s @todo" % arg
+    elif style == SPHINX:
+        return ":param %s: @todo" % arg
     elif style == NORMAL:
         return ":%s: @todo" % arg
 
@@ -52,7 +56,7 @@ def format_arg(arg, style):
 def format_return(style):
     if style == DOXYGEN:
         return "@return: @todo"
-    elif style == NORMAL:
+    elif style in (NORMAL, SPHINX):
         return ":returns: @todo"
 
 


### PR DESCRIPTION
This change supports Sphinx info field lists in docstrings.
http://sphinx.pocoo.org/domains.html#info-field-lists

The user can specify this preference by setting the
`ultisnips_python_style` variable to `"sphinx"`; e.g., in the .vimrc
or other configuration file, add the following line:

```
let g:ultisnips_python_style = "sphinx"
```
