### PR TITLE
Fix highlighting for nested visual tabstob

### DIFF
--- a/syntax/snippets.vim
+++ b/syntax/snippets.vim
@@ -112,7 +112,7 @@ syn region snipBalancedBraces start="{" end="}" contained transparent extend
 syn cluster snipTokens add=snipTabStop
 syn cluster snipTabStopTokens add=snipTabStop
 
-syn region snipVisual matchgroup=snipVisual start="\${VISUAL[:}/]\@=" end="}" contained contains=snipVisualDefault,snipTransformationPattern
+syn region snipVisual matchgroup=snipVisual start="\${VISUAL[:}/]\@=" end="}" contained contains=snipVisualDefault,snipTransformationPattern extend
 syn region snipVisualDefault matchgroup=snipVisual start=":" end="\ze[}/]" contained contains=snipTabStopEscape nextgroup=snipTransformationPattern
 syn cluster snipTokens add=snipVisual
 syn cluster snipTabStopTokens add=snipVisual


### PR DESCRIPTION
Consider the snippet

snippet test
${1:${VISUAL}}
endsnippet

A missing 'extend' keyword caused the inner closing bracket to end both
the inner 'snipVisual' and the outer 'snipTabStop' regions. Anything
after the inner bracket was considered 'snipSnippetBody' and thus
highlighted incorrectly.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sirver/ultisnips/628)
<!-- Reviewable:end -->
