### PR TITLE
[RFC] Fire autocommands when setting up and tearing down inner mappings

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -12,7 +12,8 @@ UltiSnips                                      *snippet* *snippets* *UltiSnips*
    3.1 Commands                                 |UltiSnips-commands|
    3.2 Triggers                                 |UltiSnips-triggers|
       3.2.1 Using your own trigger functions    |UltiSnips-trigger-functions|
-      3.2.2 Path to Python Module               |UltiSnips-python-module-path|
+      3.2.2 Overriding inner mappings           |UltiSnips-inner-mappings|
+      3.2.3 Path to Python Module               |UltiSnips-python-module-path|
    3.3 Snippet Search Path                      |UltiSnips-snippet-search-path|
    3.4 Warning About Select Mode Mappings       |UltiSnips-warning-smappings|
    3.5 Functions                                |UltiSnips-functions|
@@ -302,7 +303,33 @@ then you define your mapping as >
 and if the you can't expand or jump from the current location then the
 alternative function IMAP_Jumpfunc('', 0) is called.
 
-3.2.2 Path to Python module                   *UltiSnips-python-module-path*
+3.2.2 Inner mappings                          *UltiSnips-inner-mappings*
+--------------------
+
+                                *UltiSnipsMapInnerKeys* *UltiSnipsUnmapInnerKeys*
+For maximum compatibility with other plug-ins, UltiSnips sets up some special
+mappings when a snippet starts being expanded, and tears them down once
+expansion is completed. In order to make it possible to override these inner
+mappings, it fires the following "User" autocommands:
+
+UltiSnipsMapInnerKeys
+UltiSnipsUnmapInnerKeys
+
+For example, to call a pair of custom functions in response to these events,
+you might do: >
+
+   autocmd! User UltiSnipsMapInnerKeys
+   autocmd User UltiSnipsMapInnerKeys call CustomInnerKeyMapper()
+   autocmd! User UltiSnipsUnmapInnerKeys
+   autocmd User UltiSnipsUnmapInnerKeys call CustomInnerKeyUnmapper()
+
+Note that because snippet expansion may be nested, it is possible that
+|UltiSnipsMapInnerKeys| may be fired multiple times (as you enter nested
+snippets), but |UltiSnipsUnmapInnerKeys| will only fire once all nested
+snippets have been exited.
+
+
+3.2.3 Path to Python module                   *UltiSnips-python-module-path*
 ---------------------------
 
 For even more advanced usage, you can directly write python functions using

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -344,6 +344,7 @@ class SnippetManager(object):
                      ' <C-R>=UltiSnips#JumpBackwards()<cr>')
         _vim.command('snoremap <buffer> <silent> ' + self.backward_trigger +
                      ' <Esc>:call UltiSnips#JumpBackwards()<cr>')
+        _vim.command('silent doautocmd User UltiSnipsMapInnerKeys')
         self._inner_mappings_in_place = True
 
     def _unmap_inner_keys(self):
@@ -351,7 +352,7 @@ class SnippetManager(object):
         if not self._inner_mappings_in_place:
             return
         try:
-            _vim.command('silent doautocmd User UltiSnipsSnippetDone')
+            _vim.command('silent doautocmd User UltiSnipsUnmapInnerKeys')
             if self.expand_trigger != self.forward_trigger:
                 _vim.command('iunmap <buffer> %s' % self.forward_trigger)
                 _vim.command('sunmap <buffer> %s' % self.forward_trigger)
@@ -532,7 +533,6 @@ class SnippetManager(object):
         """Expands the given snippet, and handles everything that needs to be
         done with it."""
         self._map_inner_keys()
-        _vim.command('silent doautocmd User UltiSnipsDoSnippet')
 
         # Adjust before, maybe the trigger is not the complete word
         text_before = before

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -351,6 +351,7 @@ class SnippetManager(object):
         if not self._inner_mappings_in_place:
             return
         try:
+            _vim.command('silent doautocmd User UltiSnipsSnippetDone')
             if self.expand_trigger != self.forward_trigger:
                 _vim.command('iunmap <buffer> %s' % self.forward_trigger)
                 _vim.command('sunmap <buffer> %s' % self.forward_trigger)
@@ -531,6 +532,7 @@ class SnippetManager(object):
         """Expands the given snippet, and handles everything that needs to be
         done with it."""
         self._map_inner_keys()
+        _vim.command('silent doautocmd User UltiSnipsDoSnippet')
 
         # Adjust before, maybe the trigger is not the complete word
         text_before = before

--- a/test/test_Autocommands.py
+++ b/test/test_Autocommands.py
@@ -1,0 +1,31 @@
+# encoding: utf-8
+from test.vim_test_case import VimTestCase as _VimTest
+from test.constant import *
+
+# Autocommands  {{{#
+
+class Autocommands(_VimTest):
+    snippets = ('test', '[ ${1:foo} ]')
+    args = ''
+    keys = 'test' + EX + JF + ESC + \
+            ':execute "normal iM" . g:mapper_call_count . "\<Esc>"' + "\n" + \
+            ':execute "normal aU" . g:unmapper_call_count . "\<Esc>"' + "\n"
+    wanted = '[ foo M1U1]'
+
+    def _extra_options_pre_init(self, vim_config):
+        vim_config.append('let g:mapper_call_count = 0')
+        vim_config.append('function! CustomMapper()')
+        vim_config.append('  let g:mapper_call_count += 1')
+        vim_config.append('endfunction')
+
+        vim_config.append('let g:unmapper_call_count = 0')
+        vim_config.append('function! CustomUnmapper()')
+        vim_config.append('  let g:unmapper_call_count += 1')
+        vim_config.append('endfunction')
+
+        vim_config.append('autocmd! User UltiSnipsMapInnerKeys')
+        vim_config.append('autocmd User UltiSnipsMapInnerKeys call CustomMapper()')
+        vim_config.append('autocmd! User UltiSnipsUnmapInnerKeys')
+        vim_config.append('autocmd User UltiSnipsUnmapInnerKeys call CustomUnmapper()')
+
+# end: Autocommands  #}}}


### PR DESCRIPTION
It can be useful to set up mappings that apply only during expansion of
a snippet. UltiSnips does this internally with the `_map_inner_keys` and
`_unmap_inner_keys` methods.

This commit adds some `User` autocommands so that users of UltiSnips can
set up their own mappings and tear them down at the same time as
`_map_inner_keys` and `_unmap_inner_keys`.

This is particularly useful for people who are writing their own
expansion and jump functions using `UltiSnips#JumpForwards` and
`UltiSnips#ExpandSnippet()` and friends. Here's an example from my own
dotfiles:

- https://github.com/wincent/wincent/commit/0664b627e7390c7ab5b047ee5818801481d0f46c
- https://github.com/wincent/wincent/commit/3740c248ee498220f3e7361b5e41023bd6cb2dbf

Using this approach I've been able to get rid of Supertab and have a
more nuanced autocompletion experience that works exactly as I'd like
with YouCompleteMe.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sirver/ultisnips/514)
<!-- Reviewable:end -->
