### PR TITLE
Fix character selection when using VISUAL on all platforms

### DIFF
--- a/pythonx/UltiSnips/text_objects/_visual.py
+++ b/pythonx/UltiSnips/text_objects/_visual.py
@@ -15,7 +15,6 @@ from UltiSnips import _vim
 from UltiSnips.indent_util import IndentUtil
 from UltiSnips.text_objects._transformation import TextObjectTransformation
 from UltiSnips.text_objects._base import NoneditableTextObject
-import platform
 
 _REPLACE_NON_WS = re.compile(r"[^ \t]")
 
@@ -43,8 +42,8 @@ class Visual(NoneditableTextObject, TextObjectTransformation):
 
     def _update(self, done):
         if self._mode == 'v':  # Normal selection.
-            if platform.system() == 'Windows':
-                # Remove last character for windows in normal selection.
+            # Remove last character when selection mode is 'exclusive'
+            if _vim.eval('&selection') == 'exclusive':
                 text = self._text[:-1]
             else:
                 text = self._text


### PR DESCRIPTION
This fix is for windows users using selection `inclusive`. (Problem occurred since #868 )
> The pull request #883 is fine but missed the case when using `V` in `exclusive` mode.
> I planned to fix it after it being merged. But no one merged it because of the failing tests.

Issue #897 #921 and maybe #908 all refer to this problem, so I think it should be fixed as soon as possible.

However, `.travis.yml` seems to have some problem that make all tests fail.

The error message produced when testing using Travis CI:
It'll keep trying until the time is out.

    W: The repository 'http://ppa.launchpad.net/kalakris/tmux/ubuntu trusty Release' does not have a Release file.
    W: http://ppa.launchpad.net/couchdb/stable/ubuntu/dists/trusty/Release.gpg: Signature by key 15866BAFD9BCC4F3C1E0DFC7D69548E1C17EAB57 uses weak digest algorithm (SHA1)
    E: Failed to fetch http://ppa.launchpad.net/kalakris/tmux/ubuntu/dists/trusty/main/binary-amd64/Packages  404  Not Found
    E: Failed to fetch http://ppa.launchpad.net/kalakris/tmux/ubuntu/dists/trusty/main/binary-i386/Packages  404  Not Found
    E: Some index files failed to download. They have been ignored, or old ones used instead.

@seletskiy I had tried to fix the problem occurred in Travis CI, but I didn't find any solution. I think the problem is in `.travis.yml` line 14:

    until sudo add-apt-repository ppa:kalakris/tmux -y; do sleep 10; done