### PR TITLE
Only use <nomodeline> if we're sure it is available

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -374,7 +374,10 @@ class SnippetManager(object):
             'autocmd CmdwinLeave * call UltiSnips#LeavingBuffer()')
         _vim.command('augroup END')
 
-        _vim.command('silent doautocmd <nomodeline> User UltiSnipsEnterFirstSnippet')
+        if _vim.eval('v:version > 703 || v:version == 703 && has("patch438")') == '1':
+            _vim.command('silent doautocmd <nomodeline> User UltiSnipsEnterFirstSnippet')
+        else:
+            _vim.command('silent doautocmd User UltiSnipsEnterFirstSnippet')
         self._inner_state_up = True
 
     def _teardown_inner_state(self):
@@ -382,7 +385,10 @@ class SnippetManager(object):
         if not self._inner_state_up:
             return
         try:
-            _vim.command('silent doautocmd <nomodeline> User UltiSnipsExitLastSnippet')
+            if _vim.eval('v:version > 703 || v:version == 703 && has("patch438")') == '1':
+                _vim.command('silent doautocmd <nomodeline> User UltiSnipsExitLastSnippet')
+            else:
+                _vim.command('silent doautocmd User UltiSnipsExitLastSnippet')
             if self.expand_trigger != self.forward_trigger:
                 _vim.command('iunmap <buffer> %s' % self.forward_trigger)
                 _vim.command('sunmap <buffer> %s' % self.forward_trigger)


### PR DESCRIPTION
According to `:h version7.txt`, `<nomodeline>` was added in Vim 7.3.438.
Trying to use it prior to that will likely result in an:

    E216: No such group or event: <nomodeline> User UltiSnipsEnterFirstSnippet

Add a conditional to ensure we only use it when we know it's available.

Follow-up to: https://github.com/SirVer/ultisnips/pull/544

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sirver/ultisnips/545)
<!-- Reviewable:end -->
