### PR TITLE
Encoding comment snippets

### DIFF
--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -2,6 +2,12 @@
 #                            TEXTMATE SNIPPETS                            #
 ###########################################################################
 
+snippet # "Encoding comment" b
+# -*- coding: utf-8 -*-
+
+$0
+endsnippet
+
 #! header
 snippet #! "Shebang header for python scripts" b
 #!/usr/bin/env python


### PR DESCRIPTION
I added emacs style magic encoding comment snippet. I think emacs style is used more often. It was mentioned in [PEP263](http://www.python.org/dev/peps/pep-0263/).
