### PR TITLE
Show backtrace on error

### DIFF
--- a/pythonx/UltiSnips/snippet/definition/_base.py
+++ b/pythonx/UltiSnips/snippet/definition/_base.py
@@ -6,6 +6,7 @@
 import re
 
 import vim
+import textwrap
 
 from UltiSnips import _vim
 from UltiSnips.compatibility import as_unicode
@@ -116,7 +117,29 @@ class SnippetDefinition(object):
 
         snip = SnippetUtilForAction(locals)
 
-        exec(code, {'snip': snip})
+        try:
+            exec(code, {'snip': snip})
+        except Exception as e:
+            e.snippet_info = textwrap.dedent("""
+                Trigger: {}
+                Description: {}
+                Context: {}
+                Pre-expand: {}
+                Post-expand: {}
+            """).format(
+                self._trigger,
+                self._description,
+                self._context_code if self._context_code else '<none>',
+                self._actions['pre_expand'] if 'pre_expand' in self._actions
+                    else '<none>',
+                self._actions['post_expand'] if 'post_expand' in self._actions
+                    else '<none>',
+                code,
+            )
+
+            e.snippet_code = code
+
+            raise
 
         return snip
 

--- a/pythonx/UltiSnips/snippet/definition/_base.py
+++ b/pythonx/UltiSnips/snippet/definition/_base.py
@@ -121,12 +121,14 @@ class SnippetDefinition(object):
             exec(code, {'snip': snip})
         except Exception as e:
             e.snippet_info = textwrap.dedent("""
+                Defined in: {}
                 Trigger: {}
                 Description: {}
                 Context: {}
                 Pre-expand: {}
                 Post-expand: {}
             """).format(
+                self._location,
                 self._trigger,
                 self._description,
                 self._context_code if self._context_code else '<none>',

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -68,21 +68,17 @@ Following is the full stack trace:
 """
 
             msg += traceback.format_exc()
-            if hasattr(e, 'code'):
+            if hasattr(e, 'snippet_code'):
                 _, _, tb = sys.exc_info()
                 tb_top = traceback.extract_tb(tb)[-1]
-                msg += "\nFollowing is the full executed code:\n"
-                lines = e.code.split("\n")
-                number = 1
-                for line in lines:
+                msg += "\nExecuted snippet code:\n"
+                lines = e.snippet_code.split("\n")
+                for number, line in enumerate(lines, 1):
                     msg += str(number).rjust(3)
-                    prefix = ""
-                    if line != "":
-                        prefix = "   "
+                    prefix = "   " if line else ""
                     if tb_top[1] == number:
                         prefix = " > "
                     msg += prefix + line + "\n"
-                    number += 1
 
             # Vim sends no WinLeave msg here.
             self._leaving_buffer()  # pylint:disable=protected-access

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -8,6 +8,7 @@ from functools import wraps
 import os
 import platform
 import traceback
+import sys
 import vim
 from contextlib import contextmanager
 
@@ -68,11 +69,19 @@ Following is the full stack trace:
 
             msg += traceback.format_exc()
             if hasattr(e, 'code'):
+                _, _, tb = sys.exc_info()
+                tb_top = traceback.extract_tb(tb)[-1]
                 msg += "\nFollowing is the full executed code:\n"
                 lines = e.code.split("\n")
                 number = 1
                 for line in lines:
-                    msg += str(number) + ": " + line + "\n"
+                    msg += str(number).rjust(3)
+                    prefix = ""
+                    if line != "":
+                        prefix = "   "
+                    if tb_top[1] == number:
+                        prefix = " > "
+                    msg += prefix + line + "\n"
                     number += 1
 
             # Vim sends no WinLeave msg here.

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -68,6 +68,9 @@ Following is the full stack trace:
 """
 
             msg += traceback.format_exc()
+            # snippet_code comes from _python_code.py, it's set manually for
+            # providing error message with stacktrace of failed python code
+            # inside of the snippet.
             if hasattr(e, 'snippet_code'):
                 _, _, tb = sys.exc_info()
                 tb_top = traceback.extract_tb(tb)[-1]

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -57,7 +57,7 @@ def err_to_scratch_buffer(func):
     def wrapper(self, *args, **kwds):
         try:
             return func(self, *args, **kwds)
-        except:  # pylint: disable=bare-except
+        except Exception as e:  # pylint: disable=bare-except
             msg = \
                 """An error occured. This is either a bug in UltiSnips or a bug in a
 snippet definition. If you think this is a bug, please report it to
@@ -65,7 +65,16 @@ https://github.com/SirVer/ultisnips/issues/new.
 
 Following is the full stack trace:
 """
+
             msg += traceback.format_exc()
+            if hasattr(e, 'code'):
+                msg += "\nFollowing is the full executed code:\n"
+                lines = e.code.split("\n")
+                number = 1
+                for line in lines:
+                    msg += str(number) + ": " + line + "\n"
+                    number += 1
+
             # Vim sends no WinLeave msg here.
             self._leaving_buffer()  # pylint:disable=protected-access
             _vim.new_scratch_buffer(msg)

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -10,6 +10,7 @@ import platform
 import traceback
 import sys
 import vim
+import re
 from contextlib import contextmanager
 
 from UltiSnips import _vim
@@ -68,6 +69,11 @@ Following is the full stack trace:
 """
 
             msg += traceback.format_exc()
+            if hasattr(e, 'snippet_info'):
+                msg += "\nSnippet, caused error:\n"
+                msg += re.sub(
+                    '^(?=\S)', '  ', e.snippet_info, flags=re.MULTILINE
+                )
             # snippet_code comes from _python_code.py, it's set manually for
             # providing error message with stacktrace of failed python code
             # inside of the snippet.

--- a/pythonx/UltiSnips/text_objects/_python_code.py
+++ b/pythonx/UltiSnips/text_objects/_python_code.py
@@ -266,12 +266,11 @@ class PythonCode(NoneditableTextObject):
         })
         self._snip._reset(ct)  # pylint:disable=protected-access
 
-
         for code in self._codes:
             try:
                 exec(code, self._locals)  # pylint:disable=exec-used
             except Exception as e:
-                e.code = code
+                e.snippet_code = code
                 raise
 
         rv = as_unicode(

--- a/pythonx/UltiSnips/text_objects/_python_code.py
+++ b/pythonx/UltiSnips/text_objects/_python_code.py
@@ -266,8 +266,13 @@ class PythonCode(NoneditableTextObject):
         })
         self._snip._reset(ct)  # pylint:disable=protected-access
 
+
         for code in self._codes:
-            exec(code, self._locals)  # pylint:disable=exec-used
+            try:
+                exec(code, self._locals)  # pylint:disable=exec-used
+            except Exception as e:
+                e.code = code
+                raise
 
         rv = as_unicode(
             self._snip.rv if self._snip._rv_changed  # pylint:disable=protected-access

--- a/test/test_ParseSnippets.py
+++ b/test/test_ParseSnippets.py
@@ -304,3 +304,13 @@ class ParseSnippets_PrintErroneousSnippetPostAction(_VimTest):
     keys = 'test' + EX
     wanted = keys
     expected_error = "Post-expand: asd"
+
+class ParseSnippets_PrintErroneousSnippetLocation(_VimTest):
+    files = { 'us/all.snippets': r"""
+        post_expand "asd()"
+        snippet test
+        endsnippet
+        """}
+    keys = 'test' + EX
+    wanted = keys
+    expected_error = "Defined in: .*/all.snippets"

--- a/test/test_ParseSnippets.py
+++ b/test/test_ParseSnippets.py
@@ -263,3 +263,44 @@ class ParseSnippets_PrintPythonStacktraceMultiline(_VimTest):
     wanted = keys
     expected_error = " > \s+qwe"
 
+
+class ParseSnippets_PrintErroneousSnippet(_VimTest):
+    files = { 'us/all.snippets': r"""
+        snippet test "asd()" e
+        endsnippet
+        """}
+    keys = 'test' + EX
+    wanted = keys
+    expected_error = "Trigger: test"
+
+
+class ParseSnippets_PrintErroneousSnippetContext(_VimTest):
+    files = { 'us/all.snippets': r"""
+        snippet test "asd()" e
+        endsnippet
+        """}
+    keys = 'test' + EX
+    wanted = keys
+    expected_error = "Context: asd"
+
+
+class ParseSnippets_PrintErroneousSnippetPreAction(_VimTest):
+    files = { 'us/all.snippets': r"""
+        pre_expand "asd()"
+        snippet test
+        endsnippet
+        """}
+    keys = 'test' + EX
+    wanted = keys
+    expected_error = "Pre-expand: asd"
+
+
+class ParseSnippets_PrintErroneousSnippetPostAction(_VimTest):
+    files = { 'us/all.snippets': r"""
+        post_expand "asd()"
+        snippet test
+        endsnippet
+        """}
+    keys = 'test' + EX
+    wanted = keys
+    expected_error = "Post-expand: asd"

--- a/test/test_ParseSnippets.py
+++ b/test/test_ParseSnippets.py
@@ -239,3 +239,27 @@ endsnippet
         """}
     keys = 'ab' + EX
     wanted = 'x first a bob b y'
+
+
+class ParseSnippets_PrintPythonStacktrace(_VimTest):
+    files = { 'us/all.snippets': r"""
+        snippet test
+        `!p abc()`
+        endsnippet
+        """}
+    keys = 'test' + EX
+    wanted = keys
+    expected_error = " > abc"
+
+
+class ParseSnippets_PrintPythonStacktraceMultiline(_VimTest):
+    files = { 'us/all.snippets': r"""
+        snippet test
+        `!p if True:
+            qwe()`
+        endsnippet
+        """}
+    keys = 'test' + EX
+    wanted = keys
+    expected_error = " > \s+qwe"
+


### PR DESCRIPTION
When there is an error in executed python code inside snippet, it will print that code in the scratch buffer and mark the line where error has occured

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sirver/ultisnips/592)
<!-- Reviewable:end -->
