### PR TITLE
Add support to do transformation on multiple lines

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -1236,9 +1236,12 @@ The options can be any combination of >
           By default, regular expression matching is case sensitive. With this
           option, matching is done without regard to case.
    m    - multiline
-          By default, if you select multiple lines, transformations are made
-          on them entirely as a whole single line string. With this option you
-          can work with multi line strings.
+          By default, the '^' and '$' special characters only apply to the
+          start and end of the entire string; so if you select multiple lines,
+          transformations are made on them entirely as a whole single line
+          string. With this option, '^' and '$' special characters match the
+          start or end of any line within a string ( separated by newline
+          character - '\n' ).
    a    - ascii conversion
           By default, transformation are made on the raw utf-8 string. With
           this option, matching is done on the corresponding ASCII string

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -1235,6 +1235,10 @@ The options can be any combination of >
    i    - case insensitive
           By default, regular expression matching is case sensitive. With this
           option, matching is done without regard to case.
+   m    - multiline
+          By default, if you select multiple lines, transformations are made
+          on them entirely as a whole single line string. With this option you
+          can work with multi line strings.
    a    - ascii conversion
           By default, transformation are made on the raw utf-8 string. With
           this option, matching is done on the corresponding ASCII string

--- a/pythonx/UltiSnips/text_objects/_transformation.py
+++ b/pythonx/UltiSnips/text_objects/_transformation.py
@@ -124,6 +124,8 @@ class TextObjectTransformation(object):
                 self._match_this_many = 0
             if 'i' in token.options:
                 flags |= re.IGNORECASE
+            if 'm' in token.options:
+                flags |= re.MULTILINE
             if 'a' in token.options:
                 self._convert_to_ascii = True
 

--- a/test/test_Transformation.py
+++ b/test/test_Transformation.py
@@ -179,6 +179,12 @@ class Transformation_OptionIgnoreCase_ECR(_VimTest):
     wanted = 'TEST blah'
 
 
+class Transformation_OptionMultiline_ECR(_VimTest):
+    snippets = ('test', r"${VISUAL/^/* /mg}")
+    keys = 'test\ntest\ntest' + ESC + 'V2k' + EX + 'test' + EX
+    wanted = '* test\n* test\n* test'
+
+
 class Transformation_OptionReplaceGlobal_ECR(_VimTest):
     snippets = ('test', r"$1 ${1/, */-/g}")
     keys = 'test' + EX + 'a, nice, building'


### PR DESCRIPTION
As proposed, add re.MULTILINE flag to `TextObjectTransformation` class, it leads to an `m` option in transformations so also added respective documentation. tested with the following snippet:
```vim
snippet ul "make markdown unordered list from visual selection"
${VISUAL/^/* /mg}
endsnippet
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sirver/ultisnips/643)
<!-- Reviewable:end -->
