### PR TITLE
Fixed puppet snippets

### DIFF
--- a/UltiSnips/puppet.snippets
+++ b/UltiSnips/puppet.snippets
@@ -41,8 +41,9 @@ user { '${1:username}':
     gid        => '${4:gid}',
     comment    => '${5:gecos}',
     home       => '${6:homedirectory}',
+    homeagain       => '$6',
     managehome => false,
-    require    => Group['${7:group'],
+    require    => Group['${7:group}'],
 }
 endsnippet
 


### PR DESCRIPTION
I fixed several errors in puppet snippets:
- Some of them didnt have closure brackets
- Some were wrong (user snippet inserted a group statement, ...)
- I also changed surrounding " to ' so snippets follow puppet best practices
