### PR TITLE
Escape correctly file names in windows.

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -42,7 +42,7 @@ def _ask_snippets(snippets):
     want to use, and return it.
     """
     display = [as_unicode("%i: %s (%s)") % (i+1, escape(s.description, '\\'),
-        s.location) for i, s in enumerate(snippets)]
+        escape(s.location, '\\')) for i, s in enumerate(snippets)]
     return _ask_user(snippets, display)
 
 def err_to_scratch_buffer(func):


### PR DESCRIPTION
In windows when expanding snippets the names of the snippet files look weird because \ is not escaped properly.

Also I think there should be an option to show only part of the file name, say the path relative to ~/.vim, because this way most of the screen is taken with the paths of the file.

Going even further I think it would it look nicer if you had some kind of alignment for the string. Say "%2i: %-15s (%s)".
Of course this last suggestion might not be consensual, but maybe a option might be offered to the user.
