### PR TITLE
Fix selection when using ${VISUAL} in line selection mode on Windows.

### DIFF
--- a/pythonx/UltiSnips/text_objects/_visual.py
+++ b/pythonx/UltiSnips/text_objects/_visual.py
@@ -15,6 +15,7 @@ from UltiSnips import _vim
 from UltiSnips.indent_util import IndentUtil
 from UltiSnips.text_objects._transformation import TextObjectTransformation
 from UltiSnips.text_objects._base import NoneditableTextObject
+import platform
 
 _REPLACE_NON_WS = re.compile(r"[^ \t]")
 
@@ -42,7 +43,11 @@ class Visual(NoneditableTextObject, TextObjectTransformation):
 
     def _update(self, done):
         if self._mode == 'v':  # Normal selection.
-            text = self._text
+            if platform.system() == 'Windows':
+                # Remove last character for windows in normal selection.
+                text = self._text[:-1]
+            else:
+                text = self._text
         else:  # Block selection or line selection.
             text_before = _vim.buf[self.start.line][:self.start.col]
             indent = _REPLACE_NON_WS.sub(' ', text_before)

--- a/pythonx/UltiSnips/vim_state.py
+++ b/pythonx/UltiSnips/vim_state.py
@@ -8,7 +8,6 @@ from collections import deque, namedtuple
 from UltiSnips import _vim
 from UltiSnips.compatibility import as_unicode, byte2col
 from UltiSnips.position import Position
-import platform
 
 _Placeholder = namedtuple('_FrozenPlaceholder', ['current_text', 'start', 'end'])
 
@@ -129,19 +128,13 @@ class VisualContentPreserver(object):
 
         _vim_line_with_eol = lambda ln: _vim.buf[ln] + '\n'
 
-        # Remove last character for windows
-        if platform.system() == 'Windows':
-            add = 0
-        else:
-            add = 1
-
         if sl == el:
-            text = _vim_line_with_eol(sl - 1)[sc:ec + add]
+            text = _vim_line_with_eol(sl - 1)[sc:ec + 1]
         else:
             text = _vim_line_with_eol(sl - 1)[sc:]
             for cl in range(sl, el - 1):
                 text += _vim_line_with_eol(cl)
-            text += _vim_line_with_eol(el - 1)[:ec + add]
+            text += _vim_line_with_eol(el - 1)[:ec + 1]
         self._text = text
 
     def conserve_placeholder(self, placeholder):


### PR DESCRIPTION
The #864 fix (issue #863 ) causes selection problem when using multi-line selection.
- Fix the last character issue when using line selection mode (`V`) on Windows.