### PR TITLE
`augroup END` in ftdetect/UltiSnips.vim breaks other ftdetect scripts

### DIFF
--- a/ftdetect/UltiSnips.vim
+++ b/ftdetect/UltiSnips.vim
@@ -7,8 +7,5 @@ if exists("vimpager")
 endif
 
 if has("autocmd")
-   augroup UltiSnipsFileType
-      au!
-      autocmd FileType * call UltiSnips#FileTypeChanged()
-   augroup END
+  autocmd FileType * call UltiSnips#FileTypeChanged()
 endif

--- a/ftdetect/UltiSnips.vim
+++ b/ftdetect/UltiSnips.vim
@@ -7,5 +7,11 @@ if exists("vimpager")
 endif
 
 if has("autocmd")
-  autocmd FileType * call UltiSnips#FileTypeChanged()
+    augroup UltiSnipsFileType
+        au!
+        autocmd FileType * call UltiSnips#FileTypeChanged()
+    augroup END
+
+    " restore 'filetypedetect' group declaration
+    augroup filetypedetect
 endif


### PR DESCRIPTION
I had a trouble with [kchmck/vim-coffee-script](https://github.com/kchmck/vim-coffee-script) that filetype detection auto commands are not defined within 'filetypedetect' augroup. After hours of debugging, I found it's a problem with UltiSnippet (and some other plugins).

From the [user guide](https://github.com/vim/vim/blob/master/runtime/doc/filetype.txt#L177-L185), autocommand in ftdetect scripts should not be surrounded with an augroup block.

During the startup of vim, ftdetect scripts are executed at the below line in `filetype.vim`.

https://github.com/vim/vim/blob/master/runtime/filetype.vim#L2713

You can find that ftdetect scripts are executed in 'filetypedetect' augroup, but `augroup END` can enclose 'filetypedetect' group unexpectedly, makes following auto commands (of plugins besides `UltiSnips`) be defined in default autogroup, but not 'filetypedetect'.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sirver/ultisnips/506)
<!-- Reviewable:end -->
