### PR TITLE
Set comment string to #%s

### DIFF
--- a/ftplugin/snippets.vim
+++ b/ftplugin/snippets.vim
@@ -4,6 +4,8 @@
 setlocal foldmethod=syntax
 setlocal foldlevel=99
 
+setlocal commentstring=#%s
+
 " Define match words for use with matchit plugin
 " http://www.vim.org/scripts/script.php?script_id=39
 if exists("loaded_matchit") && !exists("b:match_words")


### PR DESCRIPTION
This allows the @tpope's vim-commentary plugin to work with UltiSnips .snippet files; e.g. typing `\\\` will comment out the current line with "# ".
