### PR TITLE
Fix escapes in conditional tabstob transformation

### DIFF
--- a/pythonx/UltiSnips/text_objects/_transformation.py
+++ b/pythonx/UltiSnips/text_objects/_transformation.py
@@ -13,15 +13,20 @@ from UltiSnips.text_objects._mirror import Mirror
 def _find_closing_brace(string, start_pos):
     """Finds the corresponding closing brace after start_pos."""
     bracks_open = 1
+    escaped = False
     for idx, char in enumerate(string[start_pos:]):
         if char == '(':
-            if string[idx + start_pos - 1] != '\\':
+            if not escaped:
                 bracks_open += 1
         elif char == ')':
-            if string[idx + start_pos - 1] != '\\':
+            if not escaped:
                 bracks_open -= 1
             if not bracks_open:
                 return start_pos + idx + 1
+        if char == '\\':
+            escaped = not escaped
+        else:
+            escaped = False
 
 
 def _split_conditional(string):
@@ -29,18 +34,24 @@ def _split_conditional(string):
     bracks_open = 0
     args = []
     carg = ''
+    escaped = False
     for idx, char in enumerate(string):
         if char == '(':
-            if string[idx - 1] != '\\':
+            if not escaped:
                 bracks_open += 1
         elif char == ')':
-            if string[idx - 1] != '\\':
+            if not escaped:
                 bracks_open -= 1
-        elif char == ':' and not bracks_open and not string[idx - 1] == '\\':
+        elif char == ':' and not bracks_open and not escaped:
             args.append(carg)
             carg = ''
+            escaped = False
             continue
         carg += char
+        if char == '\\':
+            escaped = not escaped
+        else:
+            escaped = False
     args.append(carg)
     return args
 

--- a/test/test_Transformation.py
+++ b/test/test_Transformation.py
@@ -251,4 +251,19 @@ class Transformation_TestKill_InsertEnd_Kill(_VimTest):
     keys = 'hallo test' + EX + 'AUCH' + ESC + \
         'ehihi' + ESC + 'bb' + 'ino' + JF + 'end'
     wanted = 'hallo noAUCH auchauchih_end'
+
+class Transformation_ConditionalWithEscapedDelimiter(_VimTest):
+    snippets = 'test', r"$1 ${1/(aa)|.*/(?1:yes\:no\))/}"
+    keys = 'test' + EX + 'aa'
+    wanted = 'aa yes:no)'
+
+class Transformation_ConditionalWithBackslashBeforeDelimiter(_VimTest):
+    snippets = 'test', r"$1 ${1/(aa)|.*/(?1:yes\\:no)/}"
+    keys = 'test' + EX + 'aa'
+    wanted = 'aa yes\\'
+
+class Transformation_ConditionalWithBackslashBeforeDelimiter1(_VimTest):
+    snippets = 'test', r"$1 ${1/(aa)|.*/(?1:yes:no\\)/}"
+    keys = 'test' + EX + 'ab'
+    wanted = 'ab no\\'
 # End: Transformations  #}}}


### PR DESCRIPTION
check if the delimiters ```:```, ```(```, and ```)``` are actually escaped, not only if the previous char is a backslash

See https://github.com/SirVer/ultisnips/issues/656