### PR TITLE
Fix typo "endglobals" in documentation

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -931,7 +931,7 @@ directly inside your snippets. For example to use
 
    global !p
    from my_snippet_helpers import *
-   endglobals
+   endglobal
 
 
 4.4 Tabstops and Placeholders   *UltiSnips-tabstops* *UltiSnips-placeholders*


### PR DESCRIPTION
I was working on some snippets and looking at the documentation and
noticed a typo. "endglobals" should be "endglobal".
