### PR TITLE
Add snippets for scss files

### DIFF
--- a/UltiSnips/scss.snippets
+++ b/UltiSnips/scss.snippets
@@ -1,0 +1,49 @@
+snippet /@?inc/ "@include mixin(...);" br
+@include ${1:mixin}(${2:arguments});
+endsnippet
+
+snippet /@?ext?/ "@extend %placeholder;" br
+@extend %${1:placeholder};
+endsnippet
+
+snippet /@?mixin/ "@mixin (...) { ... }" br
+@mixin ${1:name}(${2:arguments}) {
+  ${VISUAL}$0
+}
+endsnippet
+
+snippet /@?fun/ "@function (...) { ... }" br
+@function ${1:name}(${2:arguments}) {
+  ${VISUAL}$0
+}
+endsnippet
+
+snippet /@?if/ "@if (...) { ... }" br
+@if ${1:condition} {
+  ${VISUAL}$0
+}
+endsnippet
+
+snippet /(} )?@?else/ "@else { ... }" br
+@else ${1:condition} {
+  ${VISUAL}$0
+}
+endsnippet
+
+snippet /@?for/ "@for loop" br
+@for ${1:$i} from ${2:1} through ${3:3} {
+  ${VISUAL}$0
+}
+endsnippet
+
+snippet /@?each/ "@each loop" br
+@each ${1:$item} in ${2:item, item, item} {
+  ${VISUAL}$0
+}
+endsnippet
+
+snippet /@?while/ "@while loop" br
+@while ${1:$i} ${2:>} ${3:0} {
+  ${VISUAL}$0
+}
+endsnippet


### PR DESCRIPTION
This commit adds a lot of the basic Sass directives used in Sass script.
Documentation can be found at:

  http://sass-lang.com/documentation/file.SASS_REFERENCE.html

I decided to use regular expressions for the triggers, since typing the
`@` may be too cumbersome to require it to always be included, but is
likely happening due to muscle memory too often to leave it out. Regular
expressions give us the flexibility to have it both ways in this case.
