### PR TITLE
all.snippets: bbox and box snippet Python 3 compatibility

### DIFF
--- a/UltiSnips/all.snippets
+++ b/UltiSnips/all.snippets
@@ -19,7 +19,7 @@ def _parse_comments(s):
     try:
         while True:
             # get the flags and text of a comment part
-            flags,text = i.next().split(':', 1)
+            flags,text = next(i).split(':', 1)
 
             if len(flags) == 0:
                 if len(text) == 1:
@@ -33,11 +33,11 @@ def _parse_comments(s):
                     indent = " " * int(flags[-1])
                 ctriple.append(text)
 
-                flags,text = i.next().split(':', 1)
+                flags,text = next(i).split(':', 1)
                 assert(flags[0] == 'm')
                 ctriple.append(text)
 
-                flags,text = i.next().split(':', 1)
+                flags,text = next(i).split(':', 1)
                 assert(flags[0] == 'e')
                 ctriple.append(text)
                 ctriple.append(indent)


### PR DESCRIPTION
I'm not much of a python pro, but it appears the correct
way to iterate is `next(i)` instead of `i.next()`.  `i.next()` has
been renamed to `i.__next__()` on python3, but `next(i)` works on both.

Pasted below is the following test script ran through python
2.6, 2.7, and 3.3:

```
i = iter("1,2".split(","))
next(i)
i.next()
i.__next__()
next(i)
```

```
Python 2.6.8 (unknown, Jan 26 2013, 14:35:25)
[GCC 4.7.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> i = iter("1,2".split(","))
>>> next(i)
'1'
>>> i.next()
'2'
>>> i.__next__()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'listiterator' object has no attribute '__next__'
>>> next(i)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
StopIteration
>>>
```

```
Python 2.7.6 (default, Dec  6 2013, 20:05:37)
[GCC 4.8.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> i = iter("1,2".split(","))
>>> next(i)
'1'
>>> i.next()
'2'
>>> i.__next__()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'listiterator' object has no attribute '__next__'
>>> next(i)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
StopIteration
>>>
```

```
Python 3.3.3 (default, Jan  2 2014, 19:09:02)
[GCC 4.8.2] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> i = iter("1,2".split(","))
>>> next(i)
'1'
>>> i.next()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'list_iterator' object has no attribute 'next'
>>> i.__next__()
'2'
>>> next(i)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
StopIteration
>>>
```

Signed-off-by: Andrew Ruder andrew.ruder@elecsyscorp.com
