### PR TITLE
Add more precise undo levels (expanding, jumping)

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -111,6 +111,7 @@ class SnippetManager(object):
     def jump_forwards(self):
         """Jumps to the next tabstop."""
         _vim.command('let g:ulti_jump_forwards_res = 1')
+        _vim.command('let &undolevels = &undolevels')
         if not self._jump():
             _vim.command('let g:ulti_jump_forwards_res = 0')
             return self._handle_failure(self.forward_trigger)
@@ -119,6 +120,7 @@ class SnippetManager(object):
     def jump_backwards(self):
         """Jumps to the previous tabstop."""
         _vim.command('let g:ulti_jump_backwards_res = 1')
+        _vim.command('let &undolevels = &undolevels')
         if not self._jump(True):
             _vim.command('let g:ulti_jump_backwards_res = 0')
             return self._handle_failure(self.backward_trigger)
@@ -575,13 +577,15 @@ class SnippetManager(object):
         if not snippets:
             # No snippet found
             return False
-        elif len(snippets) == 1:
+        _vim.command('let &undolevels = &undolevels')
+        if len(snippets) == 1:
             snippet = snippets[0]
         else:
             snippet = _ask_snippets(snippets)
             if not snippet:
                 return True
         self._do_snippet(snippet, before)
+        _vim.command('let &undolevels = &undolevels')
         return True
 
     @property

--- a/test/test_Editing.py
+++ b/test/test_Editing.py
@@ -6,8 +6,8 @@ from test.constant import *
 
 class Undo_RemoveMultilineSnippet(_VimTest):
     snippets = ('test', 'Hello\naaa ${1} bbb\nWorld')
-    keys = 'test' + EX + ESC + 'u' + 'inothing'
-    wanted = 'nothing'
+    keys = 'test' + EX + ESC + 'u'
+    wanted = 'test'
 
 
 class Undo_RemoveEditInTabstop(_VimTest):
@@ -19,15 +19,43 @@ class Undo_RemoveEditInTabstop(_VimTest):
 class Undo_RemoveWholeSnippet(_VimTest):
     snippets = ('test', 'Hello\n${1:Hello}World')
     keys = 'first line\n\n\n\n\n\nthird line' + \
-        ESC + '3k0itest' + EX + ESC + 'uiupsy'
-    wanted = 'first line\n\n\nupsy\n\n\nthird line'
+        ESC + '3k0itest' + EX + ESC + 'u6j'
+    wanted = 'first line\n\n\ntest\n\n\nthird line'
+
+
+class Undo_RemoveOneSnippetByTime(_VimTest):
+    snippets = ('i', 'if:\n\t$1')
+    keys = 'i' + EX + 'i' + EX + ESC + 'u'
+    wanted = 'if:\n\ti'
+
+
+class Undo_RemoveOneSnippetByTime2(_VimTest):
+    snippets = ('i', 'if:\n\t$1')
+    keys = 'i' + EX + 'i' + EX + ESC + 'uu'
+    wanted = 'if:\n\t'
+
+
+class Undo_ChangesInPlaceholder(_VimTest):
+    snippets = ('i', 'if $1:\n\t$2')
+    keys = 'i' + EX + 'asd' + JF + ESC + 'u'
+    wanted = 'if :\n\t'
+
+
+class Undo_CompletelyUndoSnippet(_VimTest):
+    snippets = ('i', 'if $1:\n\t$2')
+    # undo 'feh'
+    # undo 'asd'
+    # undo snippet expansion
+    # undo entering of 'i'
+    keys = 'i' + EX + 'asd' + JF + 'feh' + ESC + 'uuuu'
+    wanted = ''
 
 
 class JumpForward_DefSnippet(_VimTest):
     snippets = (
         'test',
         "${1}\n`!p snip.rv = '\\n'.join(t[1].split())`\n\n${0:pass}")
-    keys = 'test' + EX + 'a b c' + JF + 'shallnot'
+    keys = 'test' + EX+ 'a b c' + JF + 'shallnot'
     wanted = 'a b c\na\nb\nc\n\nshallnot'
 
 
@@ -39,8 +67,8 @@ class DeleteSnippetInsertion0(_VimTest):
 
 class DeleteSnippetInsertion1(_VimTest):
     snippets = ('test', r"$1${1/(.*)/(?0::.)/}")
-    keys = 'test' + EX + ESC + 'u' + 'i' + JF + '\t'
-    wanted = '\t'
+    keys = 'test' + EX + ESC + 'u'
+    wanted = 'test'
 # End: Undo of Snippet insertion  #}}}
 
 # Normal mode editing  {{{#


### PR DESCRIPTION
Current behaviour is very annoying, when you want to undo snippet expansion and undo grabs a piece of your changes along with snippet.

Breaking undo achieved through re-setting &undolevel:

> Setting the value of 'undolevels' also breaks undo. Even when the new value is equal to the old value.
    [:h :undoj]

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sirver/ultisnips/486)
<!-- Reviewable:end -->
