### PR TITLE
Allow Deoplete entries to show up with existing matches

### DIFF
--- a/rplugin/python3/deoplete/sources/ultisnips.py
+++ b/rplugin/python3/deoplete/sources/ultisnips.py
@@ -15,6 +15,7 @@ class Source(Base):
         for trigger in snippets:
             suggestions.append({
                 'word': trigger,
-                'menu': self.mark + ' ' + snippets.get(trigger, '')
+                'menu': self.mark + ' ' + snippets.get(trigger, ''),
+                'dup': 1
             })
         return suggestions


### PR DESCRIPTION
I encountered an issue with Deoplete where Ultisnips suggestions wouldn't appear if there was a match in the current buffer with the same name as a Ultisnips snippet.  This change allows the snippet and buffer match to appear side-by-side, which is less confusing.

More information can be found on the issue on the Deoplete repo here:

https://github.com/Shougo/deoplete.nvim/issues/138#issuecomment-174050309