### PR TITLE
Matchit support for snippet files

### DIFF
--- a/ftplugin/snippets.vim
+++ b/ftplugin/snippets.vim
@@ -3,3 +3,10 @@
 " Fold by syntax, but open all folds by default
 setlocal foldmethod=syntax
 setlocal foldlevel=99
+
+" Define match words for use with matchit plugin
+" http://www.vim.org/scripts/script.php?script_id=39
+if exists("loaded_matchit") && !exists("b:match_words")
+  let b:match_ignorecase = 0
+  let b:match_words = '^snippet\>:^endsnippet\>,^global\>:^endglobal\>,\${:}'
+endif


### PR DESCRIPTION
If the matchit (http://www.vim.org/scripts/script.php?script_id=39)
plugin is loaded, define pairs to be handled by the % key.
