### PR TITLE
Only call UltiSnips_FileTypeChanged if it's available

### DIFF
--- a/ftdetect/UltiSnips.vim
+++ b/ftdetect/UltiSnips.vim
@@ -1,6 +1,13 @@
 " This has to be called before ftplugins are loaded. Therefore 
 " it is here in ftdetect though it maybe shouldn't
 if has("autocmd")
-   autocmd FileType * call UltiSnips_FileTypeChanged()
+    autocmd FileType * call UltiSnipsFileTypeChangedWrapper()
 endif
+
+function UltiSnipsFileTypeChangedWrapper()
+    if exists("*UltiSnips_FileTypeChanged")
+        call UltiSnips_FileTypeChanged()
+    endif
+endfunction
+
 


### PR DESCRIPTION
Seems like in some cases, file type event may be triggered before the function has been defined.

Workaround for https://bugs.launchpad.net/ultisnips/+bug/1095519
