### PR TITLE
Do not expand brA snippets if there is already a character in the line

### DIFF
--- a/pythonx/UltiSnips/snippet/definition/_base.py
+++ b/pythonx/UltiSnips/snippet/definition/_base.py
@@ -281,7 +281,7 @@ class SnippetDefinition(object):
 
         # Ensure the match was on a word boundry if needed
         if 'b' in self._opts and match:
-            text_before = before.rstrip()[:-len(self._matched)]
+            text_before = before.rstrip()[:-len(self._matched) + 1]
             if text_before.strip(' \t') != '':
                 self._matched = ''
                 return False


### PR DESCRIPTION
```
snippet /f / "foo" brA
foo
endsnippet
```

Current behaviour:
Typing: `af<Space>`
Becomes: `afoo`
Expected: `af<Space>`

The b option should cause the snippet to only expand if the match starts at the beginning of the line. Together with the 'r' and 'A' options the snippet also expands if there is already one alphanumerical character typed (but not more).