### PR TITLE
Fix emphasis in doc file that created a tag

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -316,7 +316,7 @@ alternative function IMAP_Jumpfunc('', 0) is called.
 3.2.2 Custom autocommands                       *UltiSnips-custom-autocommands*
 -------------------------
 
-Note Autocommands must *not* change the buffer in any way. If lines are added,
+Note Autocommands must not change the buffer in any way. If lines are added,
 deleted, or modified it will confuse UltiSnips which might scramble your
 snippets contents.
 


### PR DESCRIPTION
Emphasizing 'not' as `*not*` causes `:helptags` to generate a tag called
'not'. Because people like writing `*not*` in their documentations, this
can cause duplicate tag conflicts with other plugins (e.g. Command-T's
doc also generates a 'not' tag).