### PR TITLE
Fix Vim version checks in tests

### DIFF
--- a/test/test_Autotrigger.py
+++ b/test/test_Autotrigger.py
@@ -4,7 +4,7 @@ from test.constant import *
 def check_required_vim_version(test):
     if test.vim_flavor == 'neovim':
         return None
-    if not test.vim.has_patch(214):
+    if not test.vim.has_version(7, 4, 214):
         return 'Vim newer than 7.4.214 is required'
     else:
         return None
@@ -45,7 +45,7 @@ class Autotrigger_CanExpandOnTriggerWithLengthMoreThanOne(_VimTest):
 
 class Autotrigger_WillProduceNoExceptionWithVimLowerThan214(_VimTest):
     skip_if = lambda self: 'Vim older than 7.4.214 is required' \
-        if self.vim.has_patch(214) else None
+        if self.vim.has_version(7, 4, 214) else None
 
     files = { 'us/all.snippets': r"""
         snippet abc "desc" A

--- a/test/test_Editing.py
+++ b/test/test_Editing.py
@@ -5,7 +5,7 @@ from test.constant import *
 def check_required_vim_version(test):
     if test.vim_flavor == 'neovim':
         return None
-    if not test.vim.has_patch(1):
+    if not test.vim.has_version(7, 4, 1):
         return 'Vim newer than 7.4.1 is required'
     else:
         return None

--- a/test/vim_interface.py
+++ b/test/vim_interface.py
@@ -91,20 +91,25 @@ class VimInterface(TempFileManager):
     def __init__(self, vim_executable, name):
         TempFileManager.__init__(self, name)
         self._vim_executable = vim_executable
-        self._patch_version = None
+        self._version = None
 
-    def has_patch(self, version):
-        if self._patch_version is None:
+    def has_version(self, major, minor, patchlevel):
+        if self._version is None:
             output = subprocess.check_output([
                 self._vim_executable, "--version"
             ])
 
-            self._patch_version = 0
+            _major = 0
+            _minor = 0
+            _patch = 0
             for line in output.decode('utf-8').split("\n"):
+                if line.startswith("VIM - Vi IMproved"):
+                    _major, _minor = map(int, line.split()[4].split('.'))
                 if line.startswith("Included patches:"):
-                    self._patch_version = line.split('-')[1]
+                    _patch = int(line.split('-')[1])
+            self._version = (_major, _minor, _patch)
 
-        return int(self._patch_version) >= version
+        return self._version >= (major, minor, patchlevel)
 
     def get_buffer_data(self):
         buffer_path = self.unique_name_temp(prefix='buffer_')


### PR DESCRIPTION
has_patch(214) is meaningless if you don't pay attention to the
major/minor version: 7.4.214 != 8.0.214.