### PR TITLE
Fixed edge case in function for base class name

### DIFF
--- a/UltiSnips/puppet.snippets
+++ b/UltiSnips/puppet.snippets
@@ -28,7 +28,7 @@ def get_module_namespace_and_basename():
             parts = os.path.split(parts[0])
             continue
         if parts[1] == 'manifests':
-            return os.path.split(parts[0])[1] + '::' + namespace.rstrip(':')
+            return os.path.split(parts[0])[1] + ('::' + namespace).rstrip(':')
         else:
             namespace = parts[1] + '::' + namespace
         parts = os.path.split(parts[0])


### PR DESCRIPTION
In the instance of calling the class snippet within a puppet file
located in /home/pjfoley/puppet/modules/profile/manifests/init.pp

I would expect the return value to be "profile", it currently returns
"profile::"

The extra "::" is a bug and puppet compilation fails with the message
"Syntax error at ':'
