### PR TITLE
Added an option to disable trigger snippets in Visual mode.

### DIFF
--- a/autoload/UltiSnips/bootstrap.vim
+++ b/autoload/UltiSnips/bootstrap.vim
@@ -38,6 +38,11 @@ function! UltiSnips#bootstrap#Bootstrap()
    exec g:_uspy "from UltiSnips import UltiSnips_Manager"
 endfunction
 
+" Should UltiSnips expand a snippet in Visual mode?
+if !exists("g:UltiSnipsTriggerInVisualMode")
+    let g:UltiSnipsTriggerInVisualMode = 1
+endif
+
 " The trigger used to expand a snippet.
 " NOTE: expansion and forward jumping can, but needn't be the same trigger
 if !exists("g:UltiSnipsExpandTrigger")

--- a/autoload/UltiSnips/map_keys.vim
+++ b/autoload/UltiSnips/map_keys.vim
@@ -15,7 +15,11 @@ function! UltiSnips#map_keys#MapKeys()
         exec "inoremap <silent> " . g:UltiSnipsExpandTrigger . " <C-R>=UltiSnips#ExpandSnippet()<cr>"
         exec "snoremap <silent> " . g:UltiSnipsExpandTrigger . " <Esc>:call UltiSnips#ExpandSnippet()<cr>"
     endif
-    exec "xnoremap <silent> " . g:UltiSnipsExpandTrigger. " :call UltiSnips#SaveLastVisualSelection()<cr>gvs"
+
+    if g:UltiSnipsTriggerInVisualMode
+        exec "xnoremap <silent> " . g:UltiSnipsExpandTrigger. " :call UltiSnips#SaveLastVisualSelection()<cr>gvs"
+    endif
+
     exec "inoremap <silent> " . g:UltiSnipsListSnippets . " <C-R>=UltiSnips#ListSnippets()<cr>"
     exec "snoremap <silent> " . g:UltiSnipsListSnippets . " <Esc>:call UltiSnips#ListSnippets()<cr>"
 

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -238,6 +238,10 @@ vimrc file. >
 UltiSnips will only map the jump triggers while a snippet is active to
 interfer as little as possible with other mappings.
 
+You can control whether UltiSnips should expand a snippet in Visual mode by
+setting the global variable g:UltiSnipsTriggerInVisualMode (defaults to 1):
+   let g:UltiSnipsTriggerInVisualMode = 0
+
 The default value for g:UltiSnipsJumpBackwardTrigger interferes with the
 built-in complete function: |i_CTRL-X_CTRL-K|. A workaround is to add the
 following to your vimrc file or switching to a plugin like Supertab or


### PR DESCRIPTION
Hi Holger,
I've added an option to disable `g:UltiSnipsExpandTrigger` mapping in Visual mode. 

My use-case is simple, I use Tab to expand snippets, but in Visual mode I use Tab to fold selection. 
I don't want to change any of my key mapping, but as I don't usually work with snippets in Visual mode I just created an option to disable this mapping so I can use mine without any conflicts. 

Perhaps someone else will find this useful as well.
