### PR TITLE
Map <c-r> in select mode

### DIFF
--- a/autoload/UltiSnips/map_keys.vim
+++ b/autoload/UltiSnips/map_keys.vim
@@ -22,4 +22,5 @@ function! UltiSnips#map_keys#MapKeys()
     snoremap <silent> <BS> <c-g>c
     snoremap <silent> <DEL> <c-g>c
     snoremap <silent> <c-h> <c-g>c
+    snoremap <c-r> <c-g>"_c<c-r>
 endf


### PR DESCRIPTION
I think it would be useful to have this mapping, in order to be able to paste over the selected text in snippets.
It works in the same way as in insert mode (it is a very simple mapping), but for some strange reason, the visual behavior seems to be different: " is not shown over the next character. I don't know how to fix this apart from doing something much more involved with getchar(), so I went with the simple option. Anyway, this is only a cosmetic difference.
It would also be good to document this mapping somewhere, but I did not find a natural place to do this in the help file, so I leave it up to you.
