### PR TITLE
Don't rely on having the tmux/screen cwd being in the project directory.

### DIFF
--- a/test/vim_test_case.py
+++ b/test/vim_test_case.py
@@ -341,7 +341,8 @@ class VimTestCase(unittest.TestCase, TempFileManager):
 
         vim_config = []
         vim_config.append('set nocompatible')
-        vim_config.append('set runtimepath=$VIMRUNTIME,.,%s' % self._temp_dir)
+        vim_config.append('set runtimepath=$VIMRUNTIME,%s,%s' % (
+            os.path.dirname(os.path.dirname(__file__)), self._temp_dir))
 
         if self.plugins:
             self._link_file(os.path.join(plugin_cache_dir(), "vim-pathogen", "autoload"), ".")


### PR DESCRIPTION
Instead, let's just change the runtime path to include a pointer to the
top of the tree.
