### PR TITLE
Remove space between function declaration and arguments list (jshint com...

### DIFF
--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -45,7 +45,7 @@ for (var ${2:i}=0; $2 < ${1:Things}.length; $2++) {
 endsnippet
 
 snippet fun "function (fun)"
-function ${1:function_name} (${2:argument}) {
+function ${1:function_name}(${2:argument}) {
 	${VISUAL}$0
 }
 endsnippet


### PR DESCRIPTION
As the title says I removed the space between function and the list of arguments becouse I noticed even JSHint was complaining
