### PR TITLE
fix python 'class' snippet

### DIFF
--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -125,7 +125,7 @@ args = get_args(t[4])
 write_docstring_args(args, snip)
 if args:
     snip.rv += '\n' + snip.mkline('', indent='')
-    snip += '{0} 2 '.format(tripple_quotes(snip))
+    snip += '{0}'.format(tripple_quotes(snip))
 
 write_init_body(args, t[2], snip)
 `


### PR DESCRIPTION
Currently `class` snippet expands to this ( when args added to init):

``` python
class MyClass(object):
    """Docstring for MyClass """

    def __init__(self, a, b):
        """@todo: to be defined1

        :param a: @todo
        :param b: @todo

        """ 2 
        self._a = a
        self._b = b


```

Which is wrong because of this part: `""" 2` 
