### PR TITLE
Remove support for Python2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
 *.swp
 doc/tags
-.ropeproject/
+/.ropeproject/
+/.mypy_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ sudo: required
 services: docker
 
 env:
-  - VIM_VERSION="7.4" PYTHON_IMAGE=2.7-stretch TAG=vim_74_py2
-  - VIM_VERSION="8.0" PYTHON_IMAGE=2.7-stretch TAG=vim_80_py2
-  - VIM_VERSION="8.1" PYTHON_IMAGE=2.7-stretch TAG=vim_81_py2
-  - VIM_VERSION="git" PYTHON_IMAGE=2.7-stretch TAG=vim_git_py2
   - VIM_VERSION="7.4" PYTHON_IMAGE=3.6-stretch TAG=vim_74_py36
   - VIM_VERSION="8.0" PYTHON_IMAGE=3.6-stretch TAG=vim_80_py36
   - VIM_VERSION="8.1" PYTHON_IMAGE=3.6-stretch TAG=vim_81_py36

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,6 @@ MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MAKEFILE_DIR := $(dir ${MAKEFILE_PATH})
 
 # Test images as run on CI.
-image_vim_74_py2:
-	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=2.7-stretch --build-arg VIM_VERSION=7.4 .
-image_vim_80_py2:
-	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=2.7-stretch --build-arg VIM_VERSION=8.0 .
-image_vim_81_py2:
-	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=2.7-stretch --build-arg VIM_VERSION=8.1 .
-image_vim_git_py2:
-	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=2.7-stretch --build-arg VIM_VERSION=git .
 image_vim_74_py36:
 	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.6-stretch --build-arg VIM_VERSION=7.4 .
 image_vim_80_py36:

--- a/after/plugin/UltiSnips_after.vim
+++ b/after/plugin/UltiSnips_after.vim
@@ -1,6 +1,6 @@
 " Called after everything else to reclaim keys (Needed for Supertab)
 
-if exists("b:did_after_plugin_ultisnips_after") || !exists("g:_uspy")
+if exists("b:did_after_plugin_ultisnips_after")
    finish
 endif
 let b:did_after_plugin_ultisnips_after = 1

--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -90,7 +90,7 @@ function! UltiSnips#SnippetsInCurrentScope(...) abort
     if all
       let g:current_ulti_dict_info = {}
     endif
-    py3 UltiSnips_Manager.snippets_in_current_scope(" . all . ")
+    py3 UltiSnips_Manager.snippets_in_current_scope(int(vim.eval("all")))
     return g:current_ulti_dict
 endfunction
 

--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -1,11 +1,11 @@
-if exists("b:did_autoload_ultisnips") || !exists("g:_uspy")
+if exists("b:did_autoload_ultisnips")
     finish
 endif
 let b:did_autoload_ultisnips = 1
 
 " Also import vim as we expect it to be imported in many places.
-exec g:_uspy "import vim"
-exec g:_uspy "from UltiSnips import UltiSnips_Manager"
+py3 "import vim"
+py3 "from UltiSnips import UltiSnips_Manager"
 
 function! s:compensate_for_pum() abort
     """ The CursorMovedI event is not triggered while the popup-menu is visible,
@@ -13,7 +13,7 @@ function! s:compensate_for_pum() abort
     """ to explicitly check for the presence of the popup menu, and update
     """ the vim-state accordingly.
     if pumvisible()
-        exec g:_uspy "UltiSnips_Manager._cursor_moved()"
+        py3 "UltiSnips_Manager._cursor_moved()"
     endif
 endfunction
 
@@ -23,7 +23,7 @@ function! UltiSnips#Edit(bang, ...) abort
     else
         let type = ""
     endif
-    exec g:_uspy "vim.command(\"let file = '%s'\" % UltiSnips_Manager._file_to_edit(vim.eval(\"type\"), vim.eval('a:bang')))"
+    py3 "vim.command(\"let file = '%s'\" % UltiSnips_Manager._file_to_edit(vim.eval(\"type\"), vim.eval('a:bang')))"
 
     if !len(file)
        return
@@ -48,7 +48,7 @@ function! UltiSnips#Edit(bang, ...) abort
 endfunction
 
 function! UltiSnips#AddFiletypes(filetypes) abort
-    exec g:_uspy "UltiSnips_Manager.add_buffer_filetypes('" . a:filetypes . "')"
+    py3 "UltiSnips_Manager.add_buffer_filetypes('" . a:filetypes . "')"
     return ""
 endfunction
 
@@ -69,18 +69,18 @@ function! UltiSnips#FileTypeComplete(arglead, cmdline, cursorpos) abort
 endfunction
 
 function! UltiSnips#ExpandSnippet() abort
-    exec g:_uspy "UltiSnips_Manager.expand()"
+    py3 "UltiSnips_Manager.expand()"
     return ""
 endfunction
 
 function! UltiSnips#ExpandSnippetOrJump() abort
     call s:compensate_for_pum()
-    exec g:_uspy "UltiSnips_Manager.expand_or_jump()"
+    py3 "UltiSnips_Manager.expand_or_jump()"
     return ""
 endfunction
 
 function! UltiSnips#ListSnippets() abort
-    exec g:_uspy "UltiSnips_Manager.list_snippets()"
+    py3 "UltiSnips_Manager.list_snippets()"
     return ""
 endfunction
 
@@ -90,49 +90,49 @@ function! UltiSnips#SnippetsInCurrentScope(...) abort
     if all
       let g:current_ulti_dict_info = {}
     endif
-    exec g:_uspy "UltiSnips_Manager.snippets_in_current_scope(" . all . ")"
+    py3 "UltiSnips_Manager.snippets_in_current_scope(" . all . ")"
     return g:current_ulti_dict
 endfunction
 
 function! UltiSnips#SaveLastVisualSelection() range abort
-    exec g:_uspy "UltiSnips_Manager._save_last_visual_selection()"
+    py3 "UltiSnips_Manager._save_last_visual_selection()"
     return ""
 endfunction
 
 function! UltiSnips#JumpBackwards() abort
     call s:compensate_for_pum()
-    exec g:_uspy "UltiSnips_Manager.jump_backwards()"
+    py3 "UltiSnips_Manager.jump_backwards()"
     return ""
 endfunction
 
 function! UltiSnips#JumpForwards() abort
     call s:compensate_for_pum()
-    exec g:_uspy "UltiSnips_Manager.jump_forwards()"
+    py3 "UltiSnips_Manager.jump_forwards()"
     return ""
 endfunction
 
 function! UltiSnips#AddSnippetWithPriority(trigger, value, description, options, filetype, priority) abort
-    exec g:_uspy "trigger = vim.eval(\"a:trigger\")"
-    exec g:_uspy "value = vim.eval(\"a:value\")"
-    exec g:_uspy "description = vim.eval(\"a:description\")"
-    exec g:_uspy "options = vim.eval(\"a:options\")"
-    exec g:_uspy "filetype = vim.eval(\"a:filetype\")"
-    exec g:_uspy "priority = vim.eval(\"a:priority\")"
-    exec g:_uspy "UltiSnips_Manager.add_snippet(trigger, value, description, options, filetype, priority)"
+    py3 "trigger = vim.eval(\"a:trigger\")"
+    py3 "value = vim.eval(\"a:value\")"
+    py3 "description = vim.eval(\"a:description\")"
+    py3 "options = vim.eval(\"a:options\")"
+    py3 "filetype = vim.eval(\"a:filetype\")"
+    py3 "priority = vim.eval(\"a:priority\")"
+    py3 "UltiSnips_Manager.add_snippet(trigger, value, description, options, filetype, priority)"
     return ""
 endfunction
 
 function! UltiSnips#Anon(value, ...) abort
     " Takes the same arguments as SnippetManager.expand_anon:
     " (value, trigger="", description="", options="")
-    exec g:_uspy "args = vim.eval(\"a:000\")"
-    exec g:_uspy "value = vim.eval(\"a:value\")"
-    exec g:_uspy "UltiSnips_Manager.expand_anon(value, *args)"
+    py3 "args = vim.eval(\"a:000\")"
+    py3 "value = vim.eval(\"a:value\")"
+    py3 "UltiSnips_Manager.expand_anon(value, *args)"
     return ""
 endfunction
 
 function! UltiSnips#CursorMoved() abort
-    exec g:_uspy "UltiSnips_Manager._cursor_moved()"
+    py3 "UltiSnips_Manager._cursor_moved()"
 endf
 
 function! UltiSnips#LeavingBuffer() abort
@@ -140,19 +140,19 @@ function! UltiSnips#LeavingBuffer() abort
     let to_preview = getwinvar(winnr(), '&previewwindow')
 
     if !(from_preview || to_preview)
-        exec g:_uspy "UltiSnips_Manager._leaving_buffer()"
+        py3 "UltiSnips_Manager._leaving_buffer()"
     endif
 endf
 
 function! UltiSnips#LeavingInsertMode() abort
-    exec g:_uspy "UltiSnips_Manager._leaving_insert_mode()"
+    py3 "UltiSnips_Manager._leaving_insert_mode()"
 endfunction
 
 function! UltiSnips#TrackChange() abort
-    exec g:_uspy "UltiSnips_Manager._track_change()"
+    py3 "UltiSnips_Manager._track_change()"
 endfunction
 
 function! UltiSnips#RefreshSnippets() abort
-    exec g:_uspy "UltiSnips_Manager._refresh_snippets()"
+    py3 "UltiSnips_Manager._refresh_snippets()"
 endfunction
 " }}}

--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -4,8 +4,8 @@ endif
 let b:did_autoload_ultisnips = 1
 
 " Also import vim as we expect it to be imported in many places.
-py3 "import vim"
-py3 "from UltiSnips import UltiSnips_Manager"
+py3 import vim
+py3 from UltiSnips import UltiSnips_Manager
 
 function! s:compensate_for_pum() abort
     """ The CursorMovedI event is not triggered while the popup-menu is visible,
@@ -13,7 +13,7 @@ function! s:compensate_for_pum() abort
     """ to explicitly check for the presence of the popup menu, and update
     """ the vim-state accordingly.
     if pumvisible()
-        py3 "UltiSnips_Manager._cursor_moved()"
+        py3 UltiSnips_Manager._cursor_moved()
     endif
 endfunction
 
@@ -23,7 +23,7 @@ function! UltiSnips#Edit(bang, ...) abort
     else
         let type = ""
     endif
-    py3 "vim.command(\"let file = '%s'\" % UltiSnips_Manager._file_to_edit(vim.eval(\"type\"), vim.eval('a:bang')))"
+    py3 vim.command("let file = '%s'" % UltiSnips_Manager._file_to_edit(vim.eval("type"), vim.eval('a:bang')))
 
     if !len(file)
        return
@@ -48,7 +48,7 @@ function! UltiSnips#Edit(bang, ...) abort
 endfunction
 
 function! UltiSnips#AddFiletypes(filetypes) abort
-    py3 "UltiSnips_Manager.add_buffer_filetypes('" . a:filetypes . "')"
+    py3 UltiSnips_Manager.add_buffer_filetypes('" . a:filetypes . "')
     return ""
 endfunction
 
@@ -69,18 +69,18 @@ function! UltiSnips#FileTypeComplete(arglead, cmdline, cursorpos) abort
 endfunction
 
 function! UltiSnips#ExpandSnippet() abort
-    py3 "UltiSnips_Manager.expand()"
+    py3 UltiSnips_Manager.expand()
     return ""
 endfunction
 
 function! UltiSnips#ExpandSnippetOrJump() abort
     call s:compensate_for_pum()
-    py3 "UltiSnips_Manager.expand_or_jump()"
+    py3 UltiSnips_Manager.expand_or_jump()
     return ""
 endfunction
 
 function! UltiSnips#ListSnippets() abort
-    py3 "UltiSnips_Manager.list_snippets()"
+    py3 UltiSnips_Manager.list_snippets()
     return ""
 endfunction
 
@@ -90,49 +90,49 @@ function! UltiSnips#SnippetsInCurrentScope(...) abort
     if all
       let g:current_ulti_dict_info = {}
     endif
-    py3 "UltiSnips_Manager.snippets_in_current_scope(" . all . ")"
+    py3 UltiSnips_Manager.snippets_in_current_scope(" . all . ")
     return g:current_ulti_dict
 endfunction
 
 function! UltiSnips#SaveLastVisualSelection() range abort
-    py3 "UltiSnips_Manager._save_last_visual_selection()"
+    py3 UltiSnips_Manager._save_last_visual_selection()
     return ""
 endfunction
 
 function! UltiSnips#JumpBackwards() abort
     call s:compensate_for_pum()
-    py3 "UltiSnips_Manager.jump_backwards()"
+    py3 UltiSnips_Manager.jump_backwards()
     return ""
 endfunction
 
 function! UltiSnips#JumpForwards() abort
     call s:compensate_for_pum()
-    py3 "UltiSnips_Manager.jump_forwards()"
+    py3 UltiSnips_Manager.jump_forwards()
     return ""
 endfunction
 
 function! UltiSnips#AddSnippetWithPriority(trigger, value, description, options, filetype, priority) abort
-    py3 "trigger = vim.eval(\"a:trigger\")"
-    py3 "value = vim.eval(\"a:value\")"
-    py3 "description = vim.eval(\"a:description\")"
-    py3 "options = vim.eval(\"a:options\")"
-    py3 "filetype = vim.eval(\"a:filetype\")"
-    py3 "priority = vim.eval(\"a:priority\")"
-    py3 "UltiSnips_Manager.add_snippet(trigger, value, description, options, filetype, priority)"
+    py3 trigger = vim.eval("a:trigger")
+    py3 value = vim.eval("a:value")
+    py3 description = vim.eval("a:description")
+    py3 options = vim.eval("a:options")
+    py3 filetype = vim.eval("a:filetype")
+    py3 priority = vim.eval("a:priority")
+    py3 UltiSnips_Manager.add_snippet(trigger, value, description, options, filetype, priority)
     return ""
 endfunction
 
 function! UltiSnips#Anon(value, ...) abort
     " Takes the same arguments as SnippetManager.expand_anon:
     " (value, trigger="", description="", options="")
-    py3 "args = vim.eval(\"a:000\")"
-    py3 "value = vim.eval(\"a:value\")"
-    py3 "UltiSnips_Manager.expand_anon(value, *args)"
+    py3 args = vim.eval("a:000")
+    py3 value = vim.eval("a:value")
+    py3 UltiSnips_Manager.expand_anon(value, *args)
     return ""
 endfunction
 
 function! UltiSnips#CursorMoved() abort
-    py3 "UltiSnips_Manager._cursor_moved()"
+    py3 UltiSnips_Manager._cursor_moved()
 endf
 
 function! UltiSnips#LeavingBuffer() abort
@@ -140,19 +140,19 @@ function! UltiSnips#LeavingBuffer() abort
     let to_preview = getwinvar(winnr(), '&previewwindow')
 
     if !(from_preview || to_preview)
-        py3 "UltiSnips_Manager._leaving_buffer()"
+        py3 UltiSnips_Manager._leaving_buffer()
     endif
 endf
 
 function! UltiSnips#LeavingInsertMode() abort
-    py3 "UltiSnips_Manager._leaving_insert_mode()"
+    py3 UltiSnips_Manager._leaving_insert_mode()
 endfunction
 
 function! UltiSnips#TrackChange() abort
-    py3 "UltiSnips_Manager._track_change()"
+    py3 UltiSnips_Manager._track_change()
 endfunction
 
 function! UltiSnips#RefreshSnippets() abort
-    py3 "UltiSnips_Manager._refresh_snippets()"
+    py3 UltiSnips_Manager._refresh_snippets()
 endfunction
 " }}}

--- a/autoload/UltiSnips/map_keys.vim
+++ b/autoload/UltiSnips/map_keys.vim
@@ -1,4 +1,4 @@
-if exists("b:did_autoload_ultisnips_map_keys") || !exists("g:_uspy")
+if exists("b:did_autoload_ultisnips_map_keys")
    finish
 endif
 let b:did_autoload_ultisnips_map_keys = 1

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -58,7 +58,7 @@ UltiSnips                                      *snippet* *snippets* *UltiSnips*
 
 This plugin only works if 'compatible' is not set.
 {Vi does not have any of these features}
-{only available when |+python| or |+python3| have been enabled at compile time}
+{only available when |+python3| has been enabled at compile time}
 
 
 ==============================================================================
@@ -89,21 +89,13 @@ http://vimcasts.org/episodes/ultisnips-visual-placeholder/
 1.1 Requirements                                     *UltiSnips-requirements*
 ----------------
 
-This plugin works with Vim version 7.4 or later. It only works if the
-'compatible' setting is not set.
+This plugin works with Vim version 7.4 or later with Python 3 support enabled.
+It only works if the 'compatible' setting is not set.
 
-This plugin is tested against Python 2.7 and 3.6 in Vim 7.4 and 8. All other
-combinations are unsupported, but might work.
-
-The Python 2.x or Python 3.x interface must be available. In other words, Vim
-must be compiled with either the |+python| feature or the |+python3| feature.
+The Python 3.x interface must be available. In other words, Vim
+must be compiled with the |+python3| feature.
 The following commands show how to test if you have python compiled in Vim.
 They print '1' if the python version is compiled in, '0' if not.
-
-Test if Vim is compiled with python version 2.x: >
-    :echo has("python")
-The python version Vim is linked against can be found with: >
-    :py import sys; print(sys.version)
 
 Test if Vim is compiled with python version 3.x: >
     :echo has("python3")
@@ -112,17 +104,6 @@ The python version Vim is linked against can be found with: >
 
 Note that Vim is maybe not using your system-wide installed python version, so
 make sure to check the Python version inside of Vim.
-
-UltiSnips attempts to auto-detect which python version is compiled into Vim.
-Unfortunately, in some versions of Vim this detection does not work.
-In that case you have to explicitly tell UltiSnips which version to use using
-the 'UltiSnipsUsePythonVersion' global variable.
-
-To use python version 2.x: >
-   let g:UltiSnipsUsePythonVersion = 2
-
-To use python version 3.x: >
-   let g:UltiSnipsUsePythonVersion = 3
 
 
 1.2 Acknowledgments                               *UltiSnips-acknowledgments*

--- a/docker/build_vim.sh
+++ b/docker/build_vim.sh
@@ -5,22 +5,19 @@ set -o verbose
 
 cd /src/vim
 
-if [[ $PYTHON_VERSION =~ ^2\. ]]; then
-   PYTHON_BUILD_CONFIG="--enable-pythoninterp"
-else
-   PYTHON_BUILD_CONFIG="--enable-python3interp"
-fi
+PYTHON_BUILD_CONFIG="--enable-python3interp"
 
 export CFLAGS="$(python-config --cflags)"
 echo $CFLAGS
 ./configure \
+   --disable-gpm \
    --disable-nls \
    --disable-sysmouse \
-   --disable-gpm \
    --enable-gui=no \
    --enable-multibyte \
+   --enable-python3interp \
    --with-features=huge \
    --with-tlib=ncurses \
    --without-x \
-   $PYTHON_BUILD_CONFIG || cat $(find . -name 'config.log')
+   || cat $(find . -name 'config.log')
 make install

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,7 @@
 python_version = 3.7
 warn_return_any = True
 warn_unused_configs = True
+mypy_path=pythonx/UltiSnips
 
 [mypy-vim]
 ignore_missing_imports = True

--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -10,36 +10,6 @@ if version < 704
    finish
 endif
 
-if !exists("g:UltiSnipsUsePythonVersion")
-   let g:_uspy=":py3 "
-   if !has("python3")
-       if !has("python")
-           if !exists("g:UltiSnipsNoPythonWarning")
-               echohl WarningMsg
-               echom  "UltiSnips requires py >= 2.7 or py3"
-               echohl None
-           endif
-           unlet g:_uspy
-           finish
-       endif
-       let g:_uspy=":py "
-   endif
-else
-   " Use user-provided value, but check if it's available.
-   " This uses `has()`, because e.g. `exists(":python3")` is always 2.
-   if g:UltiSnipsUsePythonVersion == 2 && has('python')
-       let g:_uspy=":python "
-   elseif g:UltiSnipsUsePythonVersion == 3 && has('python3')
-       let g:_uspy=":python3 "
-   endif
-   if !exists('g:_uspy')
-       echohl WarningMsg
-       echom  "UltiSnips: the Python version from g:UltiSnipsUsePythonVersion (".g:UltiSnipsUsePythonVersion.") is not available."
-       echohl None
-       finish
-   endif
-endif
-
 " The Commands we define.
 command! -bang -nargs=? -complete=customlist,UltiSnips#FileTypeComplete UltiSnipsEdit
     \ :call UltiSnips#Edit(<q-bang>, <q-args>)

--- a/pylintrc
+++ b/pylintrc
@@ -144,12 +144,6 @@ max-module-lines=1000
 indent-string='    '
 
 
-[MISCELLANEOUS]
-
-# List of note tags to take in consideration, separated by a comma.
-notes=TODO
-
-
 [SIMILARITIES]
 
 # Minimum lines number of a similarity.

--- a/pylintrc
+++ b/pylintrc
@@ -48,8 +48,7 @@ disable=
    too-many-locals,
    too-many-public-methods, 
    too-many-return-statements,
-   too-many-statements,
-   useless-object-inheritance,
+   too-many-statements
 
 
 

--- a/pythonx/UltiSnips/buffer_proxy.py
+++ b/pythonx/UltiSnips/buffer_proxy.py
@@ -2,7 +2,7 @@
 
 import vim
 from UltiSnips import vim_helper
-from UltiSnips.compatibility import as_unicode, as_vimencoding
+from UltiSnips.compatibility import as_unicode
 from UltiSnips.position import Position
 from UltiSnips.diff import diff
 
@@ -96,11 +96,11 @@ class VimBufferProxy(vim_helper.VimBuffer):
         changes and applies them to the current snippet stack.
         """
         if isinstance(key, slice):
-            value = [as_vimencoding(line) for line in value]
+            value = [line for line in value]
             changes = list(self._get_diff(key.start, key.stop, value))
             self._buffer[key.start : key.stop] = [line.strip("\n") for line in value]
         else:
-            value = as_vimencoding(value)
+            value = value
             changes = list(self._get_line_diff(key, self._buffer[key], value))
             self._buffer[key] = value
 
@@ -147,7 +147,7 @@ class VimBufferProxy(vim_helper.VimBuffer):
             line_number = len(self)
         if not isinstance(line, list):
             line = [line]
-        self[line_number:line_number] = [as_vimencoding(l) for l in line]
+        self[line_number:line_number] = [l for l in line]
 
     def __delitem__(self, key):
         if isinstance(key, slice):

--- a/pythonx/UltiSnips/buffer_proxy.py
+++ b/pythonx/UltiSnips/buffer_proxy.py
@@ -2,7 +2,6 @@
 
 import vim
 from UltiSnips import vim_helper
-from UltiSnips.compatibility import as_unicode
 from UltiSnips.position import Position
 from UltiSnips.diff import diff
 
@@ -122,10 +121,7 @@ class VimBufferProxy(vim_helper.VimBuffer):
         """
         Just passing call to the vim.current.window.buffer.__getitem__.
         """
-        if isinstance(key, slice):
-            return [as_unicode(l) for l in self._buffer[key.start : key.stop]]
-        else:
-            return as_unicode(self._buffer[key])
+        return self._buffer[key]
 
     def __getslice__(self, i, j):
         """

--- a/pythonx/UltiSnips/compatibility.py
+++ b/pythonx/UltiSnips/compatibility.py
@@ -6,12 +6,14 @@ versions as possible."""
 
 import vim
 
+
 def _vim_dec(string):
     """Decode 'string' using &encoding."""
     # We don't have the luxury here of failing, everything
     # falls apart if we don't return a bytearray from the
     # passed in string
     return string.decode(vim.eval("&encoding"), "replace")
+
 
 def _vim_enc(bytearray):
     """Encode 'string' using &encoding."""
@@ -20,6 +22,7 @@ def _vim_enc(bytearray):
     # in bytearray
     return bytearray.encode(vim.eval("&encoding"), "replace")
 
+
 def col2byte(line, col):
     """Convert a valid column index into a byte index inside of vims
     buffer."""
@@ -27,12 +30,14 @@ def col2byte(line, col):
     pre_chars = (vim.current.buffer[line - 1] + "  ")[:col]
     return len(_vim_enc(pre_chars))
 
+
 def byte2col(line, nbyte):
     """Convert a column into a byteidx suitable for a mark or cursor
     position inside of vim."""
     line = vim.current.buffer[line - 1]
     raw_bytes = _vim_enc(line)[:nbyte]
     return len(_vim_dec(raw_bytes))
+
 
 def as_unicode(string):
     """Return 'string' as unicode instance."""

--- a/pythonx/UltiSnips/compatibility.py
+++ b/pythonx/UltiSnips/compatibility.py
@@ -37,10 +37,3 @@ def byte2col(line, nbyte):
     line = vim.current.buffer[line - 1]
     raw_bytes = _vim_enc(line)[:nbyte]
     return len(_vim_dec(raw_bytes))
-
-
-def as_unicode(string):
-    """Return 'string' as unicode instance."""
-    if isinstance(string, bytes):
-        return _vim_dec(string)
-    return str(string)

--- a/pythonx/UltiSnips/compatibility.py
+++ b/pythonx/UltiSnips/compatibility.py
@@ -4,102 +4,38 @@
 """This file contains compatibility code to stay compatible with as many python
 versions as possible."""
 
-import sys
+import vim
 
-import vim  # pylint:disable=import-error
+def _vim_dec(string):
+    """Decode 'string' using &encoding."""
+    # We don't have the luxury here of failing, everything
+    # falls apart if we don't return a bytearray from the
+    # passed in string
+    return string.decode(vim.eval("&encoding"), "replace")
 
-if sys.version_info >= (3, 0):
+def _vim_enc(bytearray):
+    """Encode 'string' using &encoding."""
+    # We don't have the luxury here of failing, everything
+    # falls apart if we don't return a string from the passed
+    # in bytearray
+    return bytearray.encode(vim.eval("&encoding"), "replace")
 
-    def _vim_dec(string):
-        """Decode 'string' using &encoding."""
-        # We don't have the luxury here of failing, everything
-        # falls apart if we don't return a bytearray from the
-        # passed in string
-        return string.decode(vim.eval("&encoding"), "replace")
+def col2byte(line, col):
+    """Convert a valid column index into a byte index inside of vims
+    buffer."""
+    # We pad the line so that selecting the +1 st column still works.
+    pre_chars = (vim.current.buffer[line - 1] + "  ")[:col]
+    return len(_vim_enc(pre_chars))
 
-    def _vim_enc(bytearray):
-        """Encode 'string' using &encoding."""
-        # We don't have the luxury here of failing, everything
-        # falls apart if we don't return a string from the passed
-        # in bytearray
-        return bytearray.encode(vim.eval("&encoding"), "replace")
+def byte2col(line, nbyte):
+    """Convert a column into a byteidx suitable for a mark or cursor
+    position inside of vim."""
+    line = vim.current.buffer[line - 1]
+    raw_bytes = _vim_enc(line)[:nbyte]
+    return len(_vim_dec(raw_bytes))
 
-    def open_ascii_file(filename, mode):
-        """Opens a file in "r" mode."""
-        return open(filename, mode, encoding="utf-8")
-
-    def col2byte(line, col):
-        """Convert a valid column index into a byte index inside of vims
-        buffer."""
-        # We pad the line so that selecting the +1 st column still works.
-        pre_chars = (vim.current.buffer[line - 1] + "  ")[:col]
-        return len(_vim_enc(pre_chars))
-
-    def byte2col(line, nbyte):
-        """Convert a column into a byteidx suitable for a mark or cursor
-        position inside of vim."""
-        line = vim.current.buffer[line - 1]
-        raw_bytes = _vim_enc(line)[:nbyte]
-        return len(_vim_dec(raw_bytes))
-
-    def as_unicode(string):
-        """Return 'string' as unicode instance."""
-        if isinstance(string, bytes):
-            return _vim_dec(string)
-        return str(string)
-
-    def as_vimencoding(string):
-        """Return 'string' as Vim internal encoding."""
-        return string
-
-
-else:
-    import warnings
-
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
-
-    def _vim_dec(string):
-        """Decode 'string' using &encoding."""
-        try:
-            return string.decode(vim.eval("&encoding"))
-        except UnicodeDecodeError:
-            # At least we tried. There might be some problems down the road now
-            return string
-
-    def _vim_enc(string):
-        """Encode 'string' using &encoding."""
-        try:
-            return string.encode(vim.eval("&encoding"))
-        except UnicodeDecodeError:
-            return string
-        except UnicodeEncodeError:
-            return string
-
-    def open_ascii_file(filename, mode):
-        """Opens a file in "r" mode."""
-        return open(filename, mode)
-
-    def col2byte(line, col):
-        """Convert a valid column index into a byte index inside of vims
-        buffer."""
-        # We pad the line so that selecting the +1 st column still works.
-        pre_chars = _vim_dec(vim.current.buffer[line - 1] + "  ")[:col]
-        return len(_vim_enc(pre_chars))
-
-    def byte2col(line, nbyte):
-        """Convert a column into a byteidx suitable for a mark or cursor
-        position inside of vim."""
-        line = vim.current.buffer[line - 1]
-        if nbyte >= len(line):  # This is beyond end of line
-            return nbyte
-        return len(_vim_dec(line[:nbyte]))
-
-    def as_unicode(string):
-        """Return 'string' as unicode instance."""
-        if isinstance(string, str):
-            return _vim_dec(string)
-        return unicode(string)
-
-    def as_vimencoding(string):
-        """Return 'string' as unicode instance."""
-        return _vim_enc(string)
+def as_unicode(string):
+    """Return 'string' as unicode instance."""
+    if isinstance(string, bytes):
+        return _vim_dec(string)
+    return str(string)

--- a/pythonx/UltiSnips/debug.py
+++ b/pythonx/UltiSnips/debug.py
@@ -9,8 +9,6 @@ They should never be used in production code.
 
 import sys
 
-from UltiSnips.compatibility import as_unicode
-
 DUMP_FILENAME = (
     "/tmp/file.txt"
     if not sys.platform.lower().startswith("win")
@@ -29,7 +27,7 @@ def echo_to_hierarchy(text_object):
 
     def _do_print(text_object, indent=""):
         """prints recursively."""
-        debug(indent + as_unicode(text_object))
+        debug(indent + text_object)
         try:
             for child in text_object._children:
                 _do_print(child, indent=indent + "  ")
@@ -41,7 +39,6 @@ def echo_to_hierarchy(text_object):
 
 def debug(msg):
     """Dumb 'msg' into the debug file."""
-    msg = as_unicode(msg)
     with open(DUMP_FILENAME, "ab") as dump_file:
         dump_file.write((msg + "\n").encode("utf-8"))
 

--- a/pythonx/UltiSnips/indent_util.py
+++ b/pythonx/UltiSnips/indent_util.py
@@ -6,7 +6,7 @@
 from UltiSnips import vim_helper
 
 
-class IndentUtil(object):
+class IndentUtil:
 
     """Utility class for dealing properly with indentation."""
 

--- a/pythonx/UltiSnips/position.py
+++ b/pythonx/UltiSnips/position.py
@@ -36,12 +36,9 @@ class Position:
         assert isinstance(pos, Position)
         if self.line == pos.line:
             return Position(0, self.col - pos.col)
-        else:
-            if self > pos:
-                return Position(self.line - pos.line, self.col)
-            else:
-                return Position(self.line - pos.line, pos.col)
-        return Position(self.line - pos.line, self.col - pos.col)
+        if self > pos:
+            return Position(self.line - pos.line, self.col)
+        return Position(self.line - pos.line, pos.col)
 
     def __add__(self, pos):
         assert isinstance(pos, Position)

--- a/pythonx/UltiSnips/position.py
+++ b/pythonx/UltiSnips/position.py
@@ -5,7 +5,7 @@
 index) and provides methods for moving them around."""
 
 
-class Position(object):
+class Position:
 
     """See module docstring."""
 

--- a/pythonx/UltiSnips/snippet/definition/base.py
+++ b/pythonx/UltiSnips/snippet/definition/base.py
@@ -9,7 +9,6 @@ import vim
 import textwrap
 
 from UltiSnips import vim_helper
-from UltiSnips.compatibility import as_unicode
 from UltiSnips.indent_util import IndentUtil
 from UltiSnips.text import escape
 from UltiSnips.text_objects import SnippetInstance
@@ -97,9 +96,9 @@ class SnippetDefinition:
         actions,
     ):
         self._priority = int(priority)
-        self._trigger = as_unicode(trigger)
-        self._value = as_unicode(value)
-        self._description = as_unicode(description)
+        self._trigger = trigger
+        self._value = value
+        self._description = description
         self._opts = options
         self._matched = ""
         self._last_re = None

--- a/pythonx/UltiSnips/snippet/definition/base.py
+++ b/pythonx/UltiSnips/snippet/definition/base.py
@@ -19,7 +19,7 @@ from UltiSnips.text_objects.python_code import SnippetUtilForAction
 __WHITESPACE_SPLIT = re.compile(r"\s")
 
 
-class _SnippetUtilCursor(object):
+class _SnippetUtilCursor:
     def __init__(self, cursor):
         self._cursor = [cursor[0] - 1, cursor[1]]
         self._set = False
@@ -77,7 +77,7 @@ def _words_for_line(trigger, before, num_words=None):
         return before[len(before_words) :].strip()
 
 
-class SnippetDefinition(object):
+class SnippetDefinition:
 
     """Represents a snippet as parsed from a file."""
 
@@ -396,9 +396,7 @@ class SnippetDefinition(object):
             snip = self._execute_action(
                 self._actions["pre_expand"], self._context, locals
             )
-
             self._context = snip.context
-
             return snip.cursor.is_set()
         else:
             return False

--- a/pythonx/UltiSnips/snippet/parsing/lexer.py
+++ b/pythonx/UltiSnips/snippet/parsing/lexer.py
@@ -7,7 +7,6 @@ definitions into logical units called Tokens."""
 import string
 import re
 
-from UltiSnips.compatibility import as_unicode
 from UltiSnips.position import Position
 from UltiSnips.text import unescape
 
@@ -17,7 +16,7 @@ class _TextIterator:
     """Helper class to make iterating over text easier."""
 
     def __init__(self, text, offset):
-        self._text = as_unicode(text)
+        self._text = text
         self._line = offset.line
         self._col = offset.col
 
@@ -117,7 +116,7 @@ class Token:
     """Represents a Token as parsed from a snippet definition."""
 
     def __init__(self, gen, indent):
-        self.initial_text = as_unicode("")
+        self.initial_text = ""
         self.start = gen.pos
         self._parse(gen, indent)
         self.end = gen.pos

--- a/pythonx/UltiSnips/snippet/parsing/lexer.py
+++ b/pythonx/UltiSnips/snippet/parsing/lexer.py
@@ -12,7 +12,7 @@ from UltiSnips.position import Position
 from UltiSnips.text import unescape
 
 
-class _TextIterator(object):
+class _TextIterator:
 
     """Helper class to make iterating over text easier."""
 
@@ -40,8 +40,6 @@ class _TextIterator(object):
             self._col += 1
         self._idx += 1
         return rv
-
-    next = __next__  # for python2
 
     def peek(self, count=1):
         """Returns the next 'count' characters without advancing the stream."""
@@ -114,7 +112,7 @@ def _parse_till_unescaped_char(stream, chars):
     return rv, char
 
 
-class Token(object):
+class Token:
 
     """Represents a Token as parsed from a snippet definition."""
 

--- a/pythonx/UltiSnips/snippet/source/base.py
+++ b/pythonx/UltiSnips/snippet/source/base.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from UltiSnips.snippet.source.snippet_dictionary import SnippetDictionary
 
 
-class SnippetSource(object):
+class SnippetSource:
 
     """See module docstring."""
 

--- a/pythonx/UltiSnips/snippet/source/file/base.py
+++ b/pythonx/UltiSnips/snippet/source/file/base.py
@@ -58,7 +58,8 @@ class SnippetFileSource(SnippetSource):
 
     def _parse_snippets(self, ft, filename):
         """Parse the 'filename' for the given 'ft'."""
-        file_data = compatibility.open_ascii_file(filename, "r").read()
+        with open(filename, "r", encoding="utf-8") as to_read:
+            file_data = to_read.read()
         self._snippets[ft]  # Make sure the dictionary exists
         for event, data in self._parse_snippet_file(file_data, filename):
             if event == "error":

--- a/pythonx/UltiSnips/snippet/source/snippet_dictionary.py
+++ b/pythonx/UltiSnips/snippet/source/snippet_dictionary.py
@@ -4,7 +4,7 @@
 """Implements a container for parsed snippets."""
 
 
-class SnippetDictionary(object):
+class SnippetDictionary:
 
     """See module docstring."""
 

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from contextlib import contextmanager
 import os
 import platform
-import sys
 import vim
 
 from UltiSnips import vim_helper
@@ -60,7 +59,7 @@ def _ask_snippets(snippets):
 
 # TODO(sirver): This class is still too long. It should only contain public
 # facing methods, most of the private methods should be moved outside of it.
-class SnippetManager(object):
+class SnippetManager:
 
     """The main entry point for all UltiSnips functionality.
 
@@ -726,8 +725,8 @@ class SnippetManager(object):
             with use_proxy_buffer(self._active_snippets, self._vstate):
                 with self._action_context():
                     snippet.do_post_expand(
-                        snippet_instance._start,
-                        snippet_instance._end,
+                        snippet_instance.start,
+                        snippet_instance.end,
                         self._active_snippets,
                     )
 
@@ -886,12 +885,8 @@ class SnippetManager(object):
         except UnicodeDecodeError:
             return
 
-        if sys.version_info >= (3, 0):
-            if isinstance(inserted_char, bytes):
-                return
-        else:
-            if not isinstance(inserted_char, unicode):
-                return
+        if isinstance(inserted_char, bytes):
+            return
 
         try:
             if inserted_char == "":

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -12,7 +12,6 @@ import vim
 from UltiSnips import vim_helper
 from UltiSnips import err_to_scratch_buffer
 from UltiSnips.diff import diff, guess_edit
-from UltiSnips.compatibility import as_unicode
 from UltiSnips.position import Position
 from UltiSnips.snippet.definition import UltiSnipsSnippetDefinition
 from UltiSnips.snippet.source import (
@@ -50,8 +49,7 @@ def _ask_snippets(snippets):
     """Given a list of snippets, ask the user which one they want to use, and
     return it."""
     display = [
-        as_unicode("%i: %s (%s)")
-        % (i + 1, escape(s.description, "\\"), escape(s.location, "\\"))
+        "%i: %s (%s)" % (i + 1, escape(s.description, "\\"), escape(s.location, "\\"))
         for i, s in enumerate(snippets)
     ]
     return _ask_user(snippets, display)
@@ -164,8 +162,7 @@ class SnippetManager:
 
             location = snip.location if snip.location else ""
 
-            key = as_unicode(snip.trigger)
-            description = as_unicode(description)
+            key = snip.trigger
 
             # remove surrounding "" or '' in snippet description if it exists
             if len(description) > 2:
@@ -173,20 +170,18 @@ class SnippetManager:
                     description = description[1:-1]
 
             vim_helper.command(
-                as_unicode("let g:current_ulti_dict['{key}'] = '{val}'").format(
+                "let g:current_ulti_dict['{key}'] = '{val}'".format(
                     key=key.replace("'", "''"), val=description.replace("'", "''")
                 )
             )
 
             if search_all:
                 vim_helper.command(
-                    as_unicode(
-                        (
-                            "let g:current_ulti_dict_info['{key}'] = {{"
-                            "'description': '{description}',"
-                            "'location': '{location}',"
-                            "}}"
-                        )
+                    (
+                        "let g:current_ulti_dict_info['{key}'] = {{"
+                        "'description': '{description}',"
+                        "'location': '{location}',"
+                        "}}"
                     ).format(
                         key=key.replace("'", "''"),
                         location=location.replace("'", "''"),
@@ -849,8 +844,7 @@ class SnippetManager:
         if len(potentials) > 1:
             files = sorted(potentials)
             formatted = [
-                as_unicode("%i: %s") % (i, escape(fn, "\\"))
-                for i, fn in enumerate(files, 1)
+                "%i: %s" % (i, escape(fn, "\\")) for i, fn in enumerate(files, 1)
             ]
             file_to_edit = _ask_user(files, formatted)
             if file_to_edit is None:
@@ -881,7 +875,7 @@ class SnippetManager:
         self._should_update_textobjects = True
 
         try:
-            inserted_char = vim_helper.as_unicode(vim_helper.eval("v:char"))
+            inserted_char = vim_helper.eval("v:char")
         except UnicodeDecodeError:
             return
 

--- a/pythonx/UltiSnips/test_diff.py
+++ b/pythonx/UltiSnips/test_diff.py
@@ -29,7 +29,7 @@ def transform(a, cmds):
 import unittest
 
 
-class _BaseGuessing(object):
+class _BaseGuessing:
     def runTest(self):
         rv, es = guess_edit(
             self.initial_line, self.a, self.b, Position(*self.ppos), Position(*self.pos)
@@ -73,7 +73,7 @@ class TestGuessing_DeleteOneChar(_BaseGuessing, unittest.TestCase):
     wanted = (("D", 0, 5, " "),)
 
 
-class _Base(object):
+class _Base:
     def runTest(self):
         es = diff(self.a, self.b)
         tr = transform(self.a, es)

--- a/pythonx/UltiSnips/test_diff.py
+++ b/pythonx/UltiSnips/test_diff.py
@@ -7,6 +7,7 @@ import unittest
 
 from diff import diff, guess_edit
 from position import Position
+from typing import List
 
 
 def transform(a, cmds):
@@ -26,9 +27,6 @@ def transform(a, cmds):
     return "\n".join(buf)
 
 
-import unittest
-
-
 class _BaseGuessing:
     def runTest(self):
         rv, es = guess_edit(
@@ -39,7 +37,8 @@ class _BaseGuessing:
 
 
 class TestGuessing_Noop0(_BaseGuessing, unittest.TestCase):
-    a, b = [], []
+    a: List[str] = []
+    b: List[str] = []
     initial_line = 0
     ppos, pos = (0, 6), (0, 7)
     wanted = ()

--- a/pythonx/UltiSnips/test_position.py
+++ b/pythonx/UltiSnips/test_position.py
@@ -8,7 +8,7 @@ import unittest
 from position import Position
 
 
-class _MPBase(object):
+class _MPBase:
     def runTest(self):
         obj = Position(*self.obj)
         for pivot, delta, wanted in self.steps:

--- a/pythonx/UltiSnips/text.py
+++ b/pythonx/UltiSnips/text.py
@@ -51,7 +51,7 @@ def head_tail(line):
     return head, tail
 
 
-class LineIterator(object):
+class LineIterator:
 
     """Convenience class that keeps track of line numbers in files."""
 
@@ -68,8 +68,6 @@ class LineIterator(object):
             self._line_index += 1
             return self._lines[self._line_index]
         raise StopIteration()
-
-    next = __next__  # for python2
 
     @property
     def line_index(self):

--- a/pythonx/UltiSnips/text_objects/base.py
+++ b/pythonx/UltiSnips/text_objects/base.py
@@ -41,7 +41,7 @@ def _replace_text(buf, start, end, text):
 # pylint: disable=protected-access
 
 
-class TextObject(object):
+class TextObject:
 
     """Represents any object in the text that has a span in any ways."""
 

--- a/pythonx/UltiSnips/text_objects/python_code.py
+++ b/pythonx/UltiSnips/text_objects/python_code.py
@@ -14,7 +14,7 @@ from UltiSnips.vim_state import _Placeholder
 import UltiSnips.snippet_manager
 
 
-class _Tabs(object):
+class _Tabs:
 
     """Allows access to tabstop content via t[] inside of python code."""
 
@@ -48,7 +48,7 @@ class SnippetUtilForAction(dict):
         self.cursor.preserve()
 
 
-class SnippetUtil(object):
+class SnippetUtil:
 
     """Provides easy access to indentation, etc.
 

--- a/pythonx/UltiSnips/text_objects/python_code.py
+++ b/pythonx/UltiSnips/text_objects/python_code.py
@@ -7,7 +7,6 @@ import os
 from collections import namedtuple
 
 from UltiSnips import vim_helper
-from UltiSnips.compatibility import as_unicode
 from UltiSnips.indent_util import IndentUtil
 from UltiSnips.text_objects.base import NoneditableTextObject
 from UltiSnips.vim_state import _Placeholder
@@ -272,11 +271,9 @@ class PythonCode(NoneditableTextObject):
                 e.snippet_code = code
                 raise
 
-        rv = as_unicode(
-            self._snip.rv
-            if self._snip._rv_changed  # pylint:disable=protected-access
-            else as_unicode(self._locals["res"])
-        )
+        rv = (
+            self._snip.rv if self._snip._rv_changed else self._locals["res"]
+        )  # pylint:disable=protected-access
 
         if ct != rv:
             self.overwrite(buf, rv)

--- a/pythonx/UltiSnips/text_objects/shell_code.py
+++ b/pythonx/UltiSnips/text_objects/shell_code.py
@@ -9,7 +9,6 @@ from subprocess import Popen, PIPE
 import stat
 import tempfile
 
-from UltiSnips.compatibility import as_unicode
 from UltiSnips.text_objects.base import NoneditableTextObject
 
 
@@ -41,7 +40,7 @@ def _run_shell_command(cmd, tmpdir):
     proc.wait()
     stdout, _ = proc.communicate()
     os.unlink(path)
-    return _chomp(as_unicode(stdout))
+    return _chomp(stdout.decode("utf-8"))
 
 
 def _get_tmp():

--- a/pythonx/UltiSnips/text_objects/transformation.py
+++ b/pythonx/UltiSnips/text_objects/transformation.py
@@ -79,7 +79,7 @@ _DOLLAR = re.compile(r"\$(\d+)", re.DOTALL)
 _CONDITIONAL = re.compile(r"\(\?(\d+):", re.DOTALL)
 
 
-class _CleverReplace(object):
+class _CleverReplace:
 
     """Mimics TextMates replace syntax."""
 
@@ -120,7 +120,7 @@ class _CleverReplace(object):
 UNIDECODE_ALERT_RAISED = False
 
 
-class TextObjectTransformation(object):
+class TextObjectTransformation:
 
     """Base class for Transformations and ${VISUAL}."""
 

--- a/pythonx/UltiSnips/vim_helper.py
+++ b/pythonx/UltiSnips/vim_helper.py
@@ -8,13 +8,13 @@ import re
 import vim  # pylint:disable=import-error
 from vim import error  # pylint:disable=import-error,unused-import
 
-from UltiSnips.compatibility import col2byte, byte2col, as_unicode, as_vimencoding
+from UltiSnips.compatibility import col2byte, byte2col, as_unicode
 from UltiSnips.position import Position
 
 from contextlib import contextmanager
 
 
-class VimBuffer(object):
+class VimBuffer:
 
     """Wrapper around the current Vim buffer."""
 
@@ -31,10 +31,10 @@ class VimBuffer(object):
     def __setitem__(self, idx, text):
         if isinstance(idx, slice):  # Py3
             return self.__setslice__(idx.start, idx.stop, text)
-        vim.current.buffer[idx] = as_vimencoding(text)
+        vim.current.buffer[idx] = text
 
     def __setslice__(self, i, j, text):  # pylint:disable=no-self-use
-        vim.current.buffer[i:j] = [as_vimencoding(l) for l in text]
+        vim.current.buffer[i:j] = [l for l in text]
 
     def __len__(self):
         return len(vim.current.buffer)
@@ -126,12 +126,12 @@ def escape(inp):
 
 def command(cmd):
     """Wraps vim.command."""
-    return as_unicode(vim.command(as_vimencoding(cmd)))
+    return as_unicode(vim.command(cmd))
 
 
 def eval(text):
     """Wraps vim.eval."""
-    rv = vim.eval(as_vimencoding(text))
+    rv = vim.eval(text)
     if not isinstance(rv, (dict, list)):
         return as_unicode(rv)
     return rv
@@ -139,7 +139,7 @@ def eval(text):
 
 def bindeval(text):
     """Wraps vim.bindeval."""
-    rv = vim.bindeval(as_vimencoding(text))
+    rv = vim.bindeval(text)
     if not isinstance(rv, (dict, list)):
         return as_unicode(rv)
     return rv

--- a/pythonx/UltiSnips/vim_state.py
+++ b/pythonx/UltiSnips/vim_state.py
@@ -6,7 +6,7 @@
 from collections import deque, namedtuple
 
 from UltiSnips import vim_helper
-from UltiSnips.compatibility import as_unicode, byte2col
+from UltiSnips.compatibility import byte2col
 from UltiSnips.position import Position
 
 _Placeholder = namedtuple("_FrozenPlaceholder", ["current_text", "start", "end"])
@@ -114,7 +114,7 @@ class VisualContentPreserver:
     def reset(self):
         """Forget the preserved state."""
         self._mode = ""
-        self._text = as_unicode("")
+        self._text = ""
         self._placeholder = None
 
     def conserve(self):

--- a/pythonx/UltiSnips/vim_state.py
+++ b/pythonx/UltiSnips/vim_state.py
@@ -28,7 +28,7 @@ class VimPosition(Position):
         return self._mode
 
 
-class VimState(object):
+class VimState:
 
     """Caches some state information from Vim to better guess what editing
     tasks the user might have done in the last step."""
@@ -103,7 +103,7 @@ class VimState(object):
         return self._lvb[:]
 
 
-class VisualContentPreserver(object):
+class VisualContentPreserver:
 
     """Saves the current visual selection and the selection mode it was done in
     (e.g. line selection, block selection or regular selection.)"""

--- a/test/constant.py
+++ b/test/constant.py
@@ -1,5 +1,3 @@
-import sys
-
 # Some constants for better reading
 BS = "\x7f"
 ESC = "\x1b"
@@ -20,5 +18,3 @@ EA = "#"  # Expand anonymous
 
 COMPL_KW = chr(24) + chr(14)
 COMPL_ACCEPT = chr(25)
-
-PYTHON3 = sys.version_info >= (3, 0)

--- a/test/test_Plugin.py
+++ b/test/test_Plugin.py
@@ -3,13 +3,6 @@ import sys
 from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
-PYTHON3 = sys.version_info >= (3, 0)
-
-
-def python3():
-    if PYTHON3:
-        return "Test does not work on python3."
-
 
 class Plugin_SuperTab_SimpleTest(_VimTest):
     plugins = ["ervandew/supertab"]

--- a/test/test_SnippetOptions.py
+++ b/test/test_SnippetOptions.py
@@ -168,7 +168,7 @@ class No_Tab_Expand_ET_SW_TS(_No_Tab_Expand):
     wanted = "\t\tExpand\tme!\t"
 
 
-class _TabExpand_RealWorld(object):
+class _TabExpand_RealWorld:
     snippets = (
         "hi",
         r"""hi

--- a/test/test_UltiSnipFunc.py
+++ b/test/test_UltiSnipFunc.py
@@ -139,15 +139,15 @@ class AddNewSnippetSource(_VimTest):
         "blumba"
         + EX
         + ESC
-        + ":%(python)s UltiSnips_Manager.register_snippet_source("
+        + ":py3 UltiSnips_Manager.register_snippet_source("
         + "'temp', MySnippetSource())\n"
         + "oblumba"
         + EX
         + ESC
-        + ":%(python)s UltiSnips_Manager.unregister_snippet_source('temp')\n"
+        + ":py3 UltiSnips_Manager.unregister_snippet_source('temp')\n"
         + "oblumba"
         + EX
-    ) % {"python": "py3" if PYTHON3 else "py"}
+    )
     wanted = "blumba" + EX + "\n" + "this is a dynamic snippet" + "\n" + "blumba" + EX
 
     def _extra_vim_config(self, vim_config):
@@ -169,5 +169,4 @@ class MySnippetSource(SnippetSource):
     return []
 """,
         )
-        pyfile = "py3file" if PYTHON3 else "pyfile"
-        vim_config.append("%s %s" % (pyfile, self.name_temp("snippet_source.py")))
+        vim_config.append("py3file %s" % (self.name_temp("snippet_source.py")))

--- a/test/vim_interface.py
+++ b/test/vim_interface.py
@@ -154,7 +154,7 @@ class VimInterface(TempFileManager):
     def leave_with_wait(self):
         self.send_to_vim(3 * ESC + ":qa!\n")
         while is_process_running(self._vim_pid):
-            time.sleep(0.2)
+            time.sleep(0.01)
 
 
 class VimInterfaceTmux(VimInterface):

--- a/test/vim_interface.py
+++ b/test/vim_interface.py
@@ -21,10 +21,10 @@ def wait_until_file_exists(file_path, times=None, interval=0.01):
     return False
 
 
-# NOCOM(#sirver): inline function?
-def read_text_file(filename):
+def _read_text_file(filename):
     """Reads the contens of a text file."""
-    return open(filename, "r", encoding="utf-8").read()
+    with open(filename, "r", encoding="utf-8") as to_read:
+        return to_read.read()
 
 
 def is_process_running(pid):
@@ -52,7 +52,7 @@ def create_directory(dirname):
         pass
 
 
-class TempFileManager(object):
+class TempFileManager:
     def __init__(self, name=""):
         self._temp_dir = tempfile.mkdtemp(prefix="UltiSnipsTest_" + name)
 
@@ -107,7 +107,7 @@ class VimInterface(TempFileManager):
         buffer_path = self.unique_name_temp(prefix="buffer_")
         self.send_to_vim(ESC + ":w! %s\n" % buffer_path)
         if wait_until_file_exists(buffer_path, 50):
-            return read_text_file(buffer_path)[:-1]
+            return _read_text_file(buffer_path)[:-1]
 
     def send_to_terminal(self, s):
         """Types 's' into the terminal."""
@@ -118,7 +118,7 @@ class VimInterface(TempFileManager):
         raise NotImplementedError()
 
     def launch(self, config=[]):
-        """Returns the python version in Vim as a string, e.g. '2.7'"""
+        """Returns the python version in Vim as a string, e.g. '3.7'"""
         pid_file = self.name_temp("vim.pid")
         done_file = self.name_temp("loading_done")
         if os.path.exists(done_file):
@@ -148,8 +148,8 @@ class VimInterface(TempFileManager):
             % (self._vim_executable, config_path)
         )
         wait_until_file_exists(done_file)
-        self._vim_pid = int(read_text_file(pid_file))
-        return read_text_file(done_file).strip()
+        self._vim_pid = int(_read_text_file(pid_file))
+        return _read_text_file(done_file).strip()
 
     def leave_with_wait(self):
         self.send_to_vim(3 * ESC + ":qa!\n")

--- a/test/vim_interface.py
+++ b/test/vim_interface.py
@@ -8,7 +8,7 @@ import tempfile
 import textwrap
 import time
 
-from test.constant import ARR_D, ARR_L, ARR_R, ARR_U, BS, ESC, PYTHON3, SEQUENCES
+from test.constant import ARR_D, ARR_L, ARR_R, ARR_U, BS, ESC, SEQUENCES
 
 
 def wait_until_file_exists(file_path, times=None, interval=0.01):
@@ -21,12 +21,10 @@ def wait_until_file_exists(file_path, times=None, interval=0.01):
     return False
 
 
+# NOCOM(#sirver): inline function?
 def read_text_file(filename):
     """Reads the contens of a text file."""
-    if PYTHON3:
-        return open(filename, "r", encoding="utf-8").read()
-    else:
-        return open(filename, "r").read()
+    return open(filename, "r", encoding="utf-8").read()
 
 
 def is_process_running(pid):
@@ -64,12 +62,8 @@ class TempFileManager(object):
     def write_temp(self, file_path, content):
         abs_path = self.name_temp(file_path)
         create_directory(os.path.dirname(abs_path))
-        if PYTHON3:
-            with open(abs_path, "w", encoding="utf-8") as f:
-                f.write(content)
-        else:
-            with open(abs_path, "w") as f:
-                f.write(content)
+        with open(abs_path, "w", encoding="utf-8") as f:
+            f.write(content)
         return abs_path
 
     def unique_name_temp(self, suffix="", prefix=""):
@@ -131,7 +125,7 @@ class VimInterface(TempFileManager):
             os.remove(done_file)
 
         post_config = []
-        post_config.append("%s << EOF" % ("py3" if PYTHON3 else "py"))
+        post_config.append("py3 << EOF")
         post_config.append("import vim, sys")
         post_config.append(
             "with open('%s', 'w') as pid_file: pid_file.write(vim.eval('getpid()'))"
@@ -189,8 +183,7 @@ class VimInterfaceTmux(VimInterface):
         stdout, _ = subprocess.Popen(
             ["tmux", "-V"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
         ).communicate()
-        if PYTHON3:
-            stdout = stdout.decode("utf-8")
+        stdout = stdout.decode("utf-8")
         m = re.match(r"tmux (\d+).(\d+)", stdout)
         if not m or not (int(m.group(1)), int(m.group(2))) >= (1, 8):
             raise RuntimeError("Need at least tmux 1.8, you have %s." % stdout.strip())

--- a/test/vim_test_case.py
+++ b/test/vim_test_case.py
@@ -9,7 +9,7 @@ import textwrap
 import time
 import unittest
 
-from test.constant import PYTHON3, SEQUENCES, EX
+from test.constant import SEQUENCES, EX
 from test.vim_interface import create_directory, TempFileManager
 
 
@@ -91,8 +91,7 @@ class VimTestCase(unittest.TestCase, TempFileManager):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             ).communicate()
-            if PYTHON3:
-                VimTestCase.version = VimTestCase.version.decode("utf-8")
+            VimTestCase.version = VimTestCase.version.decode("utf-8")
 
         if self.plugins and not self.test_plugins:
             return self.skipTest("Not testing integration with other plugins.")
@@ -135,26 +134,21 @@ class VimTestCase(unittest.TestCase, TempFileManager):
         vim_config.append('let g:UltiSnipsJumpForwardTrigger="?"')
         vim_config.append('let g:UltiSnipsJumpBackwardTrigger="+"')
         vim_config.append('let g:UltiSnipsListSnippets="@"')
-        vim_config.append(
-            'let g:UltiSnipsUsePythonVersion="%i"' % (3 if PYTHON3 else 2)
-        )
 
         # Work around https://github.com/vim/vim/issues/3117 for testing >
         # py3.7 on Vim 8.1. Actually also reported against UltiSnips
         # https://github.com/SirVer/ultisnips/issues/996
-        if PYTHON3 and "Vi IMproved 8.1" in self.version:
+        if "Vi IMproved 8.1" in self.version:
             vim_config.append("silent! python3 1")
 
         vim_config.append('let g:UltiSnipsSnippetDirectories=["us"]')
         if self.python_host_prog:
-            vim_config.append('let g:python_host_prog="%s"' % self.python_host_prog)
-        if self.python3_host_prog:
-            vim_config.append('let g:python3_host_prog="%s"' % self.python3_host_prog)
+            vim_config.append('let g:python3_host_prog="%s"' % self.python_host_prog)
 
         self._extra_vim_config(vim_config)
 
         # Finally, add the snippets and some configuration for the test.
-        vim_config.append("%s << EOF" % ("py3" if PYTHON3 else "py"))
+        vim_config.append("py3 << EOF")
         vim_config.append("from UltiSnips import UltiSnips_Manager\n")
 
         if len(self.snippets) and not isinstance(self.snippets[0], tuple):
@@ -196,10 +190,7 @@ class VimTestCase(unittest.TestCase, TempFileManager):
         if not self.interrupt:
             # Go into insert mode and type the keys but leave Vim some time to
             # react.
-            if PYTHON3:
-                text = "i" + self.keys
-            else:
-                text = u"i" + self.keys.decode("utf-8")
+            text = "i" + self.keys
             while text:
                 to_send = None
                 for seq in SEQUENCES:

--- a/test/vim_test_case.py
+++ b/test/vim_test_case.py
@@ -54,7 +54,7 @@ class VimTestCase(unittest.TestCase, TempFileManager):
                 return
             if self.output != wanted or self.output is None:
                 # Redo this, but slower
-                self.sleeptime += 0.15
+                self.sleeptime += 0.01
                 self.tearDown()
                 self.setUp()
         self.assertMultiLineEqual(self.output, wanted)

--- a/test/vim_test_case.py
+++ b/test/vim_test_case.py
@@ -48,13 +48,14 @@ class VimTestCase(unittest.TestCase, TempFileManager):
 
         # Only checks the output. All work is done in setUp().
         wanted = self.text_before + self.wanted + self.text_after
+        SLEEPTIMES = [0.01, 0.15, 0.3, 0.4, 0.5, 1]
         for i in range(self.retries):
             if self.output and self.expected_error:
                 self.assertRegexpMatches(self.output, self.expected_error)
                 return
             if self.output != wanted or self.output is None:
                 # Redo this, but slower
-                self.sleeptime += 0.01
+                self.sleeptime = SLEEPTIMES[min(i, len(SLEEPTIMES) - 1)]
                 self.tearDown()
                 self.setUp()
         self.assertMultiLineEqual(self.output, wanted)

--- a/test_all.py
+++ b/test_all.py
@@ -149,13 +149,6 @@ if __name__ == "__main__":
             "It is ignored for vanilla Vim.",
         )
         p.add_option(
-            "--python3-host-prog",
-            dest="python3_host_prog",
-            type=str,
-            default="",
-            help="See --python-host-prog.",
-        )
-        p.add_option(
             "--expected-python-version",
             dest="expected_python_version",
             type=str,
@@ -207,7 +200,6 @@ if __name__ == "__main__":
             test.retries = options.retries
             test.test_plugins = options.plugins
             test.python_host_prog = options.python_host_prog
-            test.python3_host_prog = options.python3_host_prog
             test.expected_python_version = options.expected_python_version
             test.vim = vim
             test.vim_flavor = vim_flavor


### PR DESCRIPTION
Python 3 is > 10 years old and Python 2 will no longer be supported in a few months. Time to get rid of it, simplifying the code base (slightly) and opening the opportunities to use the Py3 quality of life improvements.