### PR TITLE
Remove stray space in LaTeX section snippet

### DIFF
--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -75,7 +75,7 @@ ${0}
 endsnippet
 
 snippet sec "Section" b
-\section{${1:section name}} 
+\section{${1:section name}}
 \label{sec:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/g}}}
 
 ${0}


### PR DESCRIPTION
The reason why this patch matters is that every time 'sec' is expanded to '\section{}' a space is added at the end of the line (after the closing curly brace).
