### PR TITLE
Correct misspelling

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -236,7 +236,7 @@ vimrc file. >
    let g:UltiSnipsJumpBackwardTrigger="<s-tab>"
 
 UltiSnips will only map the jump triggers while a snippet is active to
-interfer as little as possible with other mappings.
+interfere as little as possible with other mappings.
 
 The default value for g:UltiSnipsJumpBackwardTrigger interferes with the
 built-in complete function: |i_CTRL-X_CTRL-K|. A workaround is to add the


### PR DESCRIPTION
Just a simple correction to the misspelling of `interfere` in `UltiSnips-triggers`.
