### PR TITLE
Expand environment variables in UltiSnipsSnippetsDir

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -795,8 +795,8 @@ class SnippetManager(object):
             if bang:
                 potentials.update(find_all_snippet_files(ft))
 
-        potentials = set(os.path.realpath(os.path.expanduser(p))
-                         for p in potentials)
+        potentials = set(os.path.realpath(
+            os.path.expanduser(os.path.expandvars(p))) for p in potentials)
 
         if len(potentials) > 1:
             files = sorted(potentials)


### PR DESCRIPTION
I noticed that environment variables don't work in the current version of UltiSnips within the value for `g:UltiSnipsSnippetsDir`.  For example, I tried setting it to

```vim
let g:UltiSnipsSnippetsDir = "$DOTFILES/nvim/UltiSnips"
```

But it would append the directory after the path to the current file or something weird like that.  This change expands the path at the right time so that it can find the snippet directory correctly.