### PR TITLE
fix bug when vim option 'selection' is 'exclusive'

### DIFF
--- a/pythonx/UltiSnips/text_objects/_visual.py
+++ b/pythonx/UltiSnips/text_objects/_visual.py
@@ -15,7 +15,6 @@ from UltiSnips import _vim
 from UltiSnips.indent_util import IndentUtil
 from UltiSnips.text_objects._transformation import TextObjectTransformation
 from UltiSnips.text_objects._base import NoneditableTextObject
-import platform
 
 _REPLACE_NON_WS = re.compile(r"[^ \t]")
 
@@ -43,11 +42,7 @@ class Visual(NoneditableTextObject, TextObjectTransformation):
 
     def _update(self, done):
         if self._mode == 'v':  # Normal selection.
-            if platform.system() == 'Windows':
-                # Remove last character for windows in normal selection.
-                text = self._text[:-1]
-            else:
-                text = self._text
+            text = self._text
         else:  # Block selection or line selection.
             text_before = _vim.buf[self.start.line][:self.start.col]
             indent = _REPLACE_NON_WS.sub(' ', text_before)

--- a/pythonx/UltiSnips/vim_state.py
+++ b/pythonx/UltiSnips/vim_state.py
@@ -126,6 +126,11 @@ class VisualContentPreserver(object):
         ec = byte2col(el, ebyte - 1)
         self._mode = _vim.eval('visualmode()')
 
+        # fix bug when vim option 'selection' is 'exclusive'.
+        if _vim.eval('&selection') == 'exclusive':
+            if sl != el and sbyte != ebyte:
+                ec -= 1
+
         _vim_line_with_eol = lambda ln: _vim.buf[ln] + '\n'
 
         if sl == el:


### PR DESCRIPTION
here is a vim option ``selection``.
if the value is `exclusive`, the mark `'>` is one more then real visual selection.
so var `ebyte` or `ec` must subtract 1.

and that is not a windows bug.
because gvim on windows sourced `$VIMRUNTIME\mswin.vim` by default.
the line 17 of `mswin.vim` execute `:behave mswin` will change option `selection` to `exclusive`.

more deailt in issue #863 