### PR TITLE
Added if snippets for c/c++ language and update of coding style to most common style

### DIFF
--- a/UltiSnips/c.snippets
+++ b/UltiSnips/c.snippets
@@ -112,8 +112,8 @@ else {
 endsnippet
 
 snippet eli "else if .. (eli)"
-	${VISUAL}${0:${VISUAL/(.*)/(?1::\/* code *\/)/}}
 else if (${1:/* condition */}) {
+	${VISUAL}${0:${VISUAL/(.*)/(?1::\/* code *\/)/}}
 }
 endsnippet
 


### PR DESCRIPTION
Added snippets:
- else if (eli)
- if..else if (ifeli)

By update of coding style I mean e.g:
INSTEAD OF:
if
{

}

THIS:
if {

}

consistency of this through out the snippets apart from functions, structs etc..

On top of that, for "#include <;;;.h>"; pressing '#inc' to expand the snippets rather than 'inc' to follow the natural order of codes and to stop the decrease in efficiency even without this plugin under a circumstance where the programmer has to code under a strange environment.
Also capitalization of 'i' in the #inc for the local head files and non capitalization of 'i' for the standard library in the 'include' directory because standard functions are the most essential to deserve higher priority.

Any criticism welcome! This will be my 2nd pull request. :')
