### PR TITLE
Add to docs on interaction of visual modes and ${VISUAL}

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -21,6 +21,7 @@ UltiSnips                                      *snippet* *snippets* *UltiSnips*
       4.1.1 Character Escaping                  |UltiSnips-character-escaping|
    4.2 Plaintext Snippets                       |UltiSnips-plaintext-snippets|
    4.3 Visual Placeholder                       |UltiSnips-visual-placeholder|
+      4.3.1 Visual modes and ${VISUAL}          |UltiSnips-visual-modes|
    4.4 Interpolation                            |UltiSnips-interpolation|
       4.4.1 Shellcode                           |UltiSnips-shellcode|
       4.4.2 VimScript                           |UltiSnips-vimscript|
@@ -566,6 +567,44 @@ again. The result is: >
 If you expand this snippet while not in Visual mode (e.g., in Insert mode type
 t<Tab>), you will get: >
    <tag>inside text</tag>
+
+ 4.3.1 Visual modes and ${VISUAL}:                   *UltiSnips-visual-modes*
+
+The Vim visual mode affects how ${VISUAL} will be indented by a snippet.
+Consider the following example, which uses a leading tab in the snippet body
+to cause the inserted text to be indented:
+
+------------------- SNIP -------------------
+snippet {{ "Insert a viml manual fold block" !b
+" ${1:Description} {
+	${2:${VISUAL}}
+" }
+$3
+endsnippet
+------------------- SNAP -------------------
+this is line one
+this is line two<ESC>vk0<tab>{{<tab> ->
+" Description {
+  this is line one
+this is line two
+" }
+
+In this example, the two lines are typed in *insert-mode* then selected in
+*characterwise-visual* mode.  Only the first line is indented due to the
+visual mode in use.  In visual and visual block modes the selected text will
+not be internally modified.
+
+Here is an example using the same snippet with a *linewise-visual* selection:
+
+------------------- SNAP -------------------
+this is line one
+this is line two<ESC>Vk<tab>{{<tab> ->
+" Description {
+  this is line one
+  this is line two
+" }
+
+Observe that all lines of the selection are indented.
 
 
 4.4 Interpolation                                   *UltiSnips-interpolation*


### PR DESCRIPTION
This is WIP branch towards documenting issues discussed in [my recent question on Launchpad](https://answers.launchpad.net/ultisnips/+question/199400).  It covers some of the basics of how Vim's visual modes interact with `${VISUAL}`.  Open issues:
- I'm decidedly unsure about how to approach examples involving a visual selection.  I went with an approach that's a bit VimGolf-y.  I worry that this will be inscrutable to a Vim newcomer.
- From some experimentation, there's more to how visual block mode interacts with UltiSnips than is covered here.
- I haven't yet added a `snip.v` example.  I'm contemplating how to approach that a bit better; the one in the LP question seems a bit wonky after playing with it a bit.

Any/all feedback is appreciated.  I'll incorporate that as I continue work on this branch.
