### PR TITLE
Fix UltiSnipsEdit for g:UltiSnipsSnippetsDir paths that include spaces

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -66,7 +66,7 @@ function! UltiSnips#Edit(bang, ...)
             let mode = 'sp'
         endif
     endif
-    exe ':'.mode.' '.file
+    exe ':'.mode.' '.escape(file, ' \')
 endfunction
 
 function! UltiSnips#AddFiletypes(filetypes)


### PR DESCRIPTION
The spaces and backslashes in filenames should be escaped before being used with e, vs, or sp.  Otherwise, you get `E172: Only one file name allowed` when trying to run `UltiSnipsEdit` if `g:UltiSnipsSnippetsDir` points to a path that includes spaces.
