### PR TITLE
Enhancement: Align snippet names in unite source options

### DIFF
--- a/autoload/unite/sources/ultisnips.vim
+++ b/autoload/unite/sources/ultisnips.vim
@@ -31,7 +31,7 @@ function! s:unite_source.action_table.expand.func(candidate)
   return ''
 endfunction
 
-function! s:unite_source.longest_snippet(snippet_list)
+function! s:unite_source.get_longest_snippet_len(snippet_list)
   let longest = 0
   for snip in items(a:snippet_list)
     if strlen(snip['word']) > longest
@@ -46,7 +46,7 @@ function! s:unite_source.gather_candidates(args, context)
         \  'ultisnips', 'unite__is_marked': 0, 'kind': 'command', 'is_matched': 1,
         \    'is_multiline': 0}
   let snippet_list = UltiSnips#SnippetsInCurrentScope()
-  let max_len = s:unite_source.longest_snippet(snippet_list)
+  let max_len = s:unite_source.get_longest_snippet_len(snippet_list)
   let canditates = []
   for snip in items(snippet_list)
     let curr_val = copy(default_val)

--- a/autoload/unite/sources/ultisnips.vim
+++ b/autoload/unite/sources/ultisnips.vim
@@ -31,15 +31,26 @@ function! s:unite_source.action_table.expand.func(candidate)
   return ''
 endfunction
 
+function! s:unite_source.longest_snippet(snippet_list)
+  let longest = 0
+  for snip in items(a:snippet_list)
+    if strlen(snip['word']) > longest
+      let longest = strlen(snip['word'])
+    endif
+  endfor
+  return longest
+endfunction
+
 function! s:unite_source.gather_candidates(args, context)
   let default_val = {'word': '', 'unite__abbr': '', 'is_dummy': 0, 'source':
         \  'ultisnips', 'unite__is_marked': 0, 'kind': 'command', 'is_matched': 1,
         \    'is_multiline': 0}
   let snippet_list = UltiSnips#SnippetsInCurrentScope()
+  let max_len = s:unite_source.longest_snippet(snippet_list)
   let canditates = []
   for snip in items(snippet_list)
     let curr_val = copy(default_val)
-    let curr_val['word'] = snip[0] . "     " . snip[1]
+    let curr_val['word'] = printf('%-*s', max_len, snip[0]) . "     " . snip[1]
     let curr_val['trigger'] = snip[0]
     call add(canditates, curr_val)
   endfor


### PR DESCRIPTION
This is a cosmetic change. The trigger names are now aligned for the unite source. The screen shots show the before and after better than a description. 

Before:
![screen shot 2015-11-14 at 10 24 47 am](https://cloud.githubusercontent.com/assets/4416952/11164608/04a4ac3c-8abb-11e5-8d33-84dba42835a6.png)

After:
![screen shot 2015-11-14 at 10 23 25 am](https://cloud.githubusercontent.com/assets/4416952/11164607/ffbceb30-8aba-11e5-9491-060733915b70.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sirver/ultisnips/608)
<!-- Reviewable:end -->
