### PR TITLE
To Fix E154: Duplicate tag "UltiSnips-context-snippets"

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -1441,7 +1441,7 @@ There are three types of actions:
 
 Specified code will be evaluated at stages defined above and same global
 variables and modules will be available that are stated in
-the *UltiSnips-context-snippets* section.
+the |UltiSnips-context-snippets| section.
 
                                                 *UltiSnips-buffer-proxy*
 


### PR DESCRIPTION
Error in how the documentation was formatted. Like the Error is saying, duplicate tags are detected. Vim uses asterisk surrounded text for its help tags. i kept getting this Error during plugin update with vundle. Fixed by removing the duplicate tag's

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sirver/ultisnips/538)
<!-- Reviewable:end -->
