### PR TITLE
Allow creating snippet on BufNewFile

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -442,7 +442,7 @@ class SnippetManager:
 
         vim_helper.command("autocmd InsertLeave * call UltiSnips#LeavingInsertMode()")
 
-        vim_helper.command("autocmd BufEnter * call UltiSnips#LeavingBuffer()")
+        vim_helper.command("autocmd BufLeave * call UltiSnips#LeavingBuffer()")
         vim_helper.command("autocmd CmdwinEnter * call UltiSnips#LeavingBuffer()")
         vim_helper.command("autocmd CmdwinLeave * call UltiSnips#LeavingBuffer()")
 

--- a/test/test_Plugin.py
+++ b/test/test_Plugin.py
@@ -22,3 +22,26 @@ class Plugin_SuperTab_SimpleTest(_VimTest):
         vim_config.append('let g:SuperTabRetainCompletionDuration = "insert"')
         vim_config.append("let g:SuperTabLongestHighlight = 1")
         vim_config.append("let g:SuperTabCrMapping = 0")
+
+
+class Plugin_VimTemplate_SimpleTest(_VimTest):
+    test_plugins = False
+    plugins = ["srydell/vim-template"]
+    snippets = ("_skel", "Hello", "", "b")
+    keys = ()
+    # NOTE: Trailing 'i' since the test suite
+    #       expects to have to start insert mode
+    wanted = "Helloi"
+
+
+class Plugin_VimTemplate_JumpsTest(_VimTest):
+    test_plugins = False
+    plugins = ["srydell/vim-template"]
+    snippets = ("_skel", "[ ${1:foo} ] ${2:bar}")
+    keys = (
+        "HelloWorld" + JF + JF
+    )  # Should replace 'foo' with 'HelloWorld' but keep 'bar'
+
+    # NOTE: Leading 'i' since the test suite
+    #       expects to have to start insert mode
+    wanted = "[ iHelloWorld ] bar"


### PR DESCRIPTION
Hi!

First of all I want to thank you for this great plugin! It has helped me a lot.

I'm using a small plugin [srydell/vim-skeleton](https://github.com/srydell/vim-skeleton) to create templates using UltiSnips upon entering a new file. When I last updated ultisnips, the behaviour at BufNewFile had changed, and I could no longer jump through tabstops in the template snippets. A git bisect later and I found [this commit](https://github.com/SirVer/ultisnips/commit/8ff301c651d6df806c0f9305273a6c62a693bc48) to be where the behaviour changed. This PR is the smallest change I could manage that I think solves both cases.

Thanks for your time!