### PR TITLE
Fixed c/cpp comment boxes

### DIFF
--- a/UltiSnips/all.snippets
+++ b/UltiSnips/all.snippets
@@ -12,6 +12,7 @@ Automatically filled during usage"""
 _commentDict = { }
 
 def _parse_comments(s):
+    """ Parses vim's comments option to extract comment format """
     i = iter(s.split(","))
 
     rv = []
@@ -21,10 +22,10 @@ def _parse_comments(s):
             flags,text = i.next().split(':', 1)
 
             if len(flags) == 0:
-                rv.append((text,text,text, ""))
-
+                if len(text) == 1:
+                    rv.append((text,text,text, ""))
             # parse 3-part comment, but ignore those with O flag
-            elif flags[1] == 's' and 'O' not in flags:
+            elif flags[0] == 's' and 'O' not in flags:
                 ctriple = []
                 indent = ""
 


### PR DESCRIPTION
When using ultisnips in c and cpp file, I noticed comment boxes would come out wrong:

``` cpp
* -*  *  *  *  *  *  *  *  *  *  *  *  
*    content  *  
*  *  *  *  *  *  *  *  *  *  *  *  */
```

This was due to the comments option being:

```
sO:* -,mO:*  ,exO:*/,s1:/*,mb:*,ex:*/,://
```

Looking at the vim documentation the 'O' flag means:

```
O    Don't consider this comment for the "O" command.
```

I added some code to look out for that flag, so those 3-part comments are not used to make comment boxes, as well as making the parsing slightly more robust. Comments in c/cpp files now look correct:

``` cpp
/*************
 *  content  *
 *************/
```

Thanks for making ultisnips, and please let me know if anything is wrong with my changes! :D
