### PR TITLE
python.snippets: docstrings follow PEP257. PEP8 fixes.

### DIFF
--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -33,77 +33,77 @@ SINGLE_QUOTES = 0x1
 DOUBLE_QUOTES = 0x2
 
 def get_args(arglist):
-    args = [arg.split('=')[0].strip() for arg in arglist.split(',') if arg]
-    args = [arg for arg in args if arg and arg != "self"]
+	args = [arg.split('=')[0].strip() for arg in arglist.split(',') if arg]
+	args = [arg for arg in args if arg and arg != "self"]
 
-    return args
+	return args
 
 
 def get_quoting_style(snip):
-    style = snip.opt("g:ultisnips_python_quoting_style", "double")
-    if style == 'single':
-        return SINGLE_QUOTES
-    return DOUBLE_QUOTES
+	style = snip.opt("g:ultisnips_python_quoting_style", "double")
+	if style == 'single':
+		return SINGLE_QUOTES
+	return DOUBLE_QUOTES
 
 def tripple_quotes(snip):
-    if get_quoting_style(snip) == SINGLE_QUOTES:
-        return "'''"
-    return '"""'
+	if get_quoting_style(snip) == SINGLE_QUOTES:
+		return "'''"
+	return '"""'
 
 def get_style(snip):
-    style = snip.opt("g:ultisnips_python_style", "normal")
+	style = snip.opt("g:ultisnips_python_style", "normal")
 
-    if    style == "doxygen": return DOXYGEN
-    elif  style == "sphinx": return SPHINX
-    else: return NORMAL
+	if    style == "doxygen": return DOXYGEN
+	elif  style == "sphinx": return SPHINX
+	else: return NORMAL
 
 
 def format_arg(arg, style):
-    if style == DOXYGEN:
-        return "@param %s @todo" % arg
-    elif style == SPHINX:
-        return ":param %s: @todo" % arg
-    elif style == NORMAL:
-        return ":%s: @todo" % arg
+	if style == DOXYGEN:
+		return "@param %s @todo" % arg
+	elif style == SPHINX:
+		return ":param %s: @todo" % arg
+	elif style == NORMAL:
+		return ":%s: @todo" % arg
 
 
 def format_return(style):
-    if style == DOXYGEN:
-        return "@return: @todo"
-    elif style in (NORMAL, SPHINX):
-        return ":returns: @todo"
+	if style == DOXYGEN:
+		return "@return: @todo"
+	elif style in (NORMAL, SPHINX):
+		return ":returns: @todo"
 
 
 def write_docstring_args(args, snip):
-    if not args:
-        snip.rv += ' {0}'.format(tripple_quotes(snip))
-        return
+	if not args:
+		snip.rv += ' {0}'.format(tripple_quotes(snip))
+		return
 
-    snip.rv += '\n' + snip.mkline('', indent='')
+	snip.rv += '\n' + snip.mkline('', indent='')
 
-    style = get_style(snip)
+	style = get_style(snip)
 
-    for arg in args:
-        snip += format_arg(arg, style)
+	for arg in args:
+		snip += format_arg(arg, style)
 
 
 def write_init_body(args, parents, snip):
-    parents = [p.strip() for p in parents.split(",")]
-    parents = [p for p in parents if p != 'object']
+	parents = [p.strip() for p in parents.split(",")]
+	parents = [p for p in parents if p != 'object']
 
-    for p in parents:
-        snip += p + ".__init__(self)"
+	for p in parents:
+		snip += p + ".__init__(self)"
 
-    if parents:
-        snip.rv += '\n' + snip.mkline('', indent='')
+	if parents:
+		snip.rv += '\n' + snip.mkline('', indent='')
 
-    for arg in args:
-        snip += "self._%s = %s" % (arg, arg)
+	for arg in args:
+		snip += "self._%s = %s" % (arg, arg)
 
 
 def write_slots_args(args, snip):
-    args = ['"_%s"' % arg for arg in args]
-    snip += '__slots__ = (%s,)' % ', '.join(args)
+	args = ['"_%s"' % arg for arg in args]
+	snip += '__slots__ = (%s,)' % ', '.join(args)
 
 endglobal
 
@@ -125,8 +125,8 @@ args = get_args(t[4])
 
 write_docstring_args(args, snip)
 if args:
-    snip.rv += '\n' + snip.mkline('', indent='')
-    snip += '{0}'.format(tripple_quotes(snip))
+	snip.rv += '\n' + snip.mkline('', indent='')
+	snip += '{0}'.format(tripple_quotes(snip))
 
 write_init_body(args, t[2], snip)
 `
@@ -153,8 +153,8 @@ args = get_args(t[4])
 
 write_docstring_args(args, snip)
 if args:
-    snip.rv += '\n' + snip.mkline('', indent='')
-    snip += tripple_quotes(snip)
+	snip.rv += '\n' + snip.mkline('', indent='')
+	snip += tripple_quotes(snip)
 
 write_init_body(args, t[2], snip)
 `
@@ -346,14 +346,14 @@ endsnippet
 snippet def "function with docstrings" b
 def ${1:function}(`!p
 if snip.indent:
-   snip.rv = 'self' + (", " if len(t[2]) else "")`${2:arg1}):
+	snip.rv = 'self' + (", " if len(t[2]) else "")`${2:arg1}):
 	`!p snip.rv = tripple_quotes(snip)`${4:@todo: Docstring for $1.}`!p
 snip.rv = ""
 snip >> 1
 
 args = get_args(t[2])
 if args:
-   write_docstring_args(args, snip)
+	write_docstring_args(args, snip)
 
 style = get_style(snip)
 snip += format_return(style)
@@ -387,15 +387,15 @@ def ${1:name}():
 	`!p snip.rv = tripple_quotes(snip) if t[2] else ''
 `${2:@todo: Docstring for $1.}`!p
 if t[2]:
-    snip >> 1
+	snip >> 1
 
 	style = get_style(snip)
 	snip.rv += '\n' + snip.mkline('', indent='')
 	snip += format_return(style)
 	snip.rv += '\n' + snip.mkline('', indent='')
-    snip += tripple_quotes(snip)
+	snip += tripple_quotes(snip)
 else:
-    snip.rv = ""`
+	snip.rv = ""`
 	def fget(self):
 		return self._$1$0
 
@@ -412,23 +412,23 @@ endsnippet
 ####################
 snippet if "If" b
 if ${1:condition}:
-   ${2:pass}
+	${2:pass}
 endsnippet
 
 snippet ife "If / Else" b
 if ${1:condition}:
-   ${2:pass}
+	${2:pass}
 else:
-   ${3:pass}
+	${3:pass}
 endsnippet
 
 snippet ifee "If / Elif / Else" b
 if ${1:condition}:
-   ${2:pass}
+	${2:pass}
 elif ${3:condition}:
-   ${4:pass}
+	${4:pass}
 else:
-   ${5:pass}
+	${5:pass}
 endsnippet
 
 


### PR DESCRIPTION
I added blank lines before class docstrings. First line of each docstring ends with dot. Fixed indent to multiply by 4.

Now pep257 checker accepts code produced by snippets.
