### PR TITLE
syntax highlight for unite ultisnips

### DIFF
--- a/autoload/unite/sources/ultisnips.vim
+++ b/autoload/unite/sources/ultisnips.vim
@@ -5,6 +5,7 @@ let s:unite_source = {
       \ 'name': 'ultisnips',
       \ 'hooks': {},
       \ 'action_table': {},
+      \ 'syntax' : 'uniteSource__Ultisnips',
       \ 'default_action': 'expand',
       \ }
 
@@ -12,6 +13,20 @@ let s:unite_source.action_table.preview = {
       \ 'description' : 'ultisnips snippets',
       \ 'is_quit' : 0,
       \ }
+
+function! s:unite_source.hooks.on_syntax(args, context) abort
+  syntax case ignore
+  syntax match uniteSource__UltisnipsHeader /^.*$/
+        \ containedin=uniteSource__Ultisnips
+  syntax match uniteSource__UltisnipsTrigger /\v^\s.{-}\ze\s/ contained
+        \ containedin=uniteSource__UltisnipsHeader
+        \ nextgroup=uniteSource__UltisnipsDescription
+  syntax match uniteSource__UltisnipsDescription /\v.{3}\s\zs\w.*$/ contained
+        \ containedin=uniteSource__UltisnipsHeader
+
+  highlight default link uniteSource__UltisnipsTrigger Identifier
+  highlight default link uniteSource__UltisnipsDescription Statement
+endfunction
 
 function! s:unite_source.action_table.preview.func(candidate)
   " no nice preview at this point, cannot get snippet text


### PR DESCRIPTION
Looks much better
<img width="688" alt="screen shot 2015-12-21 at 22 07 09" src="https://cloud.githubusercontent.com/assets/251450/11932276/3520d89a-a82f-11e5-8245-5fffc2f2506f.png">

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sirver/ultisnips/624)
<!-- Reviewable:end -->
