### PR TITLE
Added missing px.snippets import on example

### DIFF
--- a/doc/examples/autojump-if-empty/README.md
+++ b/doc/examples/autojump-if-empty/README.md
@@ -25,7 +25,7 @@ However, with UltiSnips, it can be done via only one keypress:
 
 ## Implementation
 
-This example uses [vim-pythonx library](https://github.com/reconquest/vim-pythonx/blob/master/pythonx/px/snippets.py) which provides set of functions to make coding little bit easier.
+This example uses the [vim-pythonx library](https://github.com/reconquest/vim-pythonx/blob/master/pythonx/px/snippets.py) which provides set of functions to make coding little bit easier.
 
 ```
 global !p

--- a/doc/examples/autojump-if-empty/README.md
+++ b/doc/examples/autojump-if-empty/README.md
@@ -25,9 +25,7 @@ However, with UltiSnips, it can be done via only one keypress:
 
 ## Implementation
 
-Using awesome [vim-pythonx
-library](https://github.com/reconquest/vim-pythonx/blob/master/pythonx/px/snippets.py),
-which provides set of functions to make coding little bit easier.
+This example uses [vim-pythonx library](https://github.com/reconquest/vim-pythonx/blob/master/pythonx/px/snippets.py) which provides set of functions to make coding little bit easier.
 
 ```
 global !p

--- a/doc/examples/snippets-aliasing/README.md
+++ b/doc/examples/snippets-aliasing/README.md
@@ -2,12 +2,11 @@
 
 ![gif](https://raw.githubusercontent.com/SirVer/ultisnips/master/doc/examples/snippets-aliasing/demo.gif)
 
-Let's imagine we're editing shell file and we need to debug some vars.
+These examples use [vim-pythonx library](https://github.com/reconquest/vim-pythonx/blob/master/pythonx/px/snippets.py) which provides set of functions to make coding little bit easier.
 
-Essentially, we will end up with snippet like that, that will automatically
-insert location of the debug statement and variable name.
+Let's imagine we're editing a shell file and we need to debug some state.
 
-Example of that snippet is shown below:
+We will probably end up with a snippet that will automatically insert the location of the debug statement, the variable name and its content:
 
 ```
 global !p
@@ -26,7 +25,7 @@ prefix = "{}:{}: {}".format(
 endsnippet
 ```
 
-Now, we want to use same debug snippet, but dump variable to the file.
+Now, we want to use same debug snippet, but dump output to a file.
 How can we do it?
 
 Simple, declare new snippet in that way:
@@ -38,7 +37,7 @@ pr$1 >${2:/tmp/debug}
 endsnippet
 ```
 
-This snippet will expand `pr` snippet automatically (note `pr$1` part) after
+This snippet will expand the `pr` snippet automatically (note `pr$1` part) after
 jumping to the first placeholder (jump will be done automatically by UltiSnips
 engine).
 
@@ -52,5 +51,4 @@ def expand(snip, jump_pos=1):
     vim.eval('feedkeys("\<C-R>=UltiSnips#ExpandSnippet()\<CR>")')
 ```
 
-`px.buffer.get()` and `px.cursor.get()` are simple helpers for the
-`vim.current.window.buffer` and `vim.current.window.cursor`.
+`px.buffer.get()` and `px.cursor.get()` are simple helpers for the `vim.current.window.buffer` and `vim.current.window.cursor`.

--- a/doc/examples/snippets-aliasing/README.md
+++ b/doc/examples/snippets-aliasing/README.md
@@ -2,7 +2,7 @@
 
 ![gif](https://raw.githubusercontent.com/SirVer/ultisnips/master/doc/examples/snippets-aliasing/demo.gif)
 
-These examples use [vim-pythonx library](https://github.com/reconquest/vim-pythonx/blob/master/pythonx/px/snippets.py) which provides set of functions to make coding little bit easier.
+These examples use thes [vim-pythonx library](https://github.com/reconquest/vim-pythonx/blob/master/pythonx/px/snippets.py) which provides set of functions to make coding little bit easier.
 
 Let's imagine we're editing a shell file and we need to debug some state.
 

--- a/doc/examples/snippets-aliasing/README.md
+++ b/doc/examples/snippets-aliasing/README.md
@@ -10,6 +10,10 @@ insert location of the debug statement and variable name.
 Example of that snippet is shown below:
 
 ```
+global !p
+import px.snippets
+endglobal
+
 snippet pr "print debug" bw
 `!p
 prefix = t[1] + ": %q\\n' "


### PR DESCRIPTION
Hi!

Thank you for your amazing plugin!

I am new to it, and I was trying to learn how to use it from example files.

I took the code 'px.buffer.get().name' , but it was not working.
So I spent 2 hours searching why and, it was because the import px.snippets
was missing inside of this file.

So that's why I added it, I hope it can help other people.

Thank you for your time!