### PR TITLE
Added a terminal emulator warning line for using c-tab combo with usnips

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -226,7 +226,8 @@ The priority will then be rails -> ruby -> programming -> all.
 You can define the keys used to trigger UltiSnips actions by setting global
 variables. Variables define the keys used to expand a snippet, jump forward
 and jump backwards within a snippet, and list all available snippets in the
-current expand context. The variables with their default values are: >
+current expand context. Be advised, that some terminal emulators don't send
+<c-tab> to the running program. The variables with their default values are: >
    g:UltiSnipsExpandTrigger               <tab>
    g:UltiSnipsListSnippets                <c-tab>
    g:UltiSnipsJumpForwardTrigger          <c-j>


### PR DESCRIPTION
Hello,
a little late but creating a pull request as asked in an email.

"I have a proposal to add a warning about not using c-tab combination for
ultisnips triggers. I just lost lots of time debugging this. It works in gvim but
not in vim. It's related to terminal emulators. See:
https://bugs.launchpad.net/ultisnips/+bug/987860

regards,
Ivo "
