### PR TITLE
JSHint complained about 'Unnecessary semicolon'.

### DIFF
--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -35,13 +35,13 @@ endsnippet
 snippet for "for (...) {...} (faster)"
 for (var ${2:i} = ${1:Things}.length - 1; $2 >= 0; $2--) {
 	${3:$1[$2]}${VISUAL}$0
-};
+}
 endsnippet
 
 snippet for "for (...) {...}"
 for (var ${2:i}=0; $2 < ${1:Things}.length; $2++) {
 	${3:$1[$2]}${VISUAL}$0
-};
+}
 endsnippet
 
 snippet fun "function (fun)"


### PR DESCRIPTION
Minor change: JSHint complained about the semicolons at the end of the for loop snippets in `javascript.snippets`, so I've removed the semicolons after both for loop closing braces.
