### PR TITLE
Allow snippet files for multiple dotted filetypes

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -597,7 +597,8 @@ example, would fit well in the all.snippets file.
 UltiSnips understands Vim's dotted filetype syntax. For example, if you define
 a dotted filetype for the CUDA C++ framework, e.g. ":set ft=cuda.cpp", then
 UltiSnips will search for and activate snippets for both the cuda and cpp
-filetypes.
+filetypes. You can also create a "cuda.cpp.snippets" file that would only
+activate for that combination of two filetypes.
 
 The snippets file syntax is simple. All lines starting with a # character are
 considered comments. Comments are ignored by UltiSnips. Use them to document

--- a/pythonx/UltiSnips/_vim.py
+++ b/pythonx/UltiSnips/_vim.py
@@ -53,7 +53,11 @@ class VimBuffer(object):
 
     @property
     def filetypes(self):
-        return [ft for ft in vim.eval('&filetype').split('.') if ft]
+        full_filetype = vim.eval('&filetype')
+        if full_filetype:
+            return [ft for ft in full_filetype.split('.') if ft] + [full_filetype]
+        else:
+            return []
 
     @property
     def cursor(self):  # pylint:disable=no-self-use


### PR DESCRIPTION
This PR allows the creation of a `foo.bar.snippets` file that will get loaded for the combination filetype "foo.bar".

As an example, I have "ruby" and "erb" snippet files that are general-purpose, for any ruby or erb file. For rails projects, I'd like to add a few more snippets to both of these filetypes, but the snippets are different in both. I could create a `rails.snippets` file that combines the two snippet sets, but it would be impossible to use the same trigger for different snippets.

With this PR, I can create the files `rails.ruby.snippets` and `rails.erb.snippets` and organize them properly. I have the same setup for javascript and coffeescript -- similar triggers generate different code, and different ember.js snippets need to be loaded depending on the language used.

If there's an existing way of getting the same results, I don't mind using it and closing the PR. Also, I'm not an experienced python developer, so there may be a more sensible way of implementing that particular function. I'm open to any suggestions to change the code to fit the codebase better.