### PR TITLE
Evaluate word boundaries with Vim, not r'\b'

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -612,7 +612,7 @@ The options currently supported are: >
        the tab trigger start matches a word boundary and the tab trigger end
        matches a word boundary. In other words the tab trigger must be
        preceded and followed by non-word characters. Word characters are
-       letters, digits and the underscore. Use this option, for example, to
+       defined by the 'iskeyword' setting. Use this option, for example, to
        permit expansion where the tab trigger follows punctuation without
        expanding suffixes of larger words.
 

--- a/plugin/UltiSnips/__init__.py
+++ b/plugin/UltiSnips/__init__.py
@@ -315,7 +315,8 @@ class Snippet(object):
             if match and words_prefix:
                 # Require a word boundary between prefix and suffix.
                 boundaryChars = words_prefix[-1:] + words_suffix[:1]
-                match = re.match(r'.\b.', boundaryChars)
+                boundaryChars = boundaryChars.replace('"', '\\"')
+                match = _vim.eval('"%s" =~# "\\\\v.<."' % boundaryChars) != '0'
         elif "i" in self._opts:
             match = words.endswith(self._t)
         else:
@@ -350,7 +351,8 @@ class Snippet(object):
             match = self._re_match(trigger)
         elif "w" in self._opts:
             # Trim non-empty prefix up to word boundary, if present.
-            words_suffix = re.sub(r'^.+\b(.+)$', r'\1', words)
+            qwords = words.replace('"', '\\"')
+            words_suffix = _vim.eval('substitute("%s", "\\\\v^.+<(.+)", "\\\\1", "")' % qwords)
             match = self._t.startswith(words_suffix)
             self._matched = words_suffix
 


### PR DESCRIPTION
Hello,

UltiSnips currently has a hard-coded notion of a word boundary (python's
`r'\b'`), which makes using snippets from languages like Scheme and
Clojure a bit problematic.

e.g.

```
snippet map "map" w
(map ${0:pred} ${1:coll})
endsnippet
```

`-` is a word character in Lisps, so the following should not trigger
the snippet:

``` clojure
(hash-map^I)
```

If we use vim's regex engine to do the word matching, we can have
dynamic word character classes per FileType. This is what this patch
implements. I ran the test suite and all tests pass with Vim 7.4.131.

Please let me know if you'd like me to make any amendments.

Cheers!

From the patch header:

Certain non ALGOL-derived languages (notably LISP derivatives) do not
share the alphanumeric + underscore definition of a word character.

Fortunately, each language FileType has its own definition of a word
character, which Vim's regex engine uses when matching against the
boundary classes `\<` and `\>`.

We change the word matching routine of 'w' snippets to use Vim's regex
engine instead of a static pattern.
