### PR TITLE
fix visual placeholder multi call

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -99,7 +99,7 @@ function! UltiSnips#SnippetsInCurrentScope(...)
     return g:current_ulti_dict
 endfunction
 
-function! UltiSnips#SaveLastVisualSelection()
+function! UltiSnips#SaveLastVisualSelection() range
     exec g:_uspy "UltiSnips_Manager._save_last_visual_selection()"
     return ""
 endfunction


### PR DESCRIPTION
in `exec "xnoremap <silent> " . g:UltiSnipsExpandTrigger. " :call UltiSnips#SaveLastVisualSelection()<cr>gás"`

mapping to `:call` will actually execute `:'<,'>call`, which will call the function multiple times.  This will cause delay when visual contains many lines, and may have other unexpected behavior. so add the range argument