### PR TITLE
add function isExpandable(): check if expands, but do not expand

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -66,6 +66,11 @@ function! UltiSnips#FileTypeComplete(arglead, cmdline, cursorpos)
     return sort(keys(ret))
 endfunction
 
+function! UltiSnips#isExpandable()
+    exec g:_uspy "UltiSnips_Manager.is_expandable()"
+    return ""
+endfunction
+
 function! UltiSnips#ExpandSnippet()
     exec g:_uspy "UltiSnips_Manager.expand()"
     return ""

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -282,12 +282,13 @@ If you have g:UltiSnipsExpandTrigger and g:UltiSnipsJumpForwardTrigger set
 to the same value then the function you are actually going to use is
 UltiSnips#ExpandSnippetOrJump.
 
-Each time any of the functions UltiSnips#ExpandSnippet,
+Each time any of the functions UltiSnips#isExpandable, UltiSnips#ExpandSnippet,
 UltiSnips#ExpandSnippetOrJump, UltiSnips#JumpForwards or
 UltiSnips#JumpBackwards is called a global variable is set that contains the
 return value of the corresponding function.
 
 The corresponding variables and functions are:
+UltiSnips#isExpandable        --> g:ulti_is_expandable (0: fail, 1: success)
 UltiSnips#ExpandSnippet       --> g:ulti_expand_res (0: fail, 1: success)
 UltiSnips#ExpandSnippetOrJump --> g:ulti_expand_or_jump_res (0: fail,
                                                     1: expand, 2: jump)

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -118,6 +118,13 @@ class SnippetManager(object):
             return self._handle_failure(self.backward_trigger)
 
     @err_to_scratch_buffer.wrap
+    def is_expandable(self):
+        _vim.command('let g:ulti_is_expandable = 1')
+        if not self._is_expandable():
+            _vim.command('let g:ulti_is_expandable = 0')
+            # self._handle_failure(self.expand_trigger)
+
+    @err_to_scratch_buffer.wrap
     def expand(self):
         """Try to expand a snippet at the current position."""
         _vim.command('let g:ulti_expand_res = 1')
@@ -695,6 +702,14 @@ class SnippetManager(object):
             if self._inside_action:
                 self._snip_expanded_in_action = True
 
+
+    def _is_expandable(self):
+        before = _vim.buf.line_till_cursor
+        snippets = self._snips(before, False, False)
+        if snippets:
+            return True
+        else:
+            return False
 
     def _try_expand(self, autotrigger_only=False):
         """Try to expand a snippet in the current place."""

--- a/test/test_isExpandable.py
+++ b/test/test_isExpandable.py
@@ -1,0 +1,16 @@
+from test.vim_test_case import VimTestCase as _VimTest
+from test.constant import *
+
+# Simple isExpandables  {{{#
+
+
+class _SimpleExpands(_VimTest):
+    snippets = ('hallo', 'Hallo Welt!')
+
+
+class SimpleExpand_ExpectCorrectResult(_SimpleExpands):
+    keys = 'hallo' + ':<c-u>:call UltiSnips#isExpandable()<cr>' + ':let @a = g:UltiSnips#isExpandable<cr>' + 'cc' + ':0put a'
+    wanted = '1'
+
+
+# End: Simple Expands  #}}}


### PR DESCRIPTION
A first take at https://github.com/SirVer/ultisnips/issues/786:

Add a function UltiSnips#isExpandable() (as neosnippet offers in guise of neosnippet#expandable()), useful for example for autocompletion plug-ins like delimitmate:
```vim
 nnoremap <expr> <tab> delimitMate#isEmptyPair() && UltiSnips#isExpandable() ? <del>:UltiSnips#Expand() : '<tab>'
```
This way, a snippet with delimiters such as
```vim
  snippet [
	[${1:text}](http://${2:address})
```
in markdown.snippets of vim-snippets, is expanded with no trailing ] (auto-inserted by the autocompletion plugin).

