### PR TITLE
Bug fix, snippets with a value at the beginning of the line would sometimes trigger the snippet to stop

### DIFF
--- a/plugin/UltiSnips/__init__.py
+++ b/plugin/UltiSnips/__init__.py
@@ -750,12 +750,13 @@ class SnippetManager(object):
 
     def _check_if_still_inside_snippet(self):
         # Did we leave the snippet with this movement?
-        if self._cs and (
-            not self._cs.start <= _vim.buf.cursor <= self._cs.end
-        ):
-            self._current_snippet_is_done()
-            self._reinit()
-            self._check_if_still_inside_snippet()
+        if self._cs:
+            startExtra = Position(self._cs.start.line, self._cs.start.col-1)
+
+            if not startExtra <= _vim.buf.cursor <= self._cs.end:
+                self._current_snippet_is_done()
+                self._reinit()
+                self._check_if_still_inside_snippet()
 
     def _current_snippet_is_done(self):
         self._csnippets.pop()


### PR DESCRIPTION
The following snippet repro's the issue:

```
snippet fu "Function" b
${2:void} ${1:Name}(${3})
{
    $0
}
endsnippet
```
