### PR TITLE
Remove dead code & fold markers.

### DIFF
--- a/pythonx/UltiSnips/test_diff.py
+++ b/pythonx/UltiSnips/test_diff.py
@@ -73,7 +73,6 @@ class TestGuessing_DeleteOneChar(_BaseGuessing, unittest.TestCase):
     wanted = (("D", 0, 5, " "),)
 
 
-
 class _Base(object):
     def runTest(self):
         es = diff(self.a, self.b)

--- a/pythonx/UltiSnips/test_diff.py
+++ b/pythonx/UltiSnips/test_diff.py
@@ -28,8 +28,6 @@ def transform(a, cmds):
 
 import unittest
 
-# Test Guessing  {{{
-
 
 class _BaseGuessing(object):
     def runTest(self):
@@ -74,8 +72,6 @@ class TestGuessing_DeleteOneChar(_BaseGuessing, unittest.TestCase):
     ppos, pos = (0, 5), (0, 5)
     wanted = (("D", 0, 5, " "),)
 
-
-# End: Test Guessing  }}}
 
 
 class _Base(object):

--- a/syntax/snippets_snipmate.vim
+++ b/syntax/snippets_snipmate.vim
@@ -5,7 +5,6 @@ if exists("b:current_syntax")
     finish
 endif
 
-" Embedded syntaxes {{{1
 
 " Re-include the original file so we can share some of its definitions
 let b:ultisnips_override_snipmate = 1
@@ -16,7 +15,6 @@ unlet b:ultisnips_override_snipmate
 syn cluster snipTokens contains=snipEscape,snipVisual,snipTabStop,snipMirror,snipmateCommand
 syn cluster snipTabStopTokens contains=snipVisual,snipMirror,snipEscape,snipmateCommand
 
-" Syntax definitions {{{1
 
 syn match snipmateComment "^#.*"
 
@@ -31,7 +29,6 @@ syn region snipmateSnippetBody start="^\t" end="^\ze[^[:tab:]]" contained contai
 
 syn region snipmateCommand keepend matchgroup=snipCommandDelim start="`" skip="\\[{}\\$`]" end="`" contained contains=snipCommandSyntaxOverride,@Viml
 
-" Highlight groups {{{1
 
 hi def link snipmateComment snipComment
 
@@ -41,7 +38,5 @@ hi def link snipmateTrigger snipSnippetTrigger
 hi def link snipmateDescription snipSnippetDocString
 
 hi def link snipmateCommand snipCommand
-
-" }}}1
 
 let b:current_syntax = "snippets"

--- a/syntax/snippets_snipmate.vim
+++ b/syntax/snippets_snipmate.vim
@@ -5,6 +5,7 @@ if exists("b:current_syntax")
     finish
 endif
 
+" Embedded syntaxes {{{1
 
 " Re-include the original file so we can share some of its definitions
 let b:ultisnips_override_snipmate = 1
@@ -15,6 +16,7 @@ unlet b:ultisnips_override_snipmate
 syn cluster snipTokens contains=snipEscape,snipVisual,snipTabStop,snipMirror,snipmateCommand
 syn cluster snipTabStopTokens contains=snipVisual,snipMirror,snipEscape,snipmateCommand
 
+" Syntax definitions {{{1
 
 syn match snipmateComment "^#.*"
 
@@ -29,6 +31,7 @@ syn region snipmateSnippetBody start="^\t" end="^\ze[^[:tab:]]" contained contai
 
 syn region snipmateCommand keepend matchgroup=snipCommandDelim start="`" skip="\\[{}\\$`]" end="`" contained contains=snipCommandSyntaxOverride,@Viml
 
+" Highlight groups {{{1
 
 hi def link snipmateComment snipComment
 
@@ -38,5 +41,7 @@ hi def link snipmateTrigger snipSnippetTrigger
 hi def link snipmateDescription snipSnippetDocString
 
 hi def link snipmateCommand snipCommand
+
+" }}}1
 
 let b:current_syntax = "snippets"

--- a/test/test_AnonymousExpansion.py
+++ b/test/test_AnonymousExpansion.py
@@ -63,5 +63,3 @@ class Anon_Trigger_Opts(_AnonBase):
     args = '"simple expand", ".*abc", "desc", "r"'
     keys = "blah blah abc" + EA
     wanted = "simple expand"
-
-

--- a/test/test_AnonymousExpansion.py
+++ b/test/test_AnonymousExpansion.py
@@ -1,8 +1,6 @@
 from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
-# Anonymous Expansion  {{{#
-
 
 class _AnonBase(_VimTest):
     args = ""
@@ -67,4 +65,3 @@ class Anon_Trigger_Opts(_AnonBase):
     wanted = "simple expand"
 
 
-# End: Anonymous Expansion  #}}}

--- a/test/test_Autocommands.py
+++ b/test/test_Autocommands.py
@@ -38,5 +38,3 @@ class Autocommands(_VimTest):
         vim_config.append("autocmd User UltiSnipsEnterFirstSnippet call CustomMapper()")
         vim_config.append("autocmd! User UltiSnipsExitLastSnippet")
         vim_config.append("autocmd User UltiSnipsExitLastSnippet call CustomUnmapper()")
-
-

--- a/test/test_Autocommands.py
+++ b/test/test_Autocommands.py
@@ -2,8 +2,6 @@
 from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
-# Autocommands  {{{#
-
 
 class Autocommands(_VimTest):
     snippets = ("test", "[ ${1:foo} ]")
@@ -42,4 +40,3 @@ class Autocommands(_VimTest):
         vim_config.append("autocmd User UltiSnipsExitLastSnippet call CustomUnmapper()")
 
 
-# end: Autocommands  #}}}

--- a/test/test_Chars.py
+++ b/test/test_Chars.py
@@ -3,7 +3,6 @@ from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 from test.util import running_on_windows
 
-# Quotes in Snippets  {{{#
 # Test for Bug #774917
 
 
@@ -38,10 +37,6 @@ class Snippet_With_DoubleQuote_List(_VimTest):
     wanted = 'Expand me"!'
 
 
-# End: Quotes in Snippets  #}}}
-
-# Trailing whitespace {{{#
-
 
 class RemoveTrailingWhitespace(_VimTest):
     snippets = ("test", """Hello\t ${1:default}\n$2""", "", "s")
@@ -67,9 +62,6 @@ class LeaveTrailingWhitespace(_VimTest):
     keys = "test" + EX + BS + JF + "Goodbye"
 
 
-# End: Trailing whitespace #}}}
-
-# Newline in default text {{{#
 # Tests for bug 616315 #
 
 
@@ -214,9 +206,6 @@ x
 y"""
 
 
-# End: Newline in default text  #}}}
-
-# Umlauts and Special Chars  {{{#
 
 
 class _UmlautsBase(_VimTest):
@@ -284,4 +273,3 @@ class NoUmlautsBeforeTriggerAndCharsAfter(_UmlautsBase):
     wanted = "oouu success b"
 
 
-# End: Umlauts and Special Chars  #}}}

--- a/test/test_Chars.py
+++ b/test/test_Chars.py
@@ -37,7 +37,6 @@ class Snippet_With_DoubleQuote_List(_VimTest):
     wanted = 'Expand me"!'
 
 
-
 class RemoveTrailingWhitespace(_VimTest):
     snippets = ("test", """Hello\t ${1:default}\n$2""", "", "s")
     wanted = """Hello\nGoodbye"""
@@ -206,8 +205,6 @@ x
 y"""
 
 
-
-
 class _UmlautsBase(_VimTest):
     # SendKeys can't send UTF characters
     skip_if = lambda self: running_on_windows()
@@ -271,5 +268,3 @@ class NoUmlautsBeforeTriggerAndCharsAfter(_UmlautsBase):
     snippets = ("trig", "success")
     keys = "oouu trig b" + 2 * ARR_L + EX
     wanted = "oouu success b"
-
-

--- a/test/test_Completion.py
+++ b/test/test_Completion.py
@@ -2,7 +2,6 @@ from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
 
-
 class Completion_SimpleExample_ECR(_VimTest):
     snippets = ("test", "$1 ${1:blah}")
     keys = (
@@ -38,5 +37,3 @@ class Completion_BackwardsJumpWithoutCOMPL_ACCEPT(_VimTest):
     snippets = ("test", "$1 $2")
     keys = COMPLETION_OPTIONS + "test" + EX + "foo" + JF + "com" + COMPL_KW + JB + "foo"
     wanted = COMPLETION_OPTIONS + "foo completion1"
-
-

--- a/test/test_Completion.py
+++ b/test/test_Completion.py
@@ -1,7 +1,6 @@
 from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
-# Tab Completion of Words  {{{#
 
 
 class Completion_SimpleExample_ECR(_VimTest):
@@ -41,4 +40,3 @@ class Completion_BackwardsJumpWithoutCOMPL_ACCEPT(_VimTest):
     wanted = COMPLETION_OPTIONS + "foo completion1"
 
 
-# End: Tab Completion of Words  #}}}

--- a/test/test_Editing.py
+++ b/test/test_Editing.py
@@ -11,9 +11,6 @@ def check_required_vim_version(test):
         return None
 
 
-# Undo of Snippet insertion  {{{#
-
-
 class Undo_RemoveMultilineSnippet(_VimTest):
     snippets = ("test", "Hello\naaa ${1} bbb\nWorld")
     keys = "test" + EX + ESC + "u"
@@ -84,12 +81,8 @@ class DoNotCrashOnUndoAndJumpInNestedSnippet(_VimTest):
     wanted = "if a: test"
 
 
-# End: Undo of Snippet insertion  #}}}
 
-# Normal mode editing  {{{#
 # Test for bug #927844
-
-
 class DeleteLastTwoLinesInSnippet(_VimTest):
     snippets = ("test", "$1hello\nnice\nworld")
     keys = "test" + EX + ESC + "j2dd"
@@ -114,9 +107,6 @@ class DeleteCurrentTabStop3_JumpAround(_VimTest):
     wanted = "hello\nendworld"
 
 
-# End: Normal mode editing  #}}}
-
-# Pressing BS in TabStop  {{{#
 # Test for Bug #774917
 
 
@@ -130,9 +120,6 @@ class Backspace_TabStop_NotZero(_VimTest):
     snippets = ("test", "A${1:C} ${2:DDD}", "This is Case 1")
     keys = "test" + EX + "A" + JF + BS + "BBB"
     wanted = "AA BBB"
-
-
-# End: Pressing BS in TabStop  #}}}
 
 
 class UpdateModifiedSnippetWithoutCursorMove1(_VimTest):

--- a/test/test_Editing.py
+++ b/test/test_Editing.py
@@ -81,7 +81,6 @@ class DoNotCrashOnUndoAndJumpInNestedSnippet(_VimTest):
     wanted = "if a: test"
 
 
-
 # Test for bug #927844
 class DeleteLastTwoLinesInSnippet(_VimTest):
     snippets = ("test", "$1hello\nnice\nworld")

--- a/test/test_Expand.py
+++ b/test/test_Expand.py
@@ -75,4 +75,3 @@ class SimpleExpand_DoNotClobberDefaultRegister(_VimTest):
 
     def _extra_vim_config(self, vim_config):
         vim_config.append('let @"=""')
-

--- a/test/test_Expand.py
+++ b/test/test_Expand.py
@@ -1,8 +1,6 @@
 from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
-# Simple Expands  {{{#
-
 
 class _SimpleExpands(_VimTest):
     snippets = ("hallo", "Hallo Welt!")
@@ -78,5 +76,3 @@ class SimpleExpand_DoNotClobberDefaultRegister(_VimTest):
     def _extra_vim_config(self, vim_config):
         vim_config.append('let @"=""')
 
-
-# End: Simple Expands  #}}}

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -1,7 +1,6 @@
 from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
-# Test for bug 1251994  {{{#
 
 
 class Bug1251994(_VimTest):
@@ -10,9 +9,8 @@ class Bug1251994(_VimTest):
     wanted = "  world hello;blub"
 
 
-# End: 1251994  #}}}
 
-# Test for https://github.com/SirVer/ultisnips/issues/157 (virtualedit) {{{#
+# Test for https://github.com/SirVer/ultisnips/issues/157 (virtualedit)
 
 
 class VirtualEdit(_VimTest):
@@ -25,9 +23,9 @@ class VirtualEdit(_VimTest):
         vim_config.append("set noexpandtab")
 
 
-# End: 1251994  #}}}
+# End: 1251994
 
-# Test for Github Pull Request #134 - Retain unnamed register {{{#
+# Test for Github Pull Request #134 - Retain unnamed register
 
 
 class RetainsTheUnnamedRegister(_VimTest):
@@ -54,7 +52,7 @@ class RetainsTheUnnamedRegister_ButOnlyOnce(_VimTest):
     wanted = "\nblah\nhello world "
 
 
-# End: Github Pull Request # 134 #}}}
+# End: Github Pull Request # 134
 
 # Test to ensure that shiftwidth follows tabstop when it's set to zero post
 # version 7.3.693. Prior to that version a shiftwidth of zero effectively
@@ -70,7 +68,7 @@ class ShiftWidthZero(_VimTest):
     wanted = "\tfoo"
 
 
-# Test for https://github.com/SirVer/ultisnips/issues/171 {{{#
+# Test for https://github.com/SirVer/ultisnips/issues/171
 # Make sure that we don't crash when trying to save and restore the clipboard
 # when it contains data that we can't coerce into Unicode.
 
@@ -108,4 +106,4 @@ class NonUnicodeDataInUnnamedRegister(_VimTest):
         )
 
 
-# End: #171  #}}}
+# End: #171 

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -2,12 +2,10 @@ from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
 
-
 class Bug1251994(_VimTest):
     snippets = ("test", "${2:#2} ${1:#1};$0")
     keys = "  test" + EX + "hello" + JF + "world" + JF + "blub"
     wanted = "  world hello;blub"
-
 
 
 # Test for https://github.com/SirVer/ultisnips/issues/157 (virtualedit)
@@ -106,4 +104,4 @@ class NonUnicodeDataInUnnamedRegister(_VimTest):
         )
 
 
-# End: #171 
+# End: #171

--- a/test/test_Folding.py
+++ b/test/test_Folding.py
@@ -2,7 +2,6 @@ from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
 
-
 class FoldingEnabled_SnippetWithFold_ExpectNoFolding(_VimTest):
     def _extra_vim_config(self, vim_config):
         vim_config.append("set foldlevel=0")
@@ -57,5 +56,3 @@ ${0}
     )
     keys = "test" + EX + JF + "sub junk {}"
     wanted = "package c03;\nsub junk {}\n1;"
-
-

--- a/test/test_Folding.py
+++ b/test/test_Folding.py
@@ -1,7 +1,6 @@
 from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
-# Folding Interaction  {{{#
 
 
 class FoldingEnabled_SnippetWithFold_ExpectNoFolding(_VimTest):
@@ -60,4 +59,3 @@ ${0}
     wanted = "package c03;\nsub junk {}\n1;"
 
 
-# End: Folding Interaction  #}}}

--- a/test/test_Format.py
+++ b/test/test_Format.py
@@ -2,7 +2,6 @@ from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 from test.util import running_on_windows
 
-# ExpandTab  {{{#
 
 
 class _ExpandTabs(_VimTest):
@@ -35,9 +34,7 @@ class RecTabStopsWithExpandtab_SpecialIndentProblem_ECR(_ExpandTabs):
         vim_config.append("set indentexpr=8")
 
 
-# End: ExpandTab  #}}}
 
-# Proper Indenting  {{{#
 
 
 class ProperIndenting_SimpleCase_ECR(_VimTest):
@@ -95,9 +92,7 @@ class ProperIndenting_FirstLineInFileComplete_ECR(ProperIndenting_FirstLineInFil
     wanted = "#include <cstdlib>"
 
 
-# End: Proper Indenting  #}}}
 
-# Format options tests  {{{#
 
 
 class _FormatoptionsBase(_VimTest):
@@ -163,4 +158,3 @@ longersnippet that
 should wrap properlyend"""
 
 
-# End: Format options tests  #}}}

--- a/test/test_Format.py
+++ b/test/test_Format.py
@@ -3,7 +3,6 @@ from test.constant import *
 from test.util import running_on_windows
 
 
-
 class _ExpandTabs(_VimTest):
     def _extra_vim_config(self, vim_config):
         vim_config.append("set sw=3")
@@ -32,9 +31,6 @@ class RecTabStopsWithExpandtab_SpecialIndentProblem_ECR(_ExpandTabs):
         _ExpandTabs._extra_vim_config(self, vim_config)
         vim_config.append("set indentkeys=o,O,*<Return>,<>>,{,}")
         vim_config.append("set indentexpr=8")
-
-
-
 
 
 class ProperIndenting_SimpleCase_ECR(_VimTest):
@@ -90,9 +86,6 @@ endsnippet
 class ProperIndenting_FirstLineInFileComplete_ECR(ProperIndenting_FirstLineInFile_ECR):
     keys = "inc" + EX + "cstdl"
     wanted = "#include <cstdlib>"
-
-
-
 
 
 class _FormatoptionsBase(_VimTest):
@@ -156,5 +149,3 @@ should wrap properlyafter
 startThis is a
 longersnippet that
 should wrap properlyend"""
-
-

--- a/test/test_Interpolation.py
+++ b/test/test_Interpolation.py
@@ -5,8 +5,6 @@ from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import EX, JF, ESC
 from test.util import running_on_windows
 
-# ShellCode Interpolation  {{{#
-
 
 class TabStop_Shell_SimpleExample(_VimTest):
     skip_if = lambda self: running_on_windows()
@@ -70,19 +68,12 @@ print "Hallo Welt"
     wanted = "Hallo now Hallo Welt endand more"
 
 
-# End: ShellCode Interpolation  #}}}
-# VimScript Interpolation  {{{#
-
 
 class TabStop_VimScriptInterpolation_SimpleExample(_VimTest):
     snippets = ("test", """hi `!v indent(".")` End""")
     keys = "    test" + EX
     wanted = "    hi 4 End"
 
-
-# End: VimScript Interpolation  #}}}
-# PythonCode Interpolation  {{{#
-# Deprecated Implementation  {{{#
 
 
 class PythonCodeOld_SimpleExample(_VimTest):
@@ -125,10 +116,6 @@ else:
     )
     keys = "    test" + EX
     wanted = "    start b isbigger a end"
-
-
-# End: Deprecated Implementation  #}}}
-# New Implementation  {{{#
 
 
 class PythonCode_UseNewOverOld(_VimTest):
@@ -568,5 +555,3 @@ class Python_WeirdScoping_Error(_VimTest):
     wanted = "h5b"
 
 
-# End: New Implementation  #}}}
-# End: PythonCode Interpolation  #}}}

--- a/test/test_Interpolation.py
+++ b/test/test_Interpolation.py
@@ -68,12 +68,10 @@ print "Hallo Welt"
     wanted = "Hallo now Hallo Welt endand more"
 
 
-
 class TabStop_VimScriptInterpolation_SimpleExample(_VimTest):
     snippets = ("test", """hi `!v indent(".")` End""")
     keys = "    test" + EX
     wanted = "    hi 4 End"
-
 
 
 class PythonCodeOld_SimpleExample(_VimTest):
@@ -553,5 +551,3 @@ class Python_WeirdScoping_Error(_VimTest):
     )
     keys = "test" + EX
     wanted = "h5b"
-
-

--- a/test/test_ListSnippets.py
+++ b/test/test_ListSnippets.py
@@ -1,8 +1,6 @@
 from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
-# List Snippets  {{{#
-
 
 class _ListAllSnippets(_VimTest):
     snippets = (
@@ -50,4 +48,3 @@ class ListAllAvailable_Disabled_ExpectCorrectResult(_ListAllSnippets):
         vim_config.append('let g:UltiSnipsListSnippets=""')
 
 
-# End: List Snippets  #}}}

--- a/test/test_ListSnippets.py
+++ b/test/test_ListSnippets.py
@@ -46,5 +46,3 @@ class ListAllAvailable_Disabled_ExpectCorrectResult(_ListAllSnippets):
 
     def _extra_vim_config(self, vim_config):
         vim_config.append('let g:UltiSnipsListSnippets=""')
-
-

--- a/test/test_Movement.py
+++ b/test/test_Movement.py
@@ -1,7 +1,6 @@
 from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
-# Cursor Movement  {{{#
 
 
 class CursorMovement_Multiline_ECR(_VimTest):
@@ -22,8 +21,6 @@ class CursorMovement_BS_InEditMode(_VimTest):
     wanted = "<tr>\n\t<th>blah</th>\n</tr>\nend"
 
 
-# End: Cursor Movement  #}}}
-# Insert Mode Moving  {{{#
 
 
 class IMMoving_CursorsKeys_ECR(_VimTest):
@@ -84,4 +81,3 @@ class IMMoving_ExitWhenOutsideBelow_ECR(_VimTest):
     wanted = "hello tab\nblub this\n" + JF + "testhallo"
 
 
-# End: Insert Mode Moving  #}}}

--- a/test/test_Movement.py
+++ b/test/test_Movement.py
@@ -2,7 +2,6 @@ from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
 
-
 class CursorMovement_Multiline_ECR(_VimTest):
     snippets = ("test", r"$1 ${1:a tab}")
     keys = "test" + EX + "this is something\nvery nice\nnot" + JF + "more text"
@@ -19,8 +18,6 @@ class CursorMovement_BS_InEditMode(_VimTest):
     snippets = ("<trh", "<tr>\n\t<th>$1</th>\n\t$2\n</tr>\n$3")
     keys = "<trh" + EX + "blah" + JF + BS + BS + JF + "end"
     wanted = "<tr>\n\t<th>blah</th>\n</tr>\nend"
-
-
 
 
 class IMMoving_CursorsKeys_ECR(_VimTest):
@@ -79,5 +76,3 @@ class IMMoving_ExitWhenOutsideBelow_ECR(_VimTest):
         "hello test this" + ESC + "02f i" + EX + "tab" + 2 * ARR_D + JF + "testhallo\n"
     )
     wanted = "hello tab\nblub this\n" + JF + "testhallo"
-
-

--- a/test/test_MultipleMatches.py
+++ b/test/test_MultipleMatches.py
@@ -1,6 +1,7 @@
 from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
+
 class _MultipleMatches(_VimTest):
     snippets = (
         ("test", "Case1", "This is Case 1"),
@@ -67,5 +68,3 @@ class Multiple_ManySnippetsOneTrigger_ECR(_VimTest):
     )
     keys = "test" + EX + " " + ESC + ESC + "ahi"
     wanted = "testhi"
-
-

--- a/test/test_MultipleMatches.py
+++ b/test/test_MultipleMatches.py
@@ -1,9 +1,6 @@
 from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
-# Selecting Between Same Triggers  {{{#
-
-
 class _MultipleMatches(_VimTest):
     snippets = (
         ("test", "Case1", "This is Case 1"),
@@ -37,7 +34,6 @@ class Multiple_SimpleCaseEscapeOut_ECR(_MultipleMatches):
 
 
 class Multiple_ManySnippetsOneTrigger_ECR(_VimTest):
-    # Snippet definition {{{#
     snippets = (
         ("test", "Case1", "This is Case 1"),
         ("test", "Case2", "This is Case 2"),
@@ -68,9 +64,8 @@ class Multiple_ManySnippetsOneTrigger_ECR(_VimTest):
         ("test", "Case27", "This is Case 27"),
         ("test", "Case28", "This is Case 28"),
         ("test", "Case29", "This is Case 29"),
-    )  # }}}
+    )
     keys = "test" + EX + " " + ESC + ESC + "ahi"
     wanted = "testhi"
 
 
-# End: Selecting Between Same Triggers  #}}}

--- a/test/test_Plugin.py
+++ b/test/test_Plugin.py
@@ -11,71 +11,6 @@ def python3():
         return "Test does not work on python3."
 
 
-# Plugin: YouCompleteMe  {{{#
-# TODO(sirver): disabled because it fails right now.
-# class Plugin_YouCompleteMe_IntegrationTest(_VimTest):
-# def skip_if(self):
-# r = python3()
-# if r:
-# return r
-# if "7.4" not in self.version:
-# return "Needs Vim 7.4."
-# plugins = ["Valloric/YouCompleteMe"]
-# snippets = ("superlongtrigger", "Hello")
-# keys = "superlo\ty"
-# wanted = "Hello"
-
-# def _extra_vim_config(self, vim_config):
-# # Not sure why, but I need to make a new tab for this to work.
-# vim_config.append('let g:UltiSnipsExpandTrigger="y"')
-# vim_config.append('tabnew')
-
-# def _before_test(self):
-# self.vim.send(":set ft=python\n")
-# # Give ycm a chance to catch up.
-# time.sleep(1)
-# End: Plugin: YouCompleteMe  #}}}
-# Plugin: Neocomplete {{{#
-# TODO(sirver): disabled because it fails right now.
-# class Plugin_Neocomplete_BugTest(_VimTest):
-# Test for https://github.com/SirVer/ultisnips/issues/228
-
-# def skip_if(self):
-# if '+lua' not in self.version:
-# return 'Needs +lua'
-# plugins = ['Shougo/neocomplete.vim']
-# snippets = ('t', 'Hello', '', 'w')
-# keys = 'iab\\ t' + EX
-# wanted = 'iab\\ Hello'
-
-# def _extra_vim_config(self, vim_config):
-# vim_config.append(r'set iskeyword+=\\ ')
-# vim_config.append('let g:neocomplete#enable_at_startup = 1')
-# vim_config.append('let g:neocomplete#enable_smart_case = 1')
-# vim_config.append('let g:neocomplete#enable_camel_case = 1')
-# vim_config.append('let g:neocomplete#enable_auto_delimiter = 1')
-# vim_config.append('let g:neocomplete#enable_refresh_always = 1')
-# End: Plugin: Neocomplete  #}}}
-# Plugin: unite {{{#
-
-# TODO(sirver): Disable since it is flaky.
-# class Plugin_unite_BugTest(_VimTest):
-# plugins = ['Shougo/unite.vim']
-# snippets = ('t', 'Hello', '', 'w')
-# keys = 'iab\\ t=UltiSnipsCallUnite()\n'
-# wanted = 'iab\\ Hello '
-
-# def _extra_vim_config(self, vim_config):
-# vim_config.append(r'set iskeyword+=\\ ')
-# vim_config.append('function! UltiSnipsCallUnite()')
-# vim_config.append(
-# '  Unite -start-insert -winheight=100 -immediately -no-empty ultisnips')
-# vim_config.append('  return ""')
-# vim_config.append('endfunction')
-# End: Plugin: unite  #}}}
-# Plugin: Supertab {{{#
-
-
 class Plugin_SuperTab_SimpleTest(_VimTest):
     plugins = ["ervandew/supertab"]
     snippets = ("long", "Hello", "", "w")
@@ -95,5 +30,3 @@ class Plugin_SuperTab_SimpleTest(_VimTest):
         vim_config.append("let g:SuperTabLongestHighlight = 1")
         vim_config.append("let g:SuperTabCrMapping = 0")
 
-
-# End: Plugin: Supertab   #}}}

--- a/test/test_Plugin.py
+++ b/test/test_Plugin.py
@@ -29,4 +29,3 @@ class Plugin_SuperTab_SimpleTest(_VimTest):
         vim_config.append('let g:SuperTabRetainCompletionDuration = "insert"')
         vim_config.append("let g:SuperTabLongestHighlight = 1")
         vim_config.append("let g:SuperTabCrMapping = 0")
-

--- a/test/test_Recursive.py
+++ b/test/test_Recursive.py
@@ -1,6 +1,7 @@
 from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
+
 class RecTabStops_SimpleCase_ExpectCorrectResult(_VimTest):
     snippets = ("m", "[ ${1:first}  ${2:sec} ]")
     keys = "m" + EX + "m" + EX + "hello" + JF + "world" + JF + "ups" + JF + "end"
@@ -343,4 +344,3 @@ endsnippet
     wanted = (
         "form_for user, namespace: some_namespace, html: {(id: |class: |title:  )d: "
     )
-

--- a/test/test_Recursive.py
+++ b/test/test_Recursive.py
@@ -1,9 +1,6 @@
 from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
-# Recursive (Nested) Snippets  {{{#
-
-
 class RecTabStops_SimpleCase_ExpectCorrectResult(_VimTest):
     snippets = ("m", "[ ${1:first}  ${2:sec} ]")
     keys = "m" + EX + "m" + EX + "hello" + JF + "world" + JF + "ups" + JF + "end"
@@ -347,5 +344,3 @@ endsnippet
         "form_for user, namespace: some_namespace, html: {(id: |class: |title:  )d: "
     )
 
-
-# End: Recursive (Nested) Snippets  #}}}

--- a/test/test_Selection.py
+++ b/test/test_Selection.py
@@ -1,7 +1,6 @@
 from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
-# Unmap SelectMode Mappings  {{{#
 # Test for bug 427298 #
 
 
@@ -69,9 +68,7 @@ class SelectModeMappings_BufferLocalMappings_ECR(_SelectModeMappings):
     wanted = "Hello"
 
 
-# End: Unmap SelectMode Mappings  #}}}
 
-# Exclusive Selection  {{{#
 
 
 class _ES_Base(_VimTest):
@@ -98,9 +95,7 @@ class ExclusiveSelection_RealWorldCase_Test(_ES_Base):
 }"""
 
 
-# End: Exclusive Selection  #}}}
 
-# Old Selection {{{#
 
 
 class _OS_Base(_VimTest):
@@ -127,4 +122,3 @@ class OldSelection_RealWorldCase_Test(_OS_Base):
 }"""
 
 
-# End: Old Selection #}}}

--- a/test/test_Selection.py
+++ b/test/test_Selection.py
@@ -68,9 +68,6 @@ class SelectModeMappings_BufferLocalMappings_ECR(_SelectModeMappings):
     wanted = "Hello"
 
 
-
-
-
 class _ES_Base(_VimTest):
     def _extra_vim_config(self, vim_config):
         vim_config.append("set selection=exclusive")
@@ -95,9 +92,6 @@ class ExclusiveSelection_RealWorldCase_Test(_ES_Base):
 }"""
 
 
-
-
-
 class _OS_Base(_VimTest):
     def _extra_vim_config(self, vim_config):
         vim_config.append("set selection=old")
@@ -120,5 +114,3 @@ class OldSelection_RealWorldCase_Test(_OS_Base):
     wanted = """for ($k = 0; $k < count; $k++) {
 	// code
 }"""
-
-

--- a/test/test_SnipMate.py
+++ b/test/test_SnipMate.py
@@ -207,7 +207,6 @@ endsnippet
     wanted = "ultisnips"
 
 
-
 class snipMate_Issue658(_VimTest):
     files = {
         "snippets/_.snippets": """
@@ -223,4 +222,3 @@ snippet /*
  * 2
  */
 """
-

--- a/test/test_SnipMate.py
+++ b/test/test_SnipMate.py
@@ -2,8 +2,6 @@
 from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
-# snipMate support  {{{#
-
 
 class snipMate_SimpleSnippet(_VimTest):
     files = {
@@ -209,8 +207,6 @@ endsnippet
     wanted = "ultisnips"
 
 
-# End: snipMate support  #}}}
-
 
 class snipMate_Issue658(_VimTest):
     files = {
@@ -228,5 +224,3 @@ snippet /*
  */
 """
 
-
-# End: snipMate support  #}}}

--- a/test/test_SnippetOptions.py
+++ b/test/test_SnippetOptions.py
@@ -360,5 +360,3 @@ class MultiWord_SnippetOptions_ExpandWordSnippets_ExpandSuffix(
 ):
     keys = "a-test it" + EX
     wanted = "a-Expand me!"
-
-

--- a/test/test_SnippetOptions.py
+++ b/test/test_SnippetOptions.py
@@ -3,8 +3,6 @@ from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 from test.util import running_on_windows
 
-# Snippet Options  {{{#
-
 
 class SnippetOptions_OnlyExpandWhenWSInFront_Expand(_VimTest):
     snippets = ("test", "Expand me!", "", "b")
@@ -364,4 +362,3 @@ class MultiWord_SnippetOptions_ExpandWordSnippets_ExpandSuffix(
     wanted = "a-Expand me!"
 
 
-# Snippet Options  #}}}

--- a/test/test_SnippetPriorities.py
+++ b/test/test_SnippetPriorities.py
@@ -163,4 +163,3 @@ class SnippetPriorities_ClearedByChild(_VimTest):
         + ":set ft=p"
     )
     wanted = "Should only expand in p.\ntest" + EX
-

--- a/test/test_SnippetPriorities.py
+++ b/test/test_SnippetPriorities.py
@@ -1,8 +1,6 @@
 from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import EX, ESC
 
-# Snippet Priority  {{{#
-
 
 class SnippetPriorities_MultiWordTriggerOverwriteExisting(_VimTest):
     snippets = (
@@ -166,5 +164,3 @@ class SnippetPriorities_ClearedByChild(_VimTest):
     )
     wanted = "Should only expand in p.\ntest" + EX
 
-
-# End: Snippet Priority  #}}}

--- a/test/test_Transformation.py
+++ b/test/test_Transformation.py
@@ -4,7 +4,6 @@ from test.constant import *
 from test.util import no_unidecode_available
 
 
-
 class Transformation_SimpleCase_ExpectCorrectResult(_VimTest):
     snippets = ("test", "$1 ${1/foo/batzl/}")
     keys = "test" + EX + "hallo foo boy"
@@ -277,5 +276,3 @@ class Transformation_ConditionalWithBackslashBeforeDelimiter1(_VimTest):
     snippets = "test", r"$1 ${1/(aa)|.*/(?1:yes:no\\)/}"
     keys = "test" + EX + "ab"
     wanted = "ab no\\"
-
-

--- a/test/test_Transformation.py
+++ b/test/test_Transformation.py
@@ -3,7 +3,6 @@ from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 from test.util import no_unidecode_available
 
-# Transformations  {{{#
 
 
 class Transformation_SimpleCase_ExpectCorrectResult(_VimTest):
@@ -280,4 +279,3 @@ class Transformation_ConditionalWithBackslashBeforeDelimiter1(_VimTest):
     wanted = "ab no\\"
 
 
-# End: Transformations  #}}}

--- a/test/test_UltiSnipFunc.py
+++ b/test/test_UltiSnipFunc.py
@@ -4,7 +4,6 @@ from test.constant import *
 from test.util import running_on_windows
 
 
-
 class _AddFuncBase(_VimTest):
     args = ""
 
@@ -22,7 +21,6 @@ class AddFunc_Opt(_AddFuncBase):
     args = '".*test", "simple expand", "desc", "r", "all", 0'
     keys = "abc test" + EX
     wanted = "simple expand"
-
 
 
 # Test for bug 501727 #
@@ -136,8 +134,6 @@ class VerifyVimDict3(_VimTest):
     wanted = "te'123êabc"
 
 
-
-
 class AddNewSnippetSource(_VimTest):
     keys = (
         "blumba"
@@ -175,5 +171,3 @@ class MySnippetSource(SnippetSource):
         )
         pyfile = "py3file" if PYTHON3 else "pyfile"
         vim_config.append("%s %s" % (pyfile, self.name_temp("snippet_source.py")))
-
-

--- a/test/test_UltiSnipFunc.py
+++ b/test/test_UltiSnipFunc.py
@@ -3,7 +3,6 @@ from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 from test.util import running_on_windows
 
-# AddSnippet Function  {{{#
 
 
 class _AddFuncBase(_VimTest):
@@ -25,9 +24,7 @@ class AddFunc_Opt(_AddFuncBase):
     wanted = "simple expand"
 
 
-# End: AddSnippet Function  #}}}
 
-# Langmap Handling  {{{#
 # Test for bug 501727 #
 
 
@@ -95,11 +92,6 @@ hi4"""
         )
 
 
-# End: Langmap Handling  #}}}
-
-# SnippetsInCurrentScope  {{{#
-
-
 class VerifyVimDict1(_VimTest):
 
     """check:
@@ -144,9 +136,6 @@ class VerifyVimDict3(_VimTest):
     wanted = "te'123êabc"
 
 
-# End: SnippetsInCurrentScope  #}}}
-
-# Snippet Source  {{{#
 
 
 class AddNewSnippetSource(_VimTest):
@@ -188,4 +177,3 @@ class MySnippetSource(SnippetSource):
         vim_config.append("%s %s" % (pyfile, self.name_temp("snippet_source.py")))
 
 
-# End: Snippet Source  #}}}

--- a/test/vim_test_case.py
+++ b/test/vim_test_case.py
@@ -220,4 +220,4 @@ class VimTestCase(unittest.TestCase, TempFileManager):
         self.clear_temp()
 
 
-# vim:fileencoding=utf-8:foldmarker={{{#,#}}}:
+# vim:fileencoding=utf-8:

--- a/test_all.py
+++ b/test_all.py
@@ -235,4 +235,4 @@ if __name__ == "__main__":
 
     sys.exit(main())
 
-# vim:fileencoding=utf-8:foldmarker={{{#,#}}}:
+# vim:fileencoding=utf-8:


### PR DESCRIPTION
- I found the fold markers in the test subdirectories more annoying then useful.
- This also removes commented out code for interaction with YCM which will be unlikely to be resurrected anytime soon.