### PR TITLE
Fundamentally changes how snippets are found.

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -165,7 +165,7 @@ found here: https://github.com/honza/vim-snippets
 
 The UltiSnipsEdit command opens a private snippet definition file for the
 current filetype. If no snippet file exists, a new file is created. If used as
-UltiSnipsEdit! all public snippet files are taken into account too. If
+UltiSnipsEdit! all public snippet files that exist are taken into account too. If
 multiple files match the search, the user gets to choose the file.
 
 There are several variables associated with the UltiSnipsEdit command.
@@ -180,34 +180,13 @@ g:UltiSnipsEditSplit        Defines how the edit window is opened. Possible
                             |context|        Splits the window vertically or
                                            horizontally depending on context.
 
-                                                        *g:UltiSnipsSnippetsDir*
-g:UltiSnipsSnippetsDir
-                            Defines the directory where private snippet
-                            definition files are placed in in.
-
-                            As example, if the current 'filetype' is "cpp" the
-                            :UltiSnipsEdit command looks for a file to edit in
-                            this order:
-                            1. An existing
-                               g:UltiSnipsSnippetsDir."/cpp.snippets" file
-                            2. Find a matching "cpp" snippets file in
-                               g:UltiSnipsSnippetDirectories
-                            3. Create a new
-                               g:UltiSnipsSnippetsDir."/cpp.snippets" file
-
-                            Note that directories named "snippets" are
-                            reserved for snipMate snippets and cannot be used.
-                            Also, this setting does not affect where snippets
-                            are searched for, so it is possible to change this
-                            to opening files that are then not found by
-                            UltiSnips. See |UltiSnips-how-snippets-are-loaded|
-                            for details.
-
                                                         *g:UltiSnipsSnippetDirectories*
 g:UltiSnipsSnippetDirectories
-                            Configures the directories that are searched for
-                            snippets. Do not mix up this variable with the
-                            previous one. See |UltiSnips-how-snippets-are-loaded|.
+                            An array of relative directory names OR an array
+                            with a single absolute path. Defaults to [
+                            "UltiSnips" ]. No entry in this list must be
+                            "snippets". Please read
+                            |UltiSnips-how-snippets-are-loaded| for details.
 
                                                         *g:UltiSnipsEnableSnipMate*
 g:UltiSnipsEnableSnipMate

--- a/docker/docker_vimrc.vim
+++ b/docker/docker_vimrc.vim
@@ -1,4 +1,4 @@
-call plug#begin('~/.vim/plugged')
+call plug#begin('~/.vim_plugged')
 
 Plug '/src/UltiSnips'
 Plug 'honza/vim-snippets'

--- a/pythonx/UltiSnips/snippet/source/__init__.py
+++ b/pythonx/UltiSnips/snippet/source/__init__.py
@@ -8,6 +8,7 @@ from UltiSnips.snippet.source.added import AddedSnippetsSource
 from UltiSnips.snippet.source.file.snipmate import SnipMateFileSource
 from UltiSnips.snippet.source.file.ulti_snips import (
     UltiSnipsFileSource,
+    find_all_snippet_directories,
     find_all_snippet_files,
     find_snippet_files,
 )

--- a/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
+++ b/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
@@ -29,9 +29,9 @@ def find_snippet_files(ft, directory):
     return ret
 
 
-def _find_all_snippet_directories():
-    """Returns a list of the absolute path of all snippet directories to
-    search."""
+def find_all_snippet_directories():
+    """Returns a list of the absolute path of all potential snippet
+    directories, no matter if they exist or not."""
 
     if vim_helper.eval("exists('b:UltiSnipsSnippetDirectories')") == "1":
         snippet_dirs = vim_helper.eval("b:UltiSnipsSnippetDirectories")
@@ -56,8 +56,7 @@ def _find_all_snippet_directories():
                     "directory for UltiSnips snippets."
                 )
             pth = os.path.realpath(os.path.expanduser(os.path.join(rtp, snippet_dir)))
-            if os.path.isdir(pth):
-                all_dirs.append(pth)
+            all_dirs.append(pth)
     return all_dirs
 
 
@@ -66,7 +65,9 @@ def find_all_snippet_files(ft):
     directory."""
     patterns = ["%s.snippets", "%s_*.snippets", os.path.join("%s", "*")]
     ret = set()
-    for directory in _find_all_snippet_directories():
+    for directory in find_all_snippet_directories():
+        if not os.path.isdir(directory):
+            continue
         for pattern in patterns:
             for fn in glob.glob(os.path.join(directory, pattern % ft)):
                 ret.add(fn)

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -6,7 +6,8 @@
 from collections import defaultdict
 from contextlib import contextmanager
 import os
-import platform
+from typing import Set
+from pathlib import Path
 import vim
 
 from UltiSnips import vim_helper
@@ -15,18 +16,16 @@ from UltiSnips.diff import diff, guess_edit
 from UltiSnips.position import Position
 from UltiSnips.snippet.definition import UltiSnipsSnippetDefinition
 from UltiSnips.snippet.source import (
-    UltiSnipsFileSource,
+    AddedSnippetsSource,
     SnipMateFileSource,
+    UltiSnipsFileSource,
+    find_all_snippet_directories,
     find_all_snippet_files,
     find_snippet_files,
-    AddedSnippetsSource,
 )
 from UltiSnips.text import escape
-from UltiSnips.debug import *  # NOCOM(#sirver):
-from typing import Tuple, Set
 from UltiSnips.vim_state import VimState, VisualContentPreserver
 from UltiSnips.buffer_proxy import use_proxy_buffer, suspend_proxy_edits
-from enum import Enum
 
 
 def _ask_user(a, formatted):
@@ -58,42 +57,37 @@ def _ask_snippets(snippets):
     return _ask_user(snippets, display)
 
 
-class GetFileToEditResult(Enum):
-    EXISTS = 1
-    NOT_EXISTING = 2
-    USER_ABORT = 3
-
-
-def _get_file_to_edit(
-    snippet_dir, filetypes, bang, allow_empty
-) -> Tuple[GetFileToEditResult, str]:
-    potentials: Set[str] = set()
-
-    for ft in filetypes:
-        potentials.update(find_snippet_files(ft, snippet_dir))
-        potentials.add(os.path.join(snippet_dir, ft + ".snippets"))
-        if bang:
-            potentials.update(find_all_snippet_files(ft))
-
-    potentials = set(os.path.realpath(os.path.expanduser(p)) for p in potentials)
-
+def _select_and_create_file_to_edit(potentials: Set[str]) -> str:
+    file_to_edit = ""
     if len(potentials) > 1:
         files = sorted(potentials)
-        formatted = ["%i: %s" % (i, escape(fn, "\\")) for i, fn in enumerate(files, 1)]
+        exists = [os.path.exists(f) for f in files]
+        formatted = [
+            "%s %i: %s" % ("*" if exists else " ", i, escape(fn, "\\"))
+            for i, (fn, exists) in enumerate(zip(files, exists), 1)
+        ]
         file_to_edit = _ask_user(files, formatted)
         if file_to_edit is None:
-            return GetFileToEditResult.USER_ABORT, ""
+            return ""
     else:
         file_to_edit = potentials.pop()
-
-    if not allow_empty and not os.path.exists(file_to_edit):
-        return GetFileToEditResult.NOT_EXISTING, ""
 
     dirname = os.path.dirname(file_to_edit)
     if not os.path.exists(dirname):
         os.makedirs(dirname)
 
-    return GetFileToEditResult.EXISTS, file_to_edit
+    return file_to_edit
+
+
+def _get_potential_snippet_filenames_to_edit(snippet_dir, filetypes):
+    potentials = set()
+    for ft in filetypes:
+        ft_snippets_files = find_snippet_files(ft, snippet_dir)
+        potentials.update(ft_snippets_files)
+        if not ft_snippets_files:
+            # If there is no snippet file yet, we just default to `ft.snippets`.
+            potentials.add(os.path.join(snippet_dir, ft + ".snippets"))
+    return potentials
 
 
 # TODO(sirver): This class is still too long. It should only contain public
@@ -811,9 +805,8 @@ class SnippetManager:
     def _file_to_edit(self, requested_ft, bang):
         """Returns a file to be edited for the given requested_ft.
 
-        If 'bang' is
-        empty only private files in g:UltiSnipsSnippetsDir are considered,
-        otherwise all files are considered and the user gets to choose.
+        If 'bang' is empty a reasonable first choice is opened (see docs), otherwise
+        all files are considered and the user gets to choose.
         """
         filetypes = []
         if requested_ft:
@@ -823,66 +816,35 @@ class SnippetManager:
                 filetypes.extend(self.get_buffer_filetypes())
             else:
                 filetypes.append(self.get_buffer_filetypes()[0])
-        debug("filetypes: %r" % (filetypes))
 
-        snippet_dir = ""
-        if vim_helper.eval("exists('g:UltiSnipsSnippetsDir')") == "1":
-            dir = vim_helper.eval("g:UltiSnipsSnippetsDir")
-            result, file = _get_file_to_edit(dir, filetypes, bang, False)
-            debug("1 file: %r" % (file))
-            if result == GetFileToEditResult.USER_ABORT:
-                return ""
-            if file:
-                return file
-            snippet_dir = dir
+        potentials = set()
 
-        dirs = vim_helper.eval("g:UltiSnipsSnippetDirectories")
-        for dir in dirs:
-            result, file = _get_file_to_edit(dir, filetypes, bang, True)
-            debug("2 file: %r" % (file))
-            if result == GetFileToEditResult.USER_ABORT:
-                return ""
-            if file:
-                return file
-            if not snippet_dir:
-                snippet_dir = dir
-
-        home = vim_helper.eval("$HOME")
-        if platform.system() == "Windows":
-            dir = os.path.join(home, "vimfiles", "UltiSnips")
-            result, file = _get_file_to_edit(dir, filetypes, bang, False)
-            debug("3 file: %r" % (file))
-            if result == GetFileToEditResult.USER_ABORT:
-                return ""
-            if file:
-                return file
-            if not snippet_dir:
-                snippet_dir = dir
-
-        if vim_helper.eval("has('nvim')") == "1":
-            xdg_home_config = vim_helper.eval("$XDG_CONFIG_HOME") or os.path.join(
-                home, ".config"
+        all_snippet_directories = find_all_snippet_directories()
+        if len(all_snippet_directories) == 1:
+            # Most likely the user has set g:UltiSnipsSnippetDirectories to a
+            # single absolute path.
+            potentials.update(
+                _get_potential_snippet_filenames_to_edit(
+                    all_snippet_directories[0], filetypes
+                )
             )
-            dir = os.path.join(xdg_home_config, "nvim", "UltiSnips")
-            result, file = _get_file_to_edit(dir, filetypes, bang, False)
-            debug("4 file: %r" % (file))
-            if result == GetFileToEditResult.USER_ABORT:
-                return ""
-            if file:
-                return file
-            if not snippet_dir:
-                snippet_dir = dir
+        else:
+            # Likely the array contains things like ["UltiSnips",
+            # "mycoolsnippets"] There is no more obvious way to edit than in
+            # the users vim config directory.
+            dot_vim_dir = Path(vim_helper.get_dot_vim())
+            for snippet_dir in all_snippet_directories:
+                snippet_dir = Path(snippet_dir)
+                if dot_vim_dir != snippet_dir.parent:
+                    continue
+                potentials.update(
+                    _get_potential_snippet_filenames_to_edit(snippet_dir, filetypes)
+                )
 
-        dir = os.path.join(home, ".vim", "UltiSnips")
-        result, file = _get_file_to_edit(dir, filetypes, bang, False)
-        debug("5 file: %r" % (file))
-        if result == GetFileToEditResult.USER_ABORT:
-            return ""
-        if file:
-            return file
-        if not snippet_dir:
-            snippet_dir = dir
-        return _get_file_to_edit(snippet_dir, filetypes, bang, True)[1]
+        if bang:
+            for ft in filetypes:
+                potentials.update(find_all_snippet_files(ft))
+        return _select_and_create_file_to_edit(potentials)
 
     @contextmanager
     def _action_context(self):

--- a/pythonx/UltiSnips/vim_helper.py
+++ b/pythonx/UltiSnips/vim_helper.py
@@ -4,6 +4,8 @@
 """Wrapper functionality around the functions we need from Vim."""
 
 from contextlib import contextmanager
+import os
+import platform
 
 from UltiSnips.compatibility import col2byte, byte2col
 from UltiSnips.position import Position
@@ -207,6 +209,24 @@ def select(start, end):
             move_cmd += "%iG%i|" % virtual_position(end.line + 1, end.col + 1)
         move_cmd += "o%iG%i|o\\<c-g>" % virtual_position(start.line + 1, start.col + 1)
     feedkeys(move_cmd)
+
+
+def get_dot_vim():
+    """Returns the likely place for ~/.vim for the current setup."""
+    home = vim.eval("$HOME")
+    candidates = []
+    if platform.system() == "Windows":
+        candidates.append(os.path.join(home, "vimfiles"))
+    if vim.eval("has('nvim')") == "1":
+        xdg_home_config = vim.eval("$XDG_CONFIG_HOME") or os.path.join(home, ".config")
+        candidates.append(os.path.join(xdg_home_config, "nvim"))
+    candidates.append(os.path.join(home, ".vim"))
+    for candidate in candidates:
+        if os.path.isdir(candidate):
+            return os.path.realpath(candidate)
+    raise RuntimeError(
+        "Unable to find user configuration directory. I tried '%s'." % candidates
+    )
 
 
 def set_mark_from_pos(name, pos):


### PR DESCRIPTION
This is a fairly breaking change.

- Removes `g:UltiSnipsSnippetsDir`.
- Simplifies logic around `:UltiSnipsEdit`: Without bang, it opens a snippet file in a subdirectory  of your `.vim` directory. The name of the sub directory will come from the members of `[gb]:UltiSnipsSnippetDirectories`. This will create a new snippet file and its enclosing directory if it does not yet exist (see below for details). With bang, it additionally adds all existing snippet files that are currently loaded for the current buffer.
- When the user needs to select a snippet file for editing, it shows a `*` for existing files.


Fixes #1120, #907 hopefully #711.

## Explanation of search algorithm

There are 4 combinations to be considered here: with or without bang and with `[gb]:UltiSnipsSnippetDirectories` containing a single absolute path or many relative ones.

|   | Without Bang | With Bang              |
| ------------- | ------------- |--------|
| Single absolute  | All snippet files that are existing in the single directory and match the primary filetype. If there is none `<primary_filetype>.snippets` is used.  | same as without |
| Relative Paths | All snippet files for the primary filetype that exist in the `~/.vim/<path>`s are proposed. For each directory, if there is none `<primary_filetype>.snippets` is proposed.   | like without, but also adds all snippets files that are currently used for these settings by UltiSnips. This includes every `<runtimepath>/<path>/<ft>**.snippets` for all filetypes that match the current buffer  |