### PR TITLE
syntax fix for subdirs

### DIFF
--- a/syntax/snippets.vim
+++ b/syntax/snippets.vim
@@ -5,7 +5,7 @@ if exists("b:current_syntax")
   finish
 endif
 
-if expand("%:p:h:t") == "snippets" && search("^endsnippet", "nw") == 0
+if expand("%:p:h") =~ "snippets" && search("^endsnippet", "nw") == 0
             \ && !exists("b:ultisnips_override_snipmate")
     " this appears to be a snipmate file
     " It's in a directory called snippets/ and there's no endsnippet keyword


### PR DESCRIPTION
This will allow snippets in subdirectories (e.g. [`snippets/coffee/*`](https://github.com/honza/vim-snippets/tree/master/snippets/coffee)) to have proper syntax highlighting.