### PR TITLE
Cosmetic changes to puppet.snippets file to make things easier to find

### DIFF
--- a/UltiSnips/puppet.snippets
+++ b/UltiSnips/puppet.snippets
@@ -39,7 +39,6 @@ endglobal
 ###############################################################################
 #  Puppet Language Constructs                                                 #
 #    See http://docs.puppetlabs.com/puppet/latest/reference/lang_summary.html #
-#                                                                             #
 ###############################################################################
 
 snippet class "Class declaration" b
@@ -57,7 +56,6 @@ endsnippet
 #################################################################
 #  Puppet Types                                                 #
 #    See http://docs.puppetlabs.com/references/latest/type.html #
-#                                                               #
 #################################################################
 
 snippet cron "Cron resource type" b
@@ -131,7 +129,6 @@ endsnippet
 ########################################################################
 #  Puppet Functions                                                    #
 #    See http://docs.puppetlabs.com/references/latest/function.html    #
-#                                                                      #
 ########################################################################
 
 


### PR DESCRIPTION
Hi,

This patch set makes some cosmetic changes to the existing puppet.snippets file.  Essentially I have ordered the snippets and grouped them based on the Puppet Language guidelines, in the code block I have provided a link directly to the puppet documentation.

The one change that is not purely cosmetic is to remove a superfluous line from one of the snippets (853eed2).  I removed it due to consistency, none of the other snippets include a new line at the end of them.

Thanks,

Peter
