### PR TITLE
Improve html <div> snippet

### DIFF
--- a/UltiSnips/html.snippets
+++ b/UltiSnips/html.snippets
@@ -167,7 +167,7 @@ snip.rv = snip.fn and 'Hallo' or 'Nothin'
 endsnippet
 
 snippet div "XHTML <div>"
-<div`!p snip.rv=' id="' if t[1] else ""`${1:name}`!p snip.rv = '"' if t[1] else ""`>
+<div`!p snip.rv=' id="' if t[1] else ""`${1:name}`!p snip.rv = '"' if t[1] else ""``!p snip.rv=' class="' if t[2] else ""`${2:name}`!p snip.rv = '"' if t[2] else ""`>
    $0
 </div>
 endsnippet


### PR DESCRIPTION
The "class" attribute is commonly set for &lt;div>s, but the current
snippet definition makes it difficult to create any attributes other
than "id".  Setup that attribute as the id is done, so that either or
both may be easily included.
