### PR TITLE
Fix adjacent tabstop input issue.

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -1444,6 +1444,7 @@ individuals have contributed to UltiSnips (in chronological order):
    Stanislav Seletskiy - seletskiy
    Pawel Palucki - ppalucki
    Dettorer - dettorer
+   Zhao Jiarong - kawing-chiu
 
 
 Thank you for your support.

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -319,7 +319,7 @@ class SnippetManager(object):
                     lt = '\n'.join(lt)
                     ct = '\n'.join(ct)
                     es = diff(lt, ct, initial_line)
-                self._csnippets[0].replay_user_edits(es)
+                self._csnippets[0].replay_user_edits(es, self._ctab)
             except IndexError:
                 # Rather do nothing than throwing an error. It will be correct
                 # most of the time

--- a/pythonx/UltiSnips/text_objects/_base.py
+++ b/pythonx/UltiSnips/text_objects/_base.py
@@ -183,7 +183,7 @@ class EditableTextObject(TextObject):
     ###############################
     # Private/Protected functions #
     ###############################
-    def _do_edit(self, cmd):
+    def _do_edit(self, cmd, ctab=None):
         """Apply the edit 'cmd' to this object."""
         ctype, line, col, text = cmd
         assert ('\n' not in text) or (text == '\n')
@@ -201,7 +201,13 @@ class EditableTextObject(TextObject):
                     break
                 elif ((child._start <= pos <= child._end) and
                         isinstance(child, EditableTextObject)):
-                    child._do_edit(cmd)
+                    if pos == child.end and not child.children:
+                        try:
+                            if ctab.number != child.number:
+                                continue
+                        except AttributeError:
+                            pass
+                    child._do_edit(cmd, ctab)
                     return
             else:  # Deletion
                 delend = pos + Position(0, len(text)) if text != '\n' \
@@ -214,7 +220,7 @@ class EditableTextObject(TextObject):
                         new_cmds.append(cmd)
                         break
                     else:
-                        child._do_edit(cmd)
+                        child._do_edit(cmd, ctab)
                         return
                 elif ((pos < child._start and child._end <= delend) or
                         (pos <= child._start and child._end < delend)):

--- a/pythonx/UltiSnips/text_objects/_snippet_instance.py
+++ b/pythonx/UltiSnips/text_objects/_snippet_instance.py
@@ -45,11 +45,11 @@ class SnippetInstance(EditableTextObject):
                     _place_initial_text(child)
         _place_initial_text(self)
 
-    def replay_user_edits(self, cmds):
+    def replay_user_edits(self, cmds, ctab=None):
         """Replay the edits the user has done to keep endings of our Text
         objects in sync with reality."""
         for cmd in cmds:
-            self._do_edit(cmd)
+            self._do_edit(cmd, ctab)
 
     def update_textobjects(self):
         """Update the text objects that should change automagically after the

--- a/test/test_TabStop.py
+++ b/test/test_TabStop.py
@@ -364,3 +364,10 @@ class TabStop_CROnlyOnSelectedNear(_VimTest):
     snippets = ('test', 't$1t${2: }t{\n\t$0\n}')
     keys = 'test' + EX + JF + '\n' + JF + 't'
     wanted = 'tt\nt{\n\tt\n}'
+
+
+class TabStop_AdjacentTabStopAddText_ExpectCorrectResult(_VimTest):
+    snippets = ('test', '[ $1$2 ] $1')
+    keys = 'test' + EX + 'Hello' + JF + 'World' + JF
+    wanted = '[ HelloWorld ] Hello'
+


### PR DESCRIPTION
Previously, adjacent tabstops like $1$2 were not handled properly.
$2 could be jumped to but no text could be added. See issue #457.