### PR TITLE
Leave new scratch buffers in command mode

### DIFF
--- a/plugin/UltiSnips/_vim.py
+++ b/plugin/UltiSnips/_vim.py
@@ -119,6 +119,8 @@ def new_scratch_buffer(text):
 
     vim.buffers[-1][:] = text.splitlines()
 
+    feedkeys(r"\<Esc>")
+
 def select(start, end):
     """Select the span in Select mode"""
 


### PR DESCRIPTION
Modify new_scratch_buffer method to leave the created buffer in command
rather than insert mode.  Currently the only use of this method is for
showing stack traces for errors, when that happens it's much more likely
that the user will want to use command mode to move around than to use
insert mode to add text to the beginning of the buffer.
