### PR TITLE
Fixes g:UltiSnipsEnableSnipMate "0" bechavior

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -95,7 +95,7 @@ class SnippetManager(object):
         enable_snipmate = True
         if _vim.eval("exists('g:UltiSnipsEnableSnipMate')") == "1":
             enable_snipmate = _vim.eval("g:UltiSnipsEnableSnipMate")
-        if enable_snipmate:
+        if enable_snipmate == "1":
             self.register_snippet_source("snipmate_files",
                 SnipMateFileSource())
 


### PR DESCRIPTION
_vim.eval always returns string which evaluates to True in python. 

If value is set to "0" in vimrc, snipmate is used anyway.

It is not clear from documentation that this value have to be set to empty string "" to disable snipmate (I have lost couple of hours trying to disable snipmate).