### PR TITLE
move nvim-completion-manager Ultisnips source into Ultisnips repository.

### DIFF
--- a/autoload/cm/sources/ultisnips.vim
+++ b/autoload/cm/sources/ultisnips.vim
@@ -1,0 +1,55 @@
+
+func! cm#sources#ultisnips#cm_refresh(opt,ctx)
+
+	if get(s:, 'disable', 0)
+		return
+	endif
+
+	" UltiSnips#SnippetsInCurrentScope
+	" {
+	"     "modeline": "Vim modeline",
+	"     "au": "augroup ... autocmd block",
+	"     ......
+	" }
+	let l:snips = UltiSnips#SnippetsInCurrentScope()
+
+	let l:matches = []
+
+	" The available snippet list is fairly small, simply dump the whole list
+	" here, leave the filtering work to NCM's standard filter.  This would
+	" reduce the work done by vimscript.
+	let l:matches = map(keys(l:snips),'{"word":v:val,"dup":1,"icase":1,"info": l:snips[v:val]}')
+
+	call cm#complete(a:opt, a:ctx, a:ctx['startcol'], l:matches)
+
+endfunc
+
+
+"
+" Tips: Add this to your vimrc for triggering snips popup with <c-u>
+"
+" let g:UltiSnipsExpandTrigger = "<Plug>(ultisnips_expand)"
+" inoremap <silent> <c-u> <c-r>=cm#sources#ultisnips#trigger_or_popup("\<Plug>(ultisnips_expand)")<cr>
+"
+func! cm#sources#ultisnips#trigger_or_popup(trigger_key)
+
+	let l:ctx = cm#context()
+
+	let l:typed = l:ctx['typed']
+	let l:kw = matchstr(l:typed,'\v\S+$')
+	if len(l:kw)
+		call feedkeys(a:trigger_key)
+		return ''
+	endif
+
+	let l:snips = UltiSnips#SnippetsInCurrentScope()
+	let l:matches = map(keys(l:snips),'{"word":v:val,"dup":1,"icase":1,"info": l:snips[v:val]}')
+	let l:startcol = l:ctx['col']
+
+	" notify the completion framework
+	call cm#complete('cm-ultisnips', l:ctx, l:startcol, l:matches)
+
+	return ''
+
+endfunc
+

--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -54,4 +54,18 @@ augroup END
 
 call UltiSnips#map_keys#MapKeys()
 
+" Register ultisnips source for nvim-completion-manager
+" https://github.com/roxma/nvim-completion-manager
+"
+" Registering a source via this autocmd will avoid error when NCM has not been
+" installed yet. And it also avoid the loading of autoload/cm.vim on neovim
+" startup, so that NCM won't affect neovim's startup time
+au User CmSetup call cm#register_source({'name' : 'cm-ultisnips',
+		\ 'priority': 7, 
+		\ 'abbreviation': 'Snip',
+		\ 'default_word_pattern': '\S+',
+		\ 'cm_refresh_patterns':['(\S{3,})$'],
+		\ 'cm_refresh': 'cm#sources#ultisnips#cm_refresh',
+		\ })
+
 " vim: ts=8 sts=4 sw=4


### PR DESCRIPTION
Hi, I've been working on an async completion framework for neovim, and it also woks on vim8.
https://github.com/roxma/nvim-completion-manager

As the framework API has been stable, I think it would be nice to move UltiSnips completion source into ultisnips git repository.

This  PR adds minimized overhead to ultisnips, it only register [a single autocmd](https://github.com/roxma/ultisnips/commit/5658e6d811fc8279218a324b69a2b31e47df450c#diff-f90d96d50e75aa6a0b85b791a4b71bd9R63) at startup. 

It also simplifies the code so that it doesn't need to [check the installation of ultisnips](https://github.com/roxma/nvim-completion-manager/blob/8476d42cf191503f3c52cf9dd064dd9b06b492bb/autoload/cm/sources/ultisnips.vim#L31) any more.

I'll handle further issue on this source, and send PR if necessary.