### PR TITLE
Add check to prevent errors when using vimpager.

### DIFF
--- a/ftdetect/UltiSnips.vim
+++ b/ftdetect/UltiSnips.vim
@@ -7,8 +7,8 @@ if exists("vimpager")
 endif
 
 if has("autocmd")
-    augroup UltiSnipsFileType
-        au!
-        autocmd FileType * call UltiSnips#FileTypeChanged()
-    augroup END
+   augroup UltiSnipsFileType
+      au!
+      autocmd FileType * call UltiSnips#FileTypeChanged()
+   augroup END
 endif


### PR DESCRIPTION
This fixes an initial error message that must be bypassed when using vimpager. As far as I can tell this shouldn't affect anything outside this specific case.
