### PR TITLE
Added Visual markers to C and C++ snippets

### DIFF
--- a/UltiSnips/c.snippets
+++ b/UltiSnips/c.snippets
@@ -14,7 +14,7 @@ endsnippet
 
 snippet #if "#if #endif" !b
 #if ${1:0}
-${VISUAL:code}$0
+${VISUAL}${0:${VISUAL/(.*)/(?1::code)/}}
 #endif
 endsnippet
 
@@ -38,7 +38,7 @@ endsnippet
 snippet main "main() (main)"
 int main(int argc, char const *argv[])
 {
-	${0:/* code */}
+	${VISUAL}${0:${VISUAL/(.*)/(?1::\/* code *\/)/}}
 	return 0;
 }
 endsnippet
@@ -46,7 +46,7 @@ endsnippet
 snippet for "for int loop (fori)"
 for (${4:size_t} ${2:i} = 0; $2 < ${1:count}; ${3:++$2})
 {
-	${0:/* code */}
+	${VISUAL}${0:${VISUAL/(.*)/(?1::\/* code *\/)/}}
 }
 endsnippet
 
@@ -77,7 +77,7 @@ endsnippet
 
 snippet do "do...while loop (do)"
 do {
-	${0:/* code */}
+	${VISUAL}${0:${VISUAL/(.*)/(?1::\/* code *\/)/}}
 } while(${1:/* condition */});
 endsnippet
 
@@ -88,18 +88,18 @@ endsnippet
 snippet if "if .. (if)"
 if (${1:/* condition */})
 {
-	${0:/* code */}
+	${VISUAL}${0:${VISUAL/(.*)/(?1::\/* code *\/)/}}
 }
 endsnippet
 
 snippet ife "if .. else (ife)"
 if (${1:/* condition */})
 {
-        ${2:/* code */}
+	${2:/* code */}
 }
 else
 {
-        ${3:/* else */}
+	${3:/* else */}
 }
 endsnippet
 

--- a/UltiSnips/cpp.snippets
+++ b/UltiSnips/cpp.snippets
@@ -22,7 +22,7 @@ endsnippet
 snippet ns "namespace .. (namespace)"
 namespace${1/.+/ /m}${1:`!p snip.rv = snip.basename or "name"`}
 {
-	$0
+	${VISUAL}${0:${VISUAL/(.*)/(?1::\/* code *\/)/}}
 }${1/.+/ \/* /m}$1${1/.+/ *\/ /m}
 endsnippet
 


### PR DESCRIPTION
This adds visual markers to C and C++ snippets where (I think) it makes sense. The way I've added them is a little weird. It looks like this for most

${VISUAL}${0:${VISUAL/(._)/(?1::\/_ code *\/)/}}

The reason for this is I wanted the $0 tabstop to have no default text when the VISUAL marker contains text and otherwise have the default text /\* code */. This is the only way I could come up with to do this. If there is a better way, let me know.

also changed ife snippet to have tabs instead of spaces
