### PR TITLE
Fix thousands of stat calls

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -189,9 +189,22 @@ g:UltiSnipsSnippetsDir
                             files are stored in. For example, if the variable
                             is set to "~/.vim/mydir/UltiSnips" and the current
                             'filetype' is "cpp", then :UltiSnipsEdit will open
-                            "~/.vim/mydir/UltiSnips/cpp.snippets". Note that
-                            directories named "snippets" are reserved for
-                            snipMate snippets and cannot be used.
+                            "~/.vim/mydir/UltiSnips/cpp.snippets". If only one
+                            directory is specified in this variable and this
+                            directory is specified by absolute path,
+                            UltiSnips will not look for snippets in
+                            &runtimepath, which can lead to significant
+                            speedup.  Note that directories named "snippets"
+                            are reserved for snipMate snippets and cannot be used.
+
+                                                        *g:UltiSnipsDisableSnipMate*
+g:UltiSnipsDisableSnipMate
+                            Disable looking for SnipMate snippets in
+                            &runtimepath. Defaults to "0", so UltiSnips will
+                            look for SnipMate snippets. If you use only
+                            UltiSnips snippets, you probably want to set this
+                            variable to "1". Disabling SnipMate lookup can
+                            speedup UltiSnips.
 
 
                                                        *:UltiSnipsAddFiletypes*

--- a/pythonx/UltiSnips/snippet/source/file/ultisnips.py
+++ b/pythonx/UltiSnips/snippet/source/file/ultisnips.py
@@ -30,10 +30,13 @@ def find_all_snippet_files(ft):
         snippet_dirs = _vim.eval("b:UltiSnipsSnippetDirectories")
     else:
         snippet_dirs = _vim.eval("g:UltiSnipsSnippetDirectories")
-
+    if len(snippet_dirs) == 1 and os.path.isabs(snippet_dirs[0]):
+        check_dirs = ['']
+    else:
+        check_dirs = _vim.eval("&runtimepath").split(',')
     patterns = ["%s.snippets", "%s_*.snippets", os.path.join("%s", "*")]
     ret = set()
-    for rtp in _vim.eval("&runtimepath").split(','):
+    for rtp in check_dirs:
         for snippet_dir in snippet_dirs:
             if snippet_dir == "snippets":
                 raise RuntimeError(

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -91,7 +91,14 @@ class SnippetManager(object):
         self._added_snippets_source = AddedSnippetsSource()
         self.register_snippet_source("ultisnips_files", UltiSnipsFileSource())
         self.register_snippet_source("added", self._added_snippets_source)
-        self.register_snippet_source("snipmate_files", SnipMateFileSource())
+
+        if _vim.eval("exists('g:UltiSnipsDisableSnipMate')") == "1":
+            disable_snipmate = _vim.eval("g:UltiSnipsDisableSnipMate")
+        else:
+            disable_snipmate = "0"
+        if disable_snipmate != "1":
+            self.register_snippet_source("snipmate_files",
+                SnipMateFileSource())
 
         self._reinit()
 


### PR DESCRIPTION
I've noticed, that opening files and expanding snippets is very slow on my oldy Atom netbook. After digging around I've come up to running `strace` on vim and after typing `:e lala.go`:

```
$ sudo strace -p `pidof vim` -ttf -o strace.log
$ grep stat ~/strace.log -c
12040
```

Number can greatly depends on amount of plugins one have installed, because every plugin (when using plugin manager) will add it's own path to `&runtimepath`.

I understand concern about looking snippets in the &runtimepath, but most usable way is to have own collection of snippets laying in the single directory.

Proposed patch will change code in that way so UltiSnips will not look for every &runtimepath directory if `g:UltiSnipsSnippetsDir` contains only one absolute path.

Also, patch introduces `g:UltiSnipsDisableSnipMate` option to disable looking for snipmate snippets in `&runtimepath`. I use only UltiSnips syntax and I guess many users so; it's useless to search for snipmate snippets every time. However, value of `g:UltiSnipsDisableSnipMate` is equals to `"0"` by default.

After patch applied:

```
$ grep stat ~/strace.log -c
1256
```

Possible fix for #384.
