### PR TITLE
Teach list_snippets_dict to escape apostrophes in the description.

### DIFF
--- a/plugin/UltiSnips/__init__.py
+++ b/plugin/UltiSnips/__init__.py
@@ -565,7 +565,7 @@ class SnippetManager(object):
                 description = description[1:-1]
 
             _vim.command(as_unicode("let g:current_ulti_dict['{key}'] = '{val}'").format(
-              key=key.replace("'", "''"), val=description))
+              key=key.replace("'", "''"), val=description.replace("'", "''")))
 
     @err_to_scratch_buffer
     def list_snippets(self):

--- a/test.py
+++ b/test.py
@@ -3021,16 +3021,16 @@ class VerifyVimDict1(_VimTest):
     """check:
     correct type (4 means vim dictionary)
     correct length of dictionary (in this case we have on element if the use same prefix, dictionary should have 1 element)
-    correct description
+    correct description (including the apostrophe)
     if the prefix is mismatched no resulting dict should have 0 elements
     """
 
-    snippets = ('testâ', 'abc123ά', '123êabc')
+    snippets = ('testâ', 'abc123ά', '123\'êabc')
     keys = ('test=(type(UltiSnips_SnippetsInCurrentScope()) . len(UltiSnips_SnippetsInCurrentScope()) . ' +
        'UltiSnips_SnippetsInCurrentScope()["testâ"]' + ')\n' +
        '=len(UltiSnips_SnippetsInCurrentScope())\n')
 
-    wanted = 'test41123êabc0'
+    wanted = 'test41123\'êabc0'
 
 class VerifyVimDict2(_VimTest):
     """check:


### PR DESCRIPTION
This was discovered while trying to use
UltiSnips_SnippetsInCurrentScope() with some snippets that have
apostrophes in the description (such as printf('...', ...)).
