### PR TITLE
add python module path to global variable

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -12,6 +12,7 @@ UltiSnips                                      *snippet* *snippets* *UltiSnips*
    3.1 Commands                                 |UltiSnips-commands|
    3.2 Triggers                                 |UltiSnips-triggers|
       3.2.1 Using your own trigger functions    |UltiSnips-trigger-functions|
+      3.2.2 Path to Python Module               |UltiSnips-python-module-path|
    3.3 Snippet Search Path                      |UltiSnips-snippet-search-path|
    3.4 Warning About Select Mode Mappings       |UltiSnips-warning-smappings|
    3.5 Functions                                |UltiSnips-functions|
@@ -281,6 +282,28 @@ then you define your mapping as >
 
 and if the you can't expand or jump from the current location then the
 alternative function IMAP_Jumpfunc('', 0) is called.
+
+3.2.2 Path to Python module                   *UltiSnips-python-module-path*
+---------------------------
+
+For even more advanced usage, you can directly write python functions
+using UltiSnips python module.
+
+Path to UltiSnips module is stored in g:UltiSnipsPythonPath variable which is
+set automatically.
+
+Usage is as follows: expample function to expand a snippet >
+
+   function! s:Ulti_ExpandSnip()
+   Python << EOF
+   import sys, vim
+   new_path = vim.eval("expand('g:UltiSnipsPythonPath')")
+   sys.path.append(new_path)
+   from UltiSnips import UltiSnips_Manager
+   UltiSnips_Manager.expand()
+   EOF
+   return ""
+   endfunction
 
 3.3 Snippet Search Path                       *UltiSnips-snippet-search-path*
 -----------------------

--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -227,6 +227,7 @@ endf
 " Expand our path
 exec g:_uspy "import vim, os, sys"
 exec g:_uspy "new_path = vim.eval('expand(\"<sfile>:h\")')"
+exec g:_uspy "vim.command(\"let g:UltiSnipsPythonPath = '%s'\" % new_path)"
 exec g:_uspy "sys.path.append(new_path)"
 exec g:_uspy "from UltiSnips import UltiSnips_Manager"
 exec g:_uspy "UltiSnips_Manager.expand_trigger = vim.eval('g:UltiSnipsExpandTrigger')"


### PR DESCRIPTION
I'm writing a neocomplcache snippet completion extension and I need to use some functions from your module that are not globally available.
I think there's no other elegant way to set python path to module :(

I'm not sure about documentation, say a word if you dont like it
