### PR TITLE
Unite doesn't work as replacement for UltiSnipsListSnippets (mapping is clobbered)

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -1773,6 +1773,11 @@ interface with matching snippets. Pressing enter will expand the corresponding
 snippet. If only one snippet matches the text in front of the cursor will be
 expanded when you press the <F12> key.
 
+To use the same mapping as |g:UltiSnipsListSnippets|, you need to disable after
+cleanup: >
+  let b:did_after_plugin_ultisnips_after = 0
+<
+
 Supertab - UltiSnips has built-in support for Supertab. Just use a recent
 enough version of both plugins and <tab> will either expand a snippet or defer
 to Supertab for expansion.


### PR DESCRIPTION
If you follow the help setup for Unite, and the binding key (F12) is the
same as UltiSnipsListSnippets, then it doesn't work because we clobber
whatever is bound to UltiSnipsListSnippets in
after/plugin/UltiSnips_after.vim. We can skip this clobbering by
defining the b:did_after_plugin_ultisnips_after flag.

I don't understand why UltiSnips_after is required to make supertab
work, but it was introduced to fix #212. As a better fix to #212, I'd
suggest checking for supertab or if supertab is bound to the expected
key sequence instead of always stomping the bindings.