### PR TITLE
Avoid mapping Visual-Line Selection mode

### DIFF
--- a/autoload/UltiSnips/map_keys.vim
+++ b/autoload/UltiSnips/map_keys.vim
@@ -61,7 +61,6 @@ function! UltiSnips#map_keys#MapKeys()
         exec "inoremap <silent> " . g:UltiSnipsExpandTrigger . " <C-R>=UltiSnips#ExpandSnippet()<cr>"
         exec "snoremap <silent> " . g:UltiSnipsExpandTrigger . " <Esc>:call UltiSnips#ExpandSnippet()<cr>"
     endif
-    exec "xnoremap <silent> " . g:UltiSnipsExpandTrigger. " :call UltiSnips#SaveLastVisualSelection()<cr>gvs"
     exec "inoremap <silent> " . g:UltiSnipsListSnippets . " <C-R>=UltiSnips#ListSnippets()<cr>"
     exec "snoremap <silent> " . g:UltiSnipsListSnippets . " <Esc>:call UltiSnips#ListSnippets()<cr>"
 


### PR DESCRIPTION
I think it more or less fix #838, I don't think Visual-Line Selection mode isn't useful and it's the mode that I'm unable to map.