### PR TITLE
Convert snipmate snippets fix

### DIFF
--- a/utils/convert_snipmate_snippets.py
+++ b/utils/convert_snipmate_snippets.py
@@ -22,9 +22,9 @@ def convert_snippet_file(source):
         # Ignore empty lines
         if line.strip() == "":
             continue
-        # The rest of the handlig is stateful
+        # The rest of the handling is stateful
         if state == 0:
-            # Find snippet start
+            # Find snippet start. Keep comments.
             if line[:8] == "snippet ":
                 snippet_info = re.match("(\S+)\s*(.*)", line[8:])
                 if not snippet_info:
@@ -33,6 +33,9 @@ def convert_snippet_file(source):
                 retval += 'snippet %s "%s"' % (snippet_info.group(1), snippet_info.group(2) if snippet_info.group(2) else snippet_info.group(1)) + "\n"
                 state = 1
                 snippet = ""
+            elif line[:1] == "#":
+                retval += line
+                state = 0
         elif state == 1:
             # First line of snippet: Get indentation
             whitespace = re.search("^\s+", line)
@@ -45,10 +48,12 @@ def convert_snippet_file(source):
                 snippet += line[len(whitespace):]
                 state = 2
         elif state == 2:
-            # In snippet: Check if indentation level is the same. If not, snippet has ended
-            if line[:len(whitespace)] != whitespace:
+            # In snippet: If indentation level is the same, add to snippet. Else end snippet.
+            if line[:len(whitespace)] == whitespace:
+                snippet += line[len(whitespace):]
+            else:
                 retval += convert_snippet_contents(snippet) + "endsnippet\n\n"
-                # Copy-paste the section from state=0 so that we don't skip every other snippet
+                #Copy-paste the section from state=0 so that we don't skip every other snippet
                 if line[:8] == "snippet ":
                     snippet_info = re.match("(\S+)\s*(.*)", line[8:])
                     if not snippet_info:
@@ -57,8 +62,9 @@ def convert_snippet_file(source):
                     retval += 'snippet %s "%s"' % (snippet_info.group(1), snippet_info.group(2) if snippet_info.group(2) else snippet_info.group(1)) + "\n"
                     state = 1
                     snippet = ""
-            else:
-                snippet += line[len(whitespace):]
+                elif line[:1] == "#":
+                    retval += line
+                    state = 0
     if state == 2:
         retval += convert_snippet_contents(snippet) + "endsnippet\n\n"
     return retval


### PR DESCRIPTION
This PR fixes 3 issues I encountered when moving from Snipmate to UtilSnips:
1.  When the source file name was the same as the  target file name, then the result was an empty file.
   - Now the script will overwrite the file.
2. If source file contained comments, then the conversion would break and repeat the previous snippet over and over until it hit a line with `snippet`
   - Now the script properly ends the snippet when it finds a comment line
3. Comments were deleted
   - Now the script preserves comments
