### PR TITLE
Some very minor changes to the perl snippets

### DIFF
--- a/UltiSnips/perl.snippets
+++ b/UltiSnips/perl.snippets
@@ -49,7 +49,7 @@ ${1:expression} while ${2:condition};
 endsnippet
 
 snippet test "Test"
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 
 use strict;
 use Test::More tests => ${1:1};
@@ -105,8 +105,7 @@ if ($1) {
 endsnippet
 
 snippet slurp "slurp"
-my $${1:var};
-{ local $/ = undef; local *FILE; open FILE, "<${2:file}"; $$1 = <FILE>; close FILE }
+my $${1:var} = do { local $/ = undef; open my $fh, '<', ${2:$file}; <$fh> };
 
 endsnippet
 


### PR DESCRIPTION
I've adjusted one of the snippets to use 3 form version of open (safer) and to use scoped variables not localised barewords, otherwise the functionality is identical.

I also changed a hashbang line in one of the snippets so that the file it produces uses the right perl.
