### PR TITLE
Set g:UltiSnipsNoMappings to not make default mappings

### DIFF
--- a/autoload/UltiSnips/map_keys.vim
+++ b/autoload/UltiSnips/map_keys.vim
@@ -6,6 +6,11 @@ function! UltiSnips#map_keys#MapKeys()
         return
     endif
 
+    if exists('g:UltiSnipsNoMappings')
+        " Do not map the keys if the user has set this variable
+        return
+    endif
+
     " Map the keys correctly
     if g:UltiSnipsExpandTrigger == g:UltiSnipsJumpForwardTrigger
 

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -289,6 +289,9 @@ then you define your mapping as >
 and if the you can't expand or jump from the current location then the
 alternative function IMAP_Jumpfunc('', 0) is called.
 
+If you don't want UltiSnips to create any mappings for you set
+    let g:UltiSnipsNoMappings = 1
+
 3.2.2 Path to Python module                   *UltiSnips-python-module-path*
 ---------------------------
 


### PR DESCRIPTION
A simple variable to stop mapping keys if they user wants to map them manually.
