### PR TITLE
Use a GitHub access token to avoid rate limiting of API.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,18 @@ cache:
     - /home/travis/docker/
 
 env:
+  matrix:
   - VIM_VERSION="7.4" PYTHON_IMAGE=2.7-stretch TAG=vim_74_py2 DOCKER_CACHE_FILE=/home/travis/docker/vim_74_py2.tar.gz
   - VIM_VERSION="8.0" PYTHON_IMAGE=2.7-stretch TAG=vim_80_py2 DOCKER_CACHE_FILE=/home/travis/docker/vim_80_py2.tar.gz
   - VIM_VERSION="git" PYTHON_IMAGE=2.7-stretch TAG=vim_git_py2 DOCKER_CACHE_FILE=/home/travis/docker/vim_git_py2.tar.gz
   - VIM_VERSION="7.4" PYTHON_IMAGE=3.6-stretch TAG=vim_74_py3 DOCKER_CACHE_FILE=/home/travis/docker/vim_74_py3.tar.gz
   - VIM_VERSION="8.0" PYTHON_IMAGE=3.6-stretch TAG=vim_80_py3 DOCKER_CACHE_FILE=/home/travis/docker/vim_80_py3.tar.gz
   - VIM_VERSION="git" PYTHON_IMAGE=3.6-stretch TAG=vim_git_py3 DOCKER_CACHE_FILE=/home/travis/docker/vim_git_py3.tar.gz
-
+  global:
+    secure: PFU1Md8NuN6SQNjx6SsHX7icS9Tacb0xS0Ue9SHll1U7FNdI90F/gnokR6v+j7sdvoiLkwRSwUXeYUmrZS/d9qq8yiRxuqcj/Y0TfHVKqcLXXV/m9xWAN2UKRVF7Z1neerznk52Roo3IRqwgd9U+6d3bTthHKKYg4azBqTM7AFE=
 before_install: docker/load_docker_cache.sh
 install:
-   - docker build -t ultisnips:${TAG} --build-arg PYTHON_IMAGE=${PYTHON_IMAGE} --build-arg VIM_VERSION=${VIM_VERSION} .
+   - docker build -t ultisnips:${TAG} --build-arg PYTHON_IMAGE=${PYTHON_IMAGE} --build-arg VIM_VERSION=${VIM_VERSION} --build-arg GITHUB_ACCESS_TOKEN=${GITHUB_ACCESS_TOKEN} .
 
 script:
    - docker run -it ultisnips:${TAG} docker/run_tests.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ARG PYTHON_IMAGE
 FROM python:${PYTHON_IMAGE}
 
 ARG VIM_VERSION
+ARG GITHUB_ACCESS_TOKEN
 
 COPY docker/install_packages.sh src/scripts/
 RUN src/scripts/install_packages.sh
@@ -16,11 +17,11 @@ RUN src/scripts/build_vim.sh
 # the cache.
 RUN mkdir -p /tmp/UltiSnips_test_vim_plugins
 
-ADD https://api.github.com/repos/tpope/vim-pathogen/git/refs/heads/master \
+ADD https://api.github.com/repos/tpope/vim-pathogen/git/refs/heads/master?access_token=$GITHUB_ACCESS_TOKEN \
     /src/scripts/vim-pathogen_version.json
 RUN git clone --recursive --depth 1 https://github.com/tpope/vim-pathogen /tmp/UltiSnips_test_vim_plugins/vim-pathogen
 
-ADD https://api.github.com/repos/ervandew/supertab/git/refs/heads/master \
+ADD https://api.github.com/repos/ervandew/supertab/git/refs/heads/master?access_token=$GITHUB_ACCESS_TOKEN \
     /src/scripts/supertab_version.json
 RUN git clone --recursive --depth 1 https://github.com/ervandew/supertab /tmp/UltiSnips_test_vim_plugins/supertab
 
@@ -28,7 +29,7 @@ RUN git clone --recursive --depth 1 https://github.com/ervandew/supertab /tmp/Ul
 # install the latest version through pip. But we still use GitHub activity as a
 # marker to invalidate the installation step, just to make sure we occasionally
 # reinstall a new version.
-ADD https://api.github.com/repos/avian2/unidecode/git/refs/heads/master \
+ADD https://api.github.com/repos/avian2/unidecode/git/refs/heads/master?access_token=$GITHUB_ACCESS_TOKEN \
     /src/scripts/unidecode_version.json
 RUN pip install unidecode
 


### PR DESCRIPTION
This will not help pull requests, as they are considered untrusted by Travis. But at least master builds and pull requests from branches in this repo should not hit rate limiting now.