### PR TITLE
When using snip.rv make sure it is interpreted as text.

### DIFF
--- a/pythonx/UltiSnips/text_objects/python_code.py
+++ b/pythonx/UltiSnips/text_objects/python_code.py
@@ -174,8 +174,7 @@ class SnippetUtil:
     def p(self):
         if self._parent.current_placeholder:
             return self._parent.current_placeholder
-        else:
-            return _Placeholder("", 0, 0)
+        return _Placeholder("", 0, 0)
 
     @property
     def context(self):
@@ -238,7 +237,7 @@ class PythonCode(NoneditableTextObject):
                 mode = snippet.visual_content.mode
                 context = snippet.context
                 break
-            except AttributeError as e:
+            except AttributeError:
                 snippet = snippet._parent  # pylint:disable=protected-access
         self._snip = SnippetUtil(token.indent, mode, text, context, snippet)
 
@@ -267,11 +266,11 @@ class PythonCode(NoneditableTextObject):
         for code in self._codes:
             try:
                 exec(code, self._locals)  # pylint:disable=exec-used
-            except Exception as e:
-                e.snippet_code = code
+            except Exception as exception:
+                exception.snippet_code = code
                 raise
 
-        rv = (
+        rv = str(
             self._snip.rv if self._snip._rv_changed else self._locals["res"]
         )  # pylint:disable=protected-access
 

--- a/test/test_Interpolation.py
+++ b/test/test_Interpolation.py
@@ -541,13 +541,8 @@ snip.rv = "placeholder: " + snip.p.current_text`)""",
 first second (placeholder: )"""
 
 
-# Tests for https://bugs.launchpad.net/bugs/1259349
-
-
-class Python_WeirdScoping_Error(_VimTest):
-    snippets = (
-        "test",
-        "h`!p import re; snip.rv = '%i' % len([re.search for i in 'aiiia'])`b",
-    )
+class Python_SnipRvCanBeNonText(_VimTest):
+    # Test for https://github.com/SirVer/ultisnips/issues/1132
+    snippets = ("test", "`!p snip.rv = 5`")
     keys = "test" + EX
-    wanted = "h5b"
+    wanted = "5"


### PR DESCRIPTION
Fixes #1132.