### PR TITLE
Replace snipMate's Filename() with vim-snippets' version

### DIFF
--- a/utils/convert_snipmate_snippets.py
+++ b/utils/convert_snipmate_snippets.py
@@ -10,6 +10,9 @@ import os
 import argparse
 
 def convert_snippet_contents(content):
+    " Replace snipMate's Filename() with vim-snippets' version "
+    content = content.replace('`Filename()', '`vim_snippets#Filename()')
+
     " If the snippet contains snipmate style substitutions, convert them to ultisnips style "
     content = re.sub("`([^`]+`)", "`!v \g<1>", content)
     return content


### PR DESCRIPTION
It appears that vim-snippets decided to namespace their `Filename()` implementation and UltiSnips has removed their implementation completely causing the previously converted snipMate snippets to fail that use the legacy `Filename()`.

https://github.com/honza/vim-snippets/commit/80697bea6feb83c870a4fa5798e897d4561900f3
https://github.com/honza/vim-snippets/blob/master/autoload/vim_snippets.vim
https://github.com/SirVer/ultisnips/tree/master/plugin

This change goes ahead and does the `Filename()` to `vim_snippets#Filename()` in the conversion script.

The one issue w/ this is that it will place an explicit dependency for vim-snippets when using converted snippets. Which, may be undesirable. Alternatively, we could replace it with `!p fn`.

I was not completely sure the most appropriate fix for this, so if there is a better way lets do that. 
