### PR TITLE
don't clean 1st tabstop if it's not empty

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -1582,7 +1582,7 @@ Following snippet will be expanded at 4 spaces indentation level no matter
 where it was triggered.
 
 ------------------- SNIP -------------------
-pre_expand "snip.buffer[snip.line] = ' '*4; snip.cursor.set(line, 4)"
+pre_expand "snip.buffer[snip.line] = ' '*4; snip.cursor.set(snip.line, 4)"
 snippet d
 def $1():
     $0

--- a/doc/examples/autojump-if-empty/README.md
+++ b/doc/examples/autojump-if-empty/README.md
@@ -46,7 +46,7 @@ def clean_first_placeholder(snip):
     # Jumper is a helper for performing jumps in UltiSnips.
     px.snippets.make_jumper(snip)
 
-    if snip.tabstop == 2:
+    if snip.tabstop == 2 and not get_jumper_text(snip):
         line = snip.buffer[snip.cursor[0]]
         snip.buffer[snip.cursor[0]] = \
             line[:snip.tabstops[1].start[1]-2] + \


### PR DESCRIPTION
Currently, in the example [Autojump from tabstop when it's empty](https://github.com/SirVer/ultisnips/tree/master/doc/examples/autojump-if-empty), the text in the 1st tabstop and the 2 parentheses around it are removed unconditionally. I think they should only be removed if the user didn't insert anything.