### PR TITLE
VimBuffer: use vim.current.buffer.number instead of vim.eval

### DIFF
--- a/pythonx/UltiSnips/_vim.py
+++ b/pythonx/UltiSnips/_vim.py
@@ -49,8 +49,8 @@ class VimBuffer(object):
 
     @property
     def number(self):  # pylint:disable=no-self-use
-        """The bufnr() of this buffer."""
-        return int(eval("bufnr('%')"))
+        """The bufnr() of the current buffer."""
+        return vim.current.buffer.number
 
     @property
     def cursor(self):  # pylint:disable=no-self-use


### PR DESCRIPTION
This should be more performant.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sirver/ultisnips/522)
<!-- Reviewable:end -->
