### PR TITLE
Fix <tab> not replaying in macro

### DIFF
--- a/plugin/UltiSnips/__init__.py
+++ b/plugin/UltiSnips/__init__.py
@@ -787,14 +787,15 @@ class SnippetManager(object):
             if trigger.lower() == sttrig.lower():
                 if idx == 0:
                     feedkey= r"\<Plug>SuperTabForward"
+                    mode = "n"
                 elif idx == 1:
                     feedkey = r"\<Plug>SuperTabBackward"
+                    mode = "p"
                 # Use remap mode so SuperTab mappings will be invoked.
-                mode = "m"
                 break
 
         if feedkey == r"\<Plug>SuperTabForward" or feedkey == r"\<Plug>SuperTabBackward":
-            _vim.feedkeys(feedkey, mode)
+            _vim.command("return SuperTab(%s)" % _vim.escape(mode))
         elif feedkey:
             _vim.command("return %s" % _vim.escape(feedkey))
 


### PR DESCRIPTION
This is a first part of fix for [this bug](https://bugs.launchpad.net/ultisnips/+bug/1060289). This fill fix not replaying tabs in macro, and this is needed for correct work of neocomplcache completion. 

I'll make a fix for supertab+ultisnips macro issue if my pull request to supertab will be merged
