### PR TITLE
removed default folding

### DIFF
--- a/ftplugin/snippets.vim
+++ b/ftplugin/snippets.vim
@@ -8,10 +8,6 @@ let b:did_ftplugin = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
-" Fold by syntax, but open all folds by default
-setlocal foldmethod=syntax
-setlocal foldlevel=99
-
 setlocal commentstring=#%s
 
 setlocal noexpandtab


### PR DESCRIPTION
Hi there!

Would it be possible to remove the default folding method as this is making it more difficult to use my own folding method?

I was thinking either remove it or make the default a variable that is set here.

What do you think?