### PR TITLE
Add note about contributing to traceback

### DIFF
--- a/pythonx/UltiSnips/err_to_scratch_buffer.py
+++ b/pythonx/UltiSnips/err_to_scratch_buffer.py
@@ -18,7 +18,9 @@ def wrap(func):
             msg = \
                 """An error occured. This is either a bug in UltiSnips or a bug in a
 snippet definition. If you think this is a bug, please report it to
-https://github.com/SirVer/ultisnips/issues/new.
+https://github.com/SirVer/ultisnips/issues/new. 
+Please read and follow:
+https://github.com/SirVer/ultisnips/blob/master/CONTRIBUTING.md#reproducing-bugs
 
 Following is the full stack trace:
 """

--- a/pythonx/UltiSnips/err_to_scratch_buffer.py
+++ b/pythonx/UltiSnips/err_to_scratch_buffer.py
@@ -18,7 +18,7 @@ def wrap(func):
             msg = \
                 """An error occured. This is either a bug in UltiSnips or a bug in a
 snippet definition. If you think this is a bug, please report it to
-https://github.com/SirVer/ultisnips/issues/new. 
+https://github.com/SirVer/ultisnips/issues/new
 Please read and follow:
 https://github.com/SirVer/ultisnips/blob/master/CONTRIBUTING.md#reproducing-bugs
 


### PR DESCRIPTION
There too many issues with traceback only. While it is good to have traceback, it is sell useful when it is the only info in the issue description. I think that contributing manual should be mentioned here even if we have issue template now. At least further new issues with traceback may follow contributing guide.