### PR TITLE
Autotrigger

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -144,3 +144,8 @@ endf
 function! UltiSnips#LeavingInsertMode()
     exec g:_uspy "UltiSnips_Manager._leaving_insert_mode()"
 endfunction
+
+function! UltiSnips#TrackChange()
+    exec g:_uspy "UltiSnips_Manager._track_change()"
+endfunction
+" }}}

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -1606,7 +1606,7 @@ endsnippet
 4.11 Autotrigger                                       *UltiSnips-autotrigger*
 ----------------
 
-Many language constructions can occur only at specific places, so it's
+Many language constructs can occur only at specific places, so it's
 possible to use snippets without manually triggering them.
 
 Snippet can be marked as autotriggered by specifying 'A' option in the snippet
@@ -1615,6 +1615,9 @@ definition.
 After snippet is defined as being autotriggered, snippet condition will be
 checked on every typed character and if condition matches, then snippet will
 be triggered.
+
+*Warning:* using of this feature can lead to significant vim slowdown. If you
+discovered that, report an issue to the github.com/SirVer/UltiSnips.
 
 Consider following snippets, that can be usefull in Go programming:
 ------------------- SNIP -------------------
@@ -1630,7 +1633,8 @@ endsnippet
 ------------------- SNAP -------------------
 
 When "p" character will occur in the beginning of the line, it will be
-automatically expanded into "package main". Same with "m" character.
+automatically expanded into "package main". Same with "m" character. There is
+no need to press trigger key after "m".
 
 ==============================================================================
 5. UltiSnips and Other Plugins                      *UltiSnips-other-plugins*

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -1606,6 +1606,8 @@ endsnippet
 4.11 Autotrigger                                       *UltiSnips-autotrigger*
 ----------------
 
+Note: vim should be newer than 7.4.214 to support this feature.
+
 Many language constructs can occur only at specific places, so it's
 possible to use snippets without manually triggering them.
 
@@ -1634,7 +1636,7 @@ endsnippet
 
 When "p" character will occur in the beginning of the line, it will be
 automatically expanded into "package main". Same with "m" character. There is
-no need to press trigger key after "m".
+no need to press trigger key after "m""
 
 ==============================================================================
 5. UltiSnips and Other Plugins                      *UltiSnips-other-plugins*

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -42,6 +42,7 @@ UltiSnips                                      *snippet* *snippets* *UltiSnips*
       4.10.1 Pre-expand actions                 |UltiSnips-pre-expand-actions|
       4.10.2 Post-expand actions                |UltiSnips-post-expand-actions|
       4.10.3 Post-jump actions                  |UltiSnips-post-jump-actions|
+   4.11 Autotrigger                             |UltiSnips-autotrigger|
 5. UltiSnips and Other Plugins                  |UltiSnips-other-plugins|
    5.1 Existing Integrations                    |UltiSnips-integrations|
    5.2 Extending UltiSnips                      |UltiSnips-extending|
@@ -689,6 +690,9 @@ The options currently supported are: >
        controlled not only by previous characters in line, but by any given
        python expression. This option can be specified along with other
        options, like 'b'. See |UltiSnips-context-snippets| for more info.
+
+   A   Snippet will be triggered automatically, when condition matches.
+       See |UltiSnips-autotrigger| for more info.
 
 The end line is the 'endsnippet' keyword on a line by itself. >
 
@@ -1598,6 +1602,35 @@ def $1():
 	$2
 endsnippet
 ------------------- SNAP -------------------
+
+4.11 Autotrigger                                       *UltiSnips-autotrigger*
+----------------
+
+Many language constructions can occur only at specific places, so it's
+possible to use snippets without manually triggering them.
+
+Snippet can be marked as autotriggered by specifying 'A' option in the snippet
+definition.
+
+After snippet is defined as being autotriggered, snippet condition will be
+checked on every typed character and if condition matches, then snippet will
+be triggered.
+
+Consider following snippets, that can be usefull in Go programming:
+------------------- SNIP -------------------
+snippet "^p" "package" rbA
+package ${1:main}
+endsnippet
+
+snippet "^m" "func main" rbA
+func main() {
+	$1
+}
+endsnippet
+------------------- SNAP -------------------
+
+When "p" character will occur in the beginning of the line, it will be
+automatically expanded into "package main". Same with "m" character.
 
 ==============================================================================
 5. UltiSnips and Other Plugins                      *UltiSnips-other-plugins*

--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -46,6 +46,12 @@ command! -bang -nargs=? -complete=customlist,UltiSnips#FileTypeComplete UltiSnip
 
 command! -nargs=1 UltiSnipsAddFiletypes :call UltiSnips#AddFiletypes(<q-args>)
 
+augroup UltiSnips_AutoTrigger
+    au!
+    au InsertCharPre * call UltiSnips#TrackChange()
+    au TextChangedI * call UltiSnips#TrackChange()
+augroup END
+
 call UltiSnips#map_keys#MapKeys()
 
 " vim: ts=8 sts=4 sw=4

--- a/pythonx/UltiSnips/snippet/source/_base.py
+++ b/pythonx/UltiSnips/snippet/source/_base.py
@@ -28,7 +28,7 @@ class SnippetSource(object):
         deep_extends = self.get_deep_extends(base_filetypes)
         return [ft for ft in deep_extends if ft in self._snippets]
 
-    def get_snippets(self, filetypes, before, possible):
+    def get_snippets(self, filetypes, before, possible, autotrigger_only):
         """Returns the snippets for all 'filetypes' (in order) and their
         parents matching the text 'before'. If 'possible' is true, a partial
         match is enough. Base classes can override this method to provide means
@@ -40,7 +40,7 @@ class SnippetSource(object):
         result = []
         for ft in self._get_existing_deep_extends(filetypes):
             snips = self._snippets[ft]
-            result.extend(snips.get_matching_snippets(before, possible))
+            result.extend(snips.get_matching_snippets(before, possible, autotrigger_only))
         return result
 
     def get_clear_priority(self, filetypes):

--- a/pythonx/UltiSnips/snippet/source/_base.py
+++ b/pythonx/UltiSnips/snippet/source/_base.py
@@ -40,7 +40,8 @@ class SnippetSource(object):
         result = []
         for ft in self._get_existing_deep_extends(filetypes):
             snips = self._snippets[ft]
-            result.extend(snips.get_matching_snippets(before, possible, autotrigger_only))
+            result.extend(snips.get_matching_snippets(before, possible,
+                                                      autotrigger_only))
         return result
 
     def get_clear_priority(self, filetypes):

--- a/pythonx/UltiSnips/snippet/source/_snippet_dictionary.py
+++ b/pythonx/UltiSnips/snippet/source/_snippet_dictionary.py
@@ -16,13 +16,16 @@ class SnippetDictionary(object):
         """Add 'snippet' to this dictionary."""
         self._snippets.append(snippet)
 
-    def get_matching_snippets(self, trigger, potentially):
+    def get_matching_snippets(self, trigger, potentially, autotrigger_only):
         """Returns all snippets matching the given trigger.
 
         If 'potentially' is true, returns all that could_match().
 
         """
         all_snippets = self._snippets
+        if autotrigger_only:
+            all_snippets = [s for s in all_snippets if s.has_option('A')]
+
         if not potentially:
             return [s for s in all_snippets if s.matches(trigger)]
         else:

--- a/pythonx/UltiSnips/snippet/source/_snippet_dictionary.py
+++ b/pythonx/UltiSnips/snippet/source/_snippet_dictionary.py
@@ -21,6 +21,13 @@ class SnippetDictionary(object):
 
         If 'potentially' is true, returns all that could_match().
 
+        If 'autotrigger_only' is true, function will return only snippets which
+        are marked with flag 'A' (should be automatically expanded without
+        trigger key press).
+        It's handled specially to avoid walking down the list of all snippets,
+        which can be very slow, because function will be called on each change
+        made in insert mode.
+
         """
         all_snippets = self._snippets
         if autotrigger_only:

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -100,6 +100,8 @@ class SnippetManager(object):
         self._snip_expanded_in_action = False
         self._inside_action = False
 
+        self._last_inserted_char = ''
+
         self._added_snippets_source = AddedSnippetsSource()
         self.register_snippet_source('ultisnips_files', UltiSnipsFileSource())
         self.register_snippet_source('added', self._added_snippets_source)
@@ -363,6 +365,8 @@ class SnippetManager(object):
         _vim.command('autocmd!')
         _vim.command('autocmd CursorMovedI * call UltiSnips#CursorMoved()')
         _vim.command('autocmd CursorMoved * call UltiSnips#CursorMoved()')
+        _vim.command('autocmd InsertCharPre * call UltiSnips#TrackChange()')
+        _vim.command('autocmd TextChangedI * call UltiSnips#TrackChange()')
 
         _vim.command(
             'autocmd InsertLeave * call UltiSnips#LeavingInsertMode()')
@@ -541,7 +545,7 @@ class SnippetManager(object):
         elif feedkey:
             _vim.command('return %s' % _vim.escape(feedkey))
 
-    def _snips(self, before, partial):
+    def _snips(self, before, partial, autotrigger_only=False):
         """Returns all the snippets for the given text before the cursor.
 
         If partial is True, then get also return partial matches.
@@ -565,7 +569,14 @@ class SnippetManager(object):
                     cleared[key] = value
 
         for _, source in self._snippet_sources:
-            for snippet in source.get_snippets(filetypes, before, partial):
+            possible_snippets = source.get_snippets(
+                filetypes,
+                before,
+                partial,
+                autotrigger_only
+            )
+
+            for snippet in possible_snippets:
                 if ((clear_priority is None or snippet.priority > clear_priority)
                         and (snippet.trigger not in cleared or
                              snippet.priority > cleared[snippet.trigger])):
@@ -667,10 +678,10 @@ class SnippetManager(object):
                 self._snip_expanded_in_action = True
 
 
-    def _try_expand(self):
+    def _try_expand(self, autotrigger_only=False):
         """Try to expand a snippet in the current place."""
         before = _vim.buf.line_till_cursor
-        snippets = self._snips(before, False)
+        snippets = self._snips(before, False, autotrigger_only)
         if snippets:
             # prefer snippets with context if any
             snippets_with_context = [s for s in snippets if s.context]
@@ -764,6 +775,16 @@ class SnippetManager(object):
             yield
         finally:
             self._inside_action = old_flag
+
+    def _track_change(self):
+        inserted_char = _vim.eval('v:char')
+        if inserted_char == '':
+            before = _vim.buf.line_till_cursor
+            if before and before[-1] == self._last_inserted_char:
+                self._try_expand(autotrigger_only=True)
+        else:
+            self._last_inserted_char = inserted_char
+
 
 UltiSnips_Manager = SnippetManager(  # pylint:disable=invalid-name
     vim.eval('g:UltiSnipsExpandTrigger'),

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -776,6 +776,7 @@ class SnippetManager(object):
         finally:
             self._inside_action = old_flag
 
+    @err_to_scratch_buffer
     def _track_change(self):
         inserted_char = _vim.eval('v:char')
         if inserted_char == '':

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -365,8 +365,6 @@ class SnippetManager(object):
         _vim.command('autocmd!')
         _vim.command('autocmd CursorMovedI * call UltiSnips#CursorMoved()')
         _vim.command('autocmd CursorMoved * call UltiSnips#CursorMoved()')
-        _vim.command('autocmd InsertCharPre * call UltiSnips#TrackChange()')
-        _vim.command('autocmd TextChangedI * call UltiSnips#TrackChange()')
 
         _vim.command(
             'autocmd InsertLeave * call UltiSnips#LeavingInsertMode()')
@@ -779,11 +777,12 @@ class SnippetManager(object):
     @err_to_scratch_buffer
     def _track_change(self):
         inserted_char = _vim.eval('v:char')
-        if inserted_char == '':
-            before = _vim.buf.line_till_cursor
-            if before and before[-1] == self._last_inserted_char:
-                self._try_expand(autotrigger_only=True)
-        else:
+        try:
+            if inserted_char == '':
+                before = _vim.buf.line_till_cursor
+                if before and before[-1] == self._last_inserted_char:
+                    self._try_expand(autotrigger_only=True)
+        finally:
             self._last_inserted_char = inserted_char
 
 

--- a/test/test_Autotrigger.py
+++ b/test/test_Autotrigger.py
@@ -1,0 +1,22 @@
+from test.vim_test_case import VimTestCase as _VimTest
+from test.constant import *
+
+
+class Autotrigger_CanMatchSimpleTrigger(_VimTest):
+    files = { 'us/all.snippets': r"""
+        snippet a "desc" A
+        autotriggered
+        endsnippet
+        """}
+    keys = 'a'
+    wanted = 'autotriggered'
+
+
+class Autotrigger_CanMatchContext(_VimTest):
+    files = { 'us/all.snippets': r"""
+        snippet a "desc" "snip.line == 2" Ae
+        autotriggered
+        endsnippet
+        """}
+    keys = 'a\na'
+    wanted = 'autotriggered\na'

--- a/test/test_Autotrigger.py
+++ b/test/test_Autotrigger.py
@@ -15,6 +15,8 @@ def has_patch(version, executable):
 
 
 def check_required_vim_version(test):
+    if test.vim_flavor == 'neovim':
+        return None
     if not has_patch(214, test.vim._vim_executable):
         return 'Vim newer than 7.4.214 is required'
     else:

--- a/test/test_Autotrigger.py
+++ b/test/test_Autotrigger.py
@@ -13,10 +13,15 @@ def has_patch(version, executable):
     return int(patch) >= version
 
 
+def check_required_vim_version(test):
+    if not has_patch(214, test.vim._vim_executable):
+        return 'Vim newer than 7.4.214 is required'
+    else:
+        return None
+
+
 class Autotrigger_CanMatchSimpleTrigger(_VimTest):
-    skip_if = lambda self: 'Vim newer than 7.4.214 is required' if \
-        not has_patch(214, self.vim._vim_executable) \
-        else None
+    skip_if = check_required_vim_version
     files = { 'us/all.snippets': r"""
         snippet a "desc" A
         autotriggered
@@ -27,9 +32,7 @@ class Autotrigger_CanMatchSimpleTrigger(_VimTest):
 
 
 class Autotrigger_CanMatchContext(_VimTest):
-    skip_if = lambda self: 'Vim newer than 7.4.214 is required' if \
-        not has_patch(214, self.vim._vim_executable) \
-        else None
+    skip_if = check_required_vim_version
     files = { 'us/all.snippets': r"""
         snippet a "desc" "snip.line == 2" Ae
         autotriggered
@@ -37,3 +40,14 @@ class Autotrigger_CanMatchContext(_VimTest):
         """}
     keys = 'a\na'
     wanted = 'autotriggered\na'
+
+
+class Autotrigger_CanExpandOnTriggerWithLengthMoreThanOne(_VimTest):
+    skip_if = check_required_vim_version
+    files = { 'us/all.snippets': r"""
+        snippet abc "desc" A
+        autotriggered
+        endsnippet
+        """}
+    keys = 'abc'
+    wanted = 'autotriggered'

--- a/test/test_Autotrigger.py
+++ b/test/test_Autotrigger.py
@@ -6,6 +6,7 @@ import subprocess
 
 def has_patch(version, executable):
     output = subprocess.check_output([executable, "--version"])
+    patch = 1
     for line in output.split("\n"):
         if line.startswith("Included patches:"):
             patch = line.split('-')[1]

--- a/test/test_Autotrigger.py
+++ b/test/test_Autotrigger.py
@@ -1,8 +1,22 @@
 from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
+import subprocess
+
+
+def has_patch(version, executable):
+    output = subprocess.check_output([executable, "--version"])
+    for line in output.split("\n"):
+        if line.startswith("Included patches:"):
+            patch = line.split('-')[1]
+
+    return int(patch) >= version
+
 
 class Autotrigger_CanMatchSimpleTrigger(_VimTest):
+    skip_if = lambda self: 'Vim newer than 7.4.214 is required' if \
+        not has_patch(214, self.vim._vim_executable) \
+        else None
     files = { 'us/all.snippets': r"""
         snippet a "desc" A
         autotriggered
@@ -13,6 +27,9 @@ class Autotrigger_CanMatchSimpleTrigger(_VimTest):
 
 
 class Autotrigger_CanMatchContext(_VimTest):
+    skip_if = lambda self: 'Vim newer than 7.4.214 is required' if \
+        not has_patch(214, self.vim._vim_executable) \
+        else None
     files = { 'us/all.snippets': r"""
         snippet a "desc" "snip.line == 2" Ae
         autotriggered

--- a/test/test_Autotrigger.py
+++ b/test/test_Autotrigger.py
@@ -7,7 +7,7 @@ import subprocess
 def has_patch(version, executable):
     output = subprocess.check_output([executable, "--version"])
     patch = 1
-    for line in output.split("\n"):
+    for line in output.decode('utf-8').split("\n"):
         if line.startswith("Included patches:"):
             patch = line.split('-')[1]
 

--- a/test/test_Autotrigger.py
+++ b/test/test_Autotrigger.py
@@ -54,3 +54,16 @@ class Autotrigger_CanExpandOnTriggerWithLengthMoreThanOne(_VimTest):
         """}
     keys = 'abc'
     wanted = 'autotriggered'
+
+
+class Autotrigger_WillProduceNoExceptionWithVimLowerThan214(_VimTest):
+    skip_if = lambda self: 'Vim older than 7.4.214 is required' \
+        if has_patch(214, self.vim._vim_executable) else None
+
+    files = { 'us/all.snippets': r"""
+        snippet abc "desc" A
+        autotriggered
+        endsnippet
+        """}
+    keys = 'abc'
+    wanted = 'abc'

--- a/test/test_UltiSnipFunc.py
+++ b/test/test_UltiSnipFunc.py
@@ -155,7 +155,7 @@ from UltiSnips.snippet.definition import UltiSnipsSnippetDefinition
 
 class MySnippetSource(SnippetSource):
   def get_snippets(self, filetypes, before, possible, autotrigger_only):
-    if before.endswith('blumba'):
+    if before.endswith('blumba') and autotrigger_only == False:
       return [
           UltiSnipsSnippetDefinition(
               -100, "blumba", "this is a dynamic snippet", "", "", {}, "blub",

--- a/test/test_UltiSnipFunc.py
+++ b/test/test_UltiSnipFunc.py
@@ -154,7 +154,7 @@ from UltiSnips.snippet.source import SnippetSource
 from UltiSnips.snippet.definition import UltiSnipsSnippetDefinition
 
 class MySnippetSource(SnippetSource):
-  def get_snippets(self, filetypes, before, possible):
+  def get_snippets(self, filetypes, before, possible, autotrigger_only):
     if before.endswith('blumba'):
       return [
           UltiSnipsSnippetDefinition(


### PR DESCRIPTION
Guess what? It's me again.

This feature is a logical continuation of two preceding: context snippets and snippet actions.

Autotrigger combines them to achieve even faster programming style: there are
many places in a program code where only specific constructions can occurs.
E.g., in Go code on the top level you can see mostly (**p**)ackage / (**t**)ype / (**f**)unction / (**m**)ethod / (**v**)ar / (**c**)onst definition and nothing more.

So why use `p/t/f/m/v/c <TAB>` to expand snippet if one can use `p/t/f/m/v/c` alone which cause specific snippet to expand?

There are numerous applications for this feature, for example expanding operators in the middle of the code, e.g.
```
if (a =|)  ->  if (a == |)    automatically convert = to ==<SPACE>
```

I'm aware that it can be slow, I have some thoughts about optimization, but right now I'm using it and not experiencing any significant slowdown.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sirver/ultisnips/539)
<!-- Reviewable:end -->
