### PR TITLE
Use range instead of xrange for Python 3 compatibility.

### DIFF
--- a/plugin/UltiSnips/__init__.py
+++ b/plugin/UltiSnips/__init__.py
@@ -22,7 +22,7 @@ def _plugin_dir():
     be updated if the code moves.
     """
     d = __file__
-    for i in xrange(10):
+    for i in range(10):
         d = os.path.dirname(d)
         if os.path.isdir(os.path.join(d, "plugin")) and os.path.isdir(os.path.join(d, "doc")):
             return d


### PR DESCRIPTION
xrange was removed from Python 3 and causes the UltiSnips plugin to
break for Vim compiled to use the Python 3 interpreter.
