### PR TITLE
Option for JumpTrigger only during snippet expansion

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -240,15 +240,6 @@ vimrc file. >
    let g:UltiSnipsJumpForwardTrigger="<tab>"
    let g:UltiSnipsJumpBackwardTrigger="<s-tab>"
 
-The mapping of g:UltiSnipsJumpForwardTrigger and g:UltiSnipsJumpBackwardTrigger 
-can be controlled with this option:
-
-                                                *g:UltiSnipsClearJumpTrigger*
-g:UltiSnipsClearJumpTrigger     By default both triggers are global mappings
-                                that are always present. By setting this
-                                variable to 1 the plugin will define <buffer>
-                                mappings only during snippet expansions.
-
 Note that the default value for g:UltiSnipsJumpBackwardTrigger interferes with
 the built-in complete function: |i_CTRL-X_CTRL-K|. A workaround is to add the
 following to your vimrc file. >

--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -88,7 +88,7 @@ endif
 " Should UltiSnips map JumpForwardTrigger and JumpBackwardTrigger only during
 " snippet expansion?
 if !exists("g:UltiSnipsClearJumpTrigger")
-    let g:UltiSnipsClearJumpTrigger = 0
+    let g:UltiSnipsClearJumpTrigger = 1
 endif
 " }}}
 

--- a/plugin/UltiSnips/__init__.py
+++ b/plugin/UltiSnips/__init__.py
@@ -763,8 +763,9 @@ class SnippetManager(object):
 
     def _current_snippet_is_done(self):
         self._csnippets.pop()
-        if _vim.eval("g:UltiSnipsClearJumpTrigger") == "1":
-            _vim.command("call UltiSnips_RestoreInnerKeys()")
+        if _vim.eval("g:UltiSnipsClearJumpTrigger") != "0":
+           if len(self._csnippets) == 0:
+              _vim.command("call UltiSnips_RestoreInnerKeys()")
 
     def _jump(self, backwards = False):
         jumped = False
@@ -881,7 +882,7 @@ class SnippetManager(object):
         that needs to be done with it.
         """
         if _vim.eval("g:UltiSnipsClearJumpTrigger") == "1":
-            _vim.command("call UltiSnips_MapInnerKeys()")
+           _vim.command("call UltiSnips_MapInnerKeys()")
         # Adjust before, maybe the trigger is not the complete word
         text_before = before
         if snippet.matched:


### PR DESCRIPTION
Solves [Bug #1231677](https://bugs.launchpad.net/ultisnips/+bug/1231677).

I think two simple test cases would be enough for this feature:

1) Start a Vim instance without parameters, check that g:UltiSnipsJumpForwardTrigger and g:UltiSnipsJumpBackwardTrigger are mapped before and after an snippet expansion

2) Start a Vim instance setting g:UltiSnipsClearJumpTrigger, check that g:UltiSnipsJumpForwardTrigger and g:UltiSnipsJumpBackwardTrigger aren't mapped before and after an snippet expansion, and using i_CTRL-R_= check the mappings during snippet expansion.

I'm not sure how this could be implemented on test.py, and as I'm currently in ms-windows I don't have screen.
I can implement those test using [runVimTests](http://www.vim.org/scripts/script.php?script_id=2565) if you like.
