### PR TITLE
Test python 3.6, 3.7 and 3.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,18 @@ env:
   - VIM_VERSION="8.0" PYTHON_IMAGE=2.7-stretch TAG=vim_80_py2
   - VIM_VERSION="8.1" PYTHON_IMAGE=2.7-stretch TAG=vim_81_py2
   - VIM_VERSION="git" PYTHON_IMAGE=2.7-stretch TAG=vim_git_py2
-  - VIM_VERSION="7.4" PYTHON_IMAGE=3.6-stretch TAG=vim_74_py3
-  - VIM_VERSION="8.0" PYTHON_IMAGE=3.6-stretch TAG=vim_80_py3
-  - VIM_VERSION="8.1" PYTHON_IMAGE=3.6-stretch TAG=vim_81_py3
-  - VIM_VERSION="git" PYTHON_IMAGE=3.6-stretch TAG=vim_git_py3
+  - VIM_VERSION="7.4" PYTHON_IMAGE=3.6-stretch TAG=vim_74_py36
+  - VIM_VERSION="8.0" PYTHON_IMAGE=3.6-stretch TAG=vim_80_py36
+  - VIM_VERSION="8.1" PYTHON_IMAGE=3.6-stretch TAG=vim_81_py36
+  - VIM_VERSION="git" PYTHON_IMAGE=3.6-stretch TAG=vim_git_py36
+  - VIM_VERSION="7.4" PYTHON_IMAGE=3.7-stretch TAG=vim_74_py37
+  - VIM_VERSION="8.0" PYTHON_IMAGE=3.7-stretch TAG=vim_80_py37
+  - VIM_VERSION="8.1" PYTHON_IMAGE=3.7-stretch TAG=vim_81_py37
+  - VIM_VERSION="git" PYTHON_IMAGE=3.7-stretch TAG=vim_git_py37
+  - VIM_VERSION="7.4" PYTHON_IMAGE=3.8-buster TAG=vim_74_py38
+  - VIM_VERSION="8.0" PYTHON_IMAGE=3.8-buster TAG=vim_80_py38
+  - VIM_VERSION="8.1" PYTHON_IMAGE=3.8-buster TAG=vim_81_py38
+  - VIM_VERSION="git" PYTHON_IMAGE=3.8-buster TAG=vim_git_py38
 
 install:
    - docker build -t ultisnips:${TAG} --build-arg PYTHON_IMAGE=${PYTHON_IMAGE} --build-arg VIM_VERSION=${VIM_VERSION} .

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,8 @@ env:
   - VIM_VERSION="8.0" PYTHON_IMAGE=3.6-stretch TAG=vim_80_py36
   - VIM_VERSION="8.1" PYTHON_IMAGE=3.6-stretch TAG=vim_81_py36
   - VIM_VERSION="git" PYTHON_IMAGE=3.6-stretch TAG=vim_git_py36
-  - VIM_VERSION="7.4" PYTHON_IMAGE=3.7-stretch TAG=vim_74_py37
-  - VIM_VERSION="8.0" PYTHON_IMAGE=3.7-stretch TAG=vim_80_py37
   - VIM_VERSION="8.1" PYTHON_IMAGE=3.7-stretch TAG=vim_81_py37
   - VIM_VERSION="git" PYTHON_IMAGE=3.7-stretch TAG=vim_git_py37
-  - VIM_VERSION="7.4" PYTHON_IMAGE=3.8-buster TAG=vim_74_py38
-  - VIM_VERSION="8.0" PYTHON_IMAGE=3.8-buster TAG=vim_80_py38
   - VIM_VERSION="8.1" PYTHON_IMAGE=3.8-buster TAG=vim_81_py38
   - VIM_VERSION="git" PYTHON_IMAGE=3.8-buster TAG=vim_git_py38
 

--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,30 @@ image_vim_81_py2:
 	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=2.7-stretch --build-arg VIM_VERSION=8.1 .
 image_vim_git_py2:
 	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=2.7-stretch --build-arg VIM_VERSION=git .
-image_vim_74_py3:
+image_vim_74_py36:
 	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.6-stretch --build-arg VIM_VERSION=7.4 .
-image_vim_80_py3:
+image_vim_80_py36:
 	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.6-stretch --build-arg VIM_VERSION=8.0 .
-image_vim_81_py3:
+image_vim_81_py36:
 	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.6-stretch --build-arg VIM_VERSION=8.1 .
-image_vim_git_py3:
+image_vim_git_py36:
 	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.6-stretch --build-arg VIM_VERSION=git .
+image_vim_74_py37:
+	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.7-stretch --build-arg VIM_VERSION=7.4 .
+image_vim_80_py37:
+	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.7-stretch --build-arg VIM_VERSION=8.0 .
+image_vim_81_py37:
+	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.7-stretch --build-arg VIM_VERSION=8.1 .
+image_vim_git_py37:
+	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.7-stretch --build-arg VIM_VERSION=git .
+image_vim_74_py38:
+	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.8-buster --build-arg VIM_VERSION=7.4 .
+image_vim_80_py38:
+	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.8-buster --build-arg VIM_VERSION=8.0 .
+image_vim_81_py38:
+	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.8-buster --build-arg VIM_VERSION=8.1 .
+image_vim_git_py38:
+	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.8-buster --build-arg VIM_VERSION=git .
 
 image_repro: image_vim_80_py3
 	docker build -t ultisnips:repro --build-arg BASE_IMAGE=$< -f Dockerfile.repro .

--- a/Makefile
+++ b/Makefile
@@ -18,18 +18,11 @@ image_vim_81_py36:
 	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.6-stretch --build-arg VIM_VERSION=8.1 .
 image_vim_git_py36:
 	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.6-stretch --build-arg VIM_VERSION=git .
-image_vim_74_py37:
-	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.7-stretch --build-arg VIM_VERSION=7.4 .
-image_vim_80_py37:
-	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.7-stretch --build-arg VIM_VERSION=8.0 .
+# 74 and 80 do not build with py37 and py38. The build errors out with "Require native threads".
 image_vim_81_py37:
 	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.7-stretch --build-arg VIM_VERSION=8.1 .
 image_vim_git_py37:
 	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.7-stretch --build-arg VIM_VERSION=git .
-image_vim_74_py38:
-	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.8-buster --build-arg VIM_VERSION=7.4 .
-image_vim_80_py38:
-	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.8-buster --build-arg VIM_VERSION=8.0 .
 image_vim_81_py38:
 	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.8-buster --build-arg VIM_VERSION=8.1 .
 image_vim_git_py38:

--- a/test/vim_test_case.py
+++ b/test/vim_test_case.py
@@ -138,6 +138,13 @@ class VimTestCase(unittest.TestCase, TempFileManager):
         vim_config.append(
             'let g:UltiSnipsUsePythonVersion="%i"' % (3 if PYTHON3 else 2)
         )
+
+        # Work around https://github.com/vim/vim/issues/3117 for testing >
+        # py3.7 on Vim 8.1. Actually also reported against UltiSnips
+        # https://github.com/SirVer/ultisnips/issues/996
+        if PYTHON3 and "Vi IMproved 8.1" in self.version:
+            vim_config.append("silent! python3 1")
+
         vim_config.append('let g:UltiSnipsSnippetDirectories=["us"]')
         if self.python_host_prog:
             vim_config.append('let g:python_host_prog="%s"' % self.python_host_prog)


### PR DESCRIPTION
After #1057 showed us that Python 3.7 changed something in the regex engine, it is time to test newer python versions independently.