### PR TITLE
Add support for django-plus.vim

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -3,7 +3,7 @@ if exists("b:did_autoload_ultisnips") || !exists("g:_uspy")
     " TODO(sirver): Add a test for that using a bad g:UltiSnipsPythonVersion
     " setting. Without this fix moving the cursor will spam errors, with this
     " it should not.
-    function! UltiSnips#FileTypeChanged()
+    function! UltiSnips#FileTypeChanged(...)
     endfunction
 
     finish
@@ -116,9 +116,9 @@ function! UltiSnips#JumpForwards()
     return ""
 endfunction
 
-function! UltiSnips#FileTypeChanged()
+function! UltiSnips#FileTypeChanged(...)
     exec g:_uspy "UltiSnips_Manager.reset_buffer_filetypes()"
-    exec g:_uspy "UltiSnips_Manager.add_buffer_filetypes('" . &ft . "')"
+    exec g:_uspy "UltiSnips_Manager.add_buffer_filetypes('" . (a:0 ? a:1 : &ft) . "')"
     return ""
 endfunction
 


### PR DESCRIPTION
Hi!  I created a plugin called [django-plus.vim][1] and would like UltiSnips to work with it since Django is an exceptional case in Vim.

The `django` filetype is considered a text template in Vim.  But, for users to easily enable the Django snippets in Python scripts, the `python.django` filetype can be used.  This causes some problems since plugins might not consider the dotted filetype, and filetypes like `markdown.django` or `yaml.django` (or even `python.django`) should actually be including `htmldjango.snippets`.

The other problem is that using `:UltisnipsEdit` without arguments, one would expect `django.snippets` to be loaded, but `python.snippets` is loaded instead.  The filetype would need to be `django.python`, but will break syntax highlighting in Python scripts.

`django-plus.vim` reliably detects files in a Django project and sets `b:is_django` and leaves the filetype alone.  I attempted to manually call `UltiSnips#FileTypeChanged()` and `UltiSnipsAddFiletypes django` in an `after/ftplugin` scripts, but that isn't reliable since other plugins can re-set `filetype`.

This shouldn't affect anyone who doesn't have `django-plus.vim` installed.  If there's a better way to do this, let me know.

[1]: https://github.com/tweekmonster/django-plus.vim