### PR TITLE
Use <nomodeline> when firing user autocmds

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -374,7 +374,7 @@ class SnippetManager(object):
             'autocmd CmdwinLeave * call UltiSnips#LeavingBuffer()')
         _vim.command('augroup END')
 
-        _vim.command('silent doautocmd User UltiSnipsEnterFirstSnippet')
+        _vim.command('silent doautocmd <nomodeline> User UltiSnipsEnterFirstSnippet')
         self._inner_state_up = True
 
     def _teardown_inner_state(self):
@@ -382,7 +382,7 @@ class SnippetManager(object):
         if not self._inner_state_up:
             return
         try:
-            _vim.command('silent doautocmd User UltiSnipsExitLastSnippet')
+            _vim.command('silent doautocmd <nomodeline> User UltiSnipsExitLastSnippet')
             if self.expand_trigger != self.forward_trigger:
                 _vim.command('iunmap <buffer> %s' % self.forward_trigger)
                 _vim.command('sunmap <buffer> %s' % self.forward_trigger)


### PR DESCRIPTION
As recommended by the Vim help (`:h <nomodeline>`):

    After applying the autocommands the modelines are
    processed, so that their settings overrule the
    settings from autocommands, like what happens when
    editing a file. This is skipped when the <nomodeline>
    argument is present. You probably want to use
    <nomodeline> for events that are not used when loading
    a buffer, such as |User|.

Fixes: https://github.com/SirVer/ultisnips/issues/542

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sirver/ultisnips/544)
<!-- Reviewable:end -->
