### PR TITLE
Correct snippet directory on Windows

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -550,7 +550,7 @@ class SnippetManager(object):
         else:
             if platform.system() == "Windows":
                 snippet_dir = os.path.join(_vim.eval("$HOME"),
-                        "_vimfiles", "UltiSnips")
+                        "vimfiles", "UltiSnips")
             else:
                 snippet_dir = os.path.join(_vim.eval("$HOME"),
                         ".vim", "UltiSnips")


### PR DESCRIPTION
Although `.vimrc` is called `_vimrc` on Windows, `.vim` becomes `vimfiles` w/o a leading underscore. See `:help initialization`:

> RECOMMENDATION: Put all your Vim configuration stuff in the
> $HOME/.vim/ directory ($HOME/vimfiles/ for MS-Windows). That makes it
> easy to copy it to another system.
