### PR TITLE
Pipe-quoting helptag reference to UltiSnips-context-snippets

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -1441,7 +1441,7 @@ There are three types of actions:
 
 Specified code will be evaluated at stages defined above and same global
 variables and modules will be available that are stated in
-the *UltiSnips-context-snippets* section.
+the |UltiSnips-context-snippets| section.
 
                                                 *UltiSnips-buffer-proxy*
 


### PR DESCRIPTION
Was getting a "duplicate tag" error when running Helptags

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sirver/ultisnips/537)
<!-- Reviewable:end -->
