### PR TITLE
Make class snippet PSR-0 compliant

### DIFF
--- a/UltiSnips/php.snippets
+++ b/UltiSnips/php.snippets
@@ -217,7 +217,7 @@ endsnippet
 
 snippet class "Class declaration template" !b
 /**
- * Class ${1:`!p snip.rv=snip.fn.capitalize().split('.')[0]`} 
+ * Class ${1:`!p snip.rv=snip.fn.split('.')[0]`} 
  * @author $2
  */
 class $1


### PR DESCRIPTION
Hi,

First off, it is wonderful to see so many snippets :) However, I have a small change:

When making a file classes ViewHelper.php, you would expect the classname to be ViewHelper, not Viewhelper.

Please let me know if there is something I have missed!
