### PR TITLE
Fix highlighting of nested tab stops

### DIFF
--- a/syntax/snippets.vim
+++ b/syntax/snippets.vim
@@ -105,7 +105,7 @@ syn match snipMirror "\$\d\+" contained
 syn cluster snipTokens add=snipMirror
 syn cluster snipTabStopTokens add=snipMirror
 
-syn region snipTabStop matchgroup=snipTabStop start="\${\d\+[:}]\@=" end="}" contained contains=snipTabStopDefault
+syn region snipTabStop matchgroup=snipTabStop start="\${\d\+[:}]\@=" end="}" contained contains=snipTabStopDefault extend
 syn region snipTabStopDefault matchgroup=snipTabStop start=":" skip="\\[{}]" end="\ze}" contained contains=snipTabStopEscape,snipBalancedBraces,@snipTabStopTokens keepend
 syn match snipTabStopEscape "\\[{}]" contained
 syn region snipBalancedBraces start="{" end="}" contained transparent extend


### PR DESCRIPTION
Nested tab stops like `${1:head ${2} tail}` were not properly
highlighting the "tail" or the closing `}` of the outer tab stop.
