### PR TITLE
Mark Deoplete source as volatile

### DIFF
--- a/rplugin/python3/deoplete/sources/ultisnips.py
+++ b/rplugin/python3/deoplete/sources/ultisnips.py
@@ -7,6 +7,7 @@ class Source(Base):
         self.name = 'ultisnips'
         self.mark = '[US]'
         self.rank = 8
+        self.is_volatile = True
 
     def gather_candidates(self, context):
         suggestions = []


### PR DESCRIPTION
As per https://github.com/Shougo/deoplete.nvim/pull/468#issuecomment-295168539 - UltiSnips suggestions depend on user input so the Deoplete source should be marked as `is_volatile`. Without this option Deoplete can cache an empty result from UltiSnips, causing no further snippets to be shown when the user input changes.