### PR TITLE
Provide a buffer local override for the global snippet directories.

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -330,6 +330,10 @@ If you do not want to use the snippets that come with UltiSnips, define the
 variable accordingly. >
    let g:UltiSnipsSnippetDirectories=["mycoolsnippets"]
 
+You can also redefine the search path on a buffer by buffer basis by setting
+the variable b:UltiSnipsSnippetDirectories.  This variable takes precedence
+over the global variable.
+
 UltiSnips searches in 'runtimepath' for snippet directories but traverses
 'runtimepath' in reverse order (last item first). If you would like to have
 UltiSnips traverse 'runtimepath' in the standard order, add this to your vimrc

--- a/plugin/UltiSnips/__init__.py
+++ b/plugin/UltiSnips/__init__.py
@@ -915,7 +915,10 @@ class SnippetManager(object):
         the filetype.
         """
 
-        snippet_dirs = _vim.eval("g:UltiSnipsSnippetDirectories")
+        if _vim.eval("exists('b:UltiSnipsSnippetDirectories')") == "1":
+            snippet_dirs = _vim.eval("b:UltiSnipsSnippetDirectories")
+        else:
+            snippet_dirs = _vim.eval("g:UltiSnipsSnippetDirectories")
         base_snippets = os.path.realpath(os.path.join(__file__, "../../../UltiSnips"))
         ret = []
 


### PR DESCRIPTION
This introduces the ability to override the global snippet directories
with a buffer local variable.  When b:UltiSnipsSnippetDirectories is
present in a buffer, it's value overrides the value of
g:UltiSnipsSnippetDirectories.  This allows for easier customization of
the snippet directories for coping with projects that have competing
code style standards, without introducing auto commands into your
configuration.
