### PR TITLE
Fix selecting one more character when using ${VISUAL}.

### DIFF
--- a/pythonx/UltiSnips/vim_state.py
+++ b/pythonx/UltiSnips/vim_state.py
@@ -8,6 +8,7 @@ from collections import deque, namedtuple
 from UltiSnips import _vim
 from UltiSnips.compatibility import as_unicode, byte2col
 from UltiSnips.position import Position
+import platform
 
 _Placeholder = namedtuple('_FrozenPlaceholder', ['current_text', 'start', 'end'])
 
@@ -117,7 +118,7 @@ class VisualContentPreserver(object):
         self._placeholder = None
 
     def conserve(self):
-        """Save the last visual selection ond the mode it was made in."""
+        """Save the last visual selection and the mode it was made in."""
         sl, sbyte = map(int,
                         (_vim.eval("""line("'<")"""), _vim.eval("""col("'<")""")))
         el, ebyte = map(int,
@@ -128,13 +129,19 @@ class VisualContentPreserver(object):
 
         _vim_line_with_eol = lambda ln: _vim.buf[ln] + '\n'
 
+        # Remove last character for windows
+        if platform.system() == 'Windows':
+            add = 0
+        else:
+            add = 1
+
         if sl == el:
-            text = _vim_line_with_eol(sl - 1)[sc:ec + 1]
+            text = _vim_line_with_eol(sl - 1)[sc:ec + add]
         else:
             text = _vim_line_with_eol(sl - 1)[sc:]
             for cl in range(sl, el - 1):
                 text += _vim_line_with_eol(cl)
-            text += _vim_line_with_eol(el - 1)[:ec + 1]
+            text += _vim_line_with_eol(el - 1)[:ec + add]
         self._text = text
 
     def conserve_placeholder(self, placeholder):


### PR DESCRIPTION
**This fix is for Windows only**
- Remove the last character in visual selection to fix the #863 issue.
- Fix typo in comment.