### PR TITLE
Give the `abort` argument to all Vim functions

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -7,7 +7,7 @@ let b:did_autoload_ultisnips = 1
 exec g:_uspy "import vim"
 exec g:_uspy "from UltiSnips import UltiSnips_Manager"
 
-function! s:compensate_for_pum()
+function! s:compensate_for_pum() abort
     """ The CursorMovedI event is not triggered while the popup-menu is visible,
     """ and it's by this event that UltiSnips updates its vim-state. The fix is
     """ to explicitly check for the presence of the popup menu, and update
@@ -17,7 +17,7 @@ function! s:compensate_for_pum()
     endif
 endfunction
 
-function! UltiSnips#Edit(bang, ...)
+function! UltiSnips#Edit(bang, ...) abort
     if a:0 == 1 && a:1 != ''
         let type = a:1
     else
@@ -47,12 +47,12 @@ function! UltiSnips#Edit(bang, ...)
     exe ':'.mode.' '.escape(file, ' ')
 endfunction
 
-function! UltiSnips#AddFiletypes(filetypes)
+function! UltiSnips#AddFiletypes(filetypes) abort
     exec g:_uspy "UltiSnips_Manager.add_buffer_filetypes('" . a:filetypes . "')"
     return ""
 endfunction
 
-function! UltiSnips#FileTypeComplete(arglead, cmdline, cursorpos)
+function! UltiSnips#FileTypeComplete(arglead, cmdline, cursorpos) abort
     let ret = {}
     let items = map(
     \   split(globpath(&runtimepath, 'syntax/*.vim'), '\n'),
@@ -68,23 +68,23 @@ function! UltiSnips#FileTypeComplete(arglead, cmdline, cursorpos)
     return sort(keys(ret))
 endfunction
 
-function! UltiSnips#ExpandSnippet()
+function! UltiSnips#ExpandSnippet() abort
     exec g:_uspy "UltiSnips_Manager.expand()"
     return ""
 endfunction
 
-function! UltiSnips#ExpandSnippetOrJump()
+function! UltiSnips#ExpandSnippetOrJump() abort
     call s:compensate_for_pum()
     exec g:_uspy "UltiSnips_Manager.expand_or_jump()"
     return ""
 endfunction
 
-function! UltiSnips#ListSnippets()
+function! UltiSnips#ListSnippets() abort
     exec g:_uspy "UltiSnips_Manager.list_snippets()"
     return ""
 endfunction
 
-function! UltiSnips#SnippetsInCurrentScope(...)
+function! UltiSnips#SnippetsInCurrentScope(...) abort
     let g:current_ulti_dict = {}
     let all = get(a:, 1, 0)
     if all
@@ -94,24 +94,24 @@ function! UltiSnips#SnippetsInCurrentScope(...)
     return g:current_ulti_dict
 endfunction
 
-function! UltiSnips#SaveLastVisualSelection() range
+function! UltiSnips#SaveLastVisualSelection() range abort
     exec g:_uspy "UltiSnips_Manager._save_last_visual_selection()"
     return ""
 endfunction
 
-function! UltiSnips#JumpBackwards()
+function! UltiSnips#JumpBackwards() abort
     call s:compensate_for_pum()
     exec g:_uspy "UltiSnips_Manager.jump_backwards()"
     return ""
 endfunction
 
-function! UltiSnips#JumpForwards()
+function! UltiSnips#JumpForwards() abort
     call s:compensate_for_pum()
     exec g:_uspy "UltiSnips_Manager.jump_forwards()"
     return ""
 endfunction
 
-function! UltiSnips#AddSnippetWithPriority(trigger, value, description, options, filetype, priority)
+function! UltiSnips#AddSnippetWithPriority(trigger, value, description, options, filetype, priority) abort
     exec g:_uspy "trigger = vim.eval(\"a:trigger\")"
     exec g:_uspy "value = vim.eval(\"a:value\")"
     exec g:_uspy "description = vim.eval(\"a:description\")"
@@ -122,7 +122,7 @@ function! UltiSnips#AddSnippetWithPriority(trigger, value, description, options,
     return ""
 endfunction
 
-function! UltiSnips#Anon(value, ...)
+function! UltiSnips#Anon(value, ...) abort
     " Takes the same arguments as SnippetManager.expand_anon:
     " (value, trigger="", description="", options="")
     exec g:_uspy "args = vim.eval(\"a:000\")"
@@ -131,23 +131,23 @@ function! UltiSnips#Anon(value, ...)
     return ""
 endfunction
 
-function! UltiSnips#CursorMoved()
+function! UltiSnips#CursorMoved() abort
     exec g:_uspy "UltiSnips_Manager._cursor_moved()"
 endf
 
-function! UltiSnips#LeavingBuffer()
+function! UltiSnips#LeavingBuffer() abort
     exec g:_uspy "UltiSnips_Manager._leaving_buffer()"
 endf
 
-function! UltiSnips#LeavingInsertMode()
+function! UltiSnips#LeavingInsertMode() abort
     exec g:_uspy "UltiSnips_Manager._leaving_insert_mode()"
 endfunction
 
-function! UltiSnips#TrackChange()
+function! UltiSnips#TrackChange() abort
     exec g:_uspy "UltiSnips_Manager._track_change()"
 endfunction
 
-function! UltiSnips#RefreshSnippets()
+function! UltiSnips#RefreshSnippets() abort
     exec g:_uspy "UltiSnips_Manager._refresh_snippets()"
 endfunction
 " }}}

--- a/autoload/UltiSnips/map_keys.vim
+++ b/autoload/UltiSnips/map_keys.vim
@@ -53,7 +53,7 @@ if !exists("g:UltiSnipsEnableSnipMate")
     let g:UltiSnipsEnableSnipMate = 1
 endif
 
-function! UltiSnips#map_keys#MapKeys()
+function! UltiSnips#map_keys#MapKeys() abort
     if g:UltiSnipsExpandTrigger == g:UltiSnipsJumpForwardTrigger
         exec "inoremap <silent> " . g:UltiSnipsExpandTrigger . " <C-R>=UltiSnips#ExpandSnippetOrJump()<cr>"
         exec "snoremap <silent> " . g:UltiSnipsExpandTrigger . " <Esc>:call UltiSnips#ExpandSnippetOrJump()<cr>"

--- a/autoload/neocomplete/sources/ultisnips.vim
+++ b/autoload/neocomplete/sources/ultisnips.vim
@@ -11,7 +11,7 @@ let s:source = {
       \ ['matcher_fuzzy'] : ['matcher_head']),
    \ }
 
-function! s:source.gather_candidates(context)
+function! s:source.gather_candidates(context) abort
    let suggestions = []
    let snippets = UltiSnips#SnippetsInCurrentScope()
    for trigger in keys(snippets)
@@ -24,7 +24,7 @@ function! s:source.gather_candidates(context)
    return suggestions
 endfunction
 
-function! neocomplete#sources#ultisnips#define()
+function! neocomplete#sources#ultisnips#define() abort
    return s:source
 endfunction
 

--- a/autoload/unite/sources/ultisnips.vim
+++ b/autoload/unite/sources/ultisnips.vim
@@ -28,7 +28,7 @@ function! s:unite_source.hooks.on_syntax(args, context) abort
   highlight default link uniteSource__UltisnipsDescription Statement
 endfunction
 
-function! s:unite_source.action_table.preview.func(candidate)
+function! s:unite_source.action_table.preview.func(candidate) abort
   " no nice preview at this point, cannot get snippet text
   let snippet_preview = a:candidate['word']
   echo snippet_preview
@@ -39,14 +39,14 @@ let s:unite_source.action_table.expand = {
       \ 'is_quit': 1
       \}
 
-function! s:unite_source.action_table.expand.func(candidate)
+function! s:unite_source.action_table.expand.func(candidate) abort
   let delCurrWord = (getline(".")[col(".")-1] == " ") ? "" : "diw"
   exe "normal " . delCurrWord . "a" . a:candidate['trigger'] . " "
   call UltiSnips#ExpandSnippet()
   return ''
 endfunction
 
-function! s:unite_source.get_longest_snippet_len(snippet_list)
+function! s:unite_source.get_longest_snippet_len(snippet_list) abort
   let longest = 0
   for snip in items(a:snippet_list)
     if strlen(snip['word']) > longest
@@ -56,7 +56,7 @@ function! s:unite_source.get_longest_snippet_len(snippet_list)
   return longest
 endfunction
 
-function! s:unite_source.gather_candidates(args, context)
+function! s:unite_source.gather_candidates(args, context) abort
   let default_val = {'word': '', 'unite__abbr': '', 'is_dummy': 0, 'source':
         \  'ultisnips', 'unite__is_marked': 0, 'kind': 'command', 'is_matched': 1,
         \    'is_multiline': 0}
@@ -72,7 +72,7 @@ function! s:unite_source.gather_candidates(args, context)
   return canditates
 endfunction
 
-function! unite#sources#ultisnips#define()
+function! unite#sources#ultisnips#define() abort
   return s:unite_source
 endfunction
 


### PR DESCRIPTION
It prevents Vim from processing the rest of the statements inside a function, after having encountered an error.

It also gives shorter and more relevant stack traces in case of an error.