### PR TITLE
Hotfix/init edge case

### DIFF
--- a/UltiSnips/puppet.snippets
+++ b/UltiSnips/puppet.snippets
@@ -14,17 +14,15 @@ def get_module_namespace_and_basename():
     * /home/nikolavp/puppet/modules/collectd/manifests/init.pp -> collectd
     * /home/nikolavp/puppet/modules/collectd/manfistes/mysql.pp -> collectd::mysql
     """
+    first_time = True
     current_file_path_without_ext = vim.eval('expand("%:p:r")') or ""
     if not current_file_path_without_ext:
         return "name"
     parts = os.path.split(current_file_path_without_ext)
     namespace = ''
     while parts[0] and parts[0] != '/':
-        # Skip the init.pp files because they don't create a deeper namespace
-        # and are special. Note this might break things like
-        # modules/collectd/init/test.pp. But I am not even sure if puppet will
-        # work for those.
-        if parts[1] == 'init':
+        if parts[1] == 'init' and first_time and not namespace:
+            first_time = False
             parts = os.path.split(parts[0])
             continue
         if parts[1] == 'manifests':


### PR DESCRIPTION
This fixes an edge case in the puppet module naming detection code.

As originally mentioned in the comment block in the python code if "init" appeared more then once it would be silently eaten and would not return the correct path.

This change checks to see if this is the first time through (which is the special case) and if it is will silently eat the "init" and than register every other "init" instance which is the correct behavior.

PS. I have also merged the previous pull request into this code block to.
