### PR TITLE
Define UltiSnips#FileTypeChanged always

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -1,5 +1,9 @@
 if exists("b:did_autoload_ultisnips") || !exists("g:_uspy")
-   finish
+    " Define no-op function, called via ftdetect/UltiSnips.vim.
+    function! UltiSnips#FileTypeChanged()
+    endfunction
+
+    finish
 endif
 let b:did_autoload_ultisnips = 1
 


### PR DESCRIPTION
This is called via ftdetect/UltiSnips.vim, and needs to be defined
also if UltiSnips fails to initialize, e.g. because of missing Python
support.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sirver/ultisnips/549)
<!-- Reviewable:end -->
