### PR TITLE
if, ife, and ifee snippets for Python

### DIFF
--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -396,6 +396,31 @@ $1 = property(**$1())
 endsnippet
 
 
+####################
+# If / Else / Elif #
+####################
+snippet if "If" b
+if ${1:condition}:
+   ${2:pass}
+endsnippet
+
+snippet ife "If / Else" b
+if ${1:condition}:
+   ${2:pass}
+else:
+   ${3:pass}
+endsnippet
+
+snippet ifee "If / Elif / Else" b
+if ${1:condition}:
+   ${2:pass}
+elif ${3:condition}:
+   ${4:pass}
+else:
+   ${5:pass}
+endsnippet
+
+
 ##########################
 # Try / Except / Finally #
 ##########################


### PR DESCRIPTION
I added if, if/else, and if/elif/else snippets for Python. They should be consistent with the style of the other Python snippets as well as the naming convention used in other languages.

Thanks for the plugin, btw!
