### PR TITLE
Add 'm' option - support for popup menu

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -636,6 +636,11 @@ The options currently supported are: >
        before jumping to the next tabstop.  This is useful if there is a
        tabstop with optional text at the end of a line.
 
+   m   Support for popup menu - Without this option, the snippet is expanded
+       only if popup menu is not visible. This option prevents snippet
+       expanding during autocompletion (if snippet trigger is on the
+       autocompletion list).
+
 The end line is the 'endsnippet' keyword on a line by itself. >
 
    endsnippet

--- a/plugin/UltiSnips/__init__.py
+++ b/plugin/UltiSnips/__init__.py
@@ -839,6 +839,10 @@ class SnippetManager(object):
         for ft in filetypes:
             found_snippets += self._find_snippets(ft, before, possible)
 
+        if _vim.eval("pumvisible()") != '0':
+            # Keep only those snippets that support popup menu
+            found_snippets = [snip for snip in found_snippets if snip.has_option("m")]
+
         # Search if any of the snippets overwrites the previous
         # Dictionary allows O(1) access for easy overwrites
         snippets = {}


### PR DESCRIPTION
Hello,
I made small update to your plugin.
The problem I met is that the ultisnips plugin breaks autocompletion when a snippet trigger is placed on the autocompletion list e.g:
- the same key triggers snippet expanding and completion (SuperTab plugin)
- there is a c snippet "printf"
- start autocompletion with the "prin" word, let say the following popup menu is shown:
  printf
  prints
  ....
- it is not possible to go through the completion list as the first item "printf" will trigger snippet expanding 

My proposal is to add new option - 'm'. Only snippets that define this option will be expanded when popup menu is visible.

Check if the patch is valuable.
