### PR TITLE
fix last jump $0 placeholder using post_expand

### DIFF
--- a/pythonx/UltiSnips/buffer_proxy.py
+++ b/pythonx/UltiSnips/buffer_proxy.py
@@ -205,7 +205,7 @@ class VimBufferProxy(_vim.VimBuffer):
         else:
             if line_number > self._snippets_stack[0]._end.line:
                 return
-            if column_number > self._snippets_stack[0]._end.col:
+            if column_number >= self._snippets_stack[0]._end.col:
                 return
             self._snippets_stack[0]._do_edit(change)
 

--- a/test/test_SnippetActions.py
+++ b/test/test_SnippetActions.py
@@ -346,3 +346,25 @@ c2
 c3
 c0
 a0"""
+
+class SnippetActions_PostActionModifiesCharAfterSnippet(_VimTest):
+    files = { 'us/all.snippets': r"""
+        post_expand "snip.buffer[snip.snippet_end[0]] = snip.buffer[snip.snippet_end[0]][:-1]"
+        snippet a "desc" i
+        ($1)
+        endsnippet
+        """}
+    keys = '[]' + ARR_L + 'a' + EX + '1' + JF + '2'
+    wanted = '[(1)2'
+
+
+class SnippetActions_PostActionModifiesLineAfterSnippet(_VimTest):
+    files = { 'us/all.snippets': r"""
+        post_expand "snip.buffer[snip.snippet_end[0]+1:snip.snippet_end[0]+2] = []"
+        snippet a "desc"
+        1: $1
+        $0
+        endsnippet
+        """}
+    keys = '\n3' + ARR_U + 'a' + EX + '1' + JF + '2'
+    wanted = '1: 1\n2'


### PR DESCRIPTION
Last jump didn't work when post_expand action modifies char next to
snippet end.

Test `SnippetActions_PostActionModifiesCharAfterSnippet` will not pass on the current master.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sirver/ultisnips/603)
<!-- Reviewable:end -->
