### PR TITLE
Do not use realpath in most cases

### DIFF
--- a/pythonx/UltiSnips/snippet/source/file/snipmate.py
+++ b/pythonx/UltiSnips/snippet/source/file/snipmate.py
@@ -44,7 +44,7 @@ def _snipmate_files_for(ft):
     ]
     ret = set()
     for rtp in vim_helper.eval("&runtimepath").split(","):
-        path = os.path.realpath(os.path.expanduser(os.path.join(rtp, "snippets")))
+        path = os.path.expanduser(os.path.join(rtp, "snippets"))
         for pattern in patterns:
             for fn in glob.glob(os.path.join(path, pattern)):
                 ret.add(fn)

--- a/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
+++ b/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
@@ -25,7 +25,7 @@ def find_snippet_files(ft, directory):
     directory = os.path.expanduser(directory)
     for pattern in patterns:
         for fn in glob.glob(os.path.join(directory, pattern % ft)):
-            ret.add(os.path.realpath(fn))
+            ret.add(fn)
     return ret
 
 
@@ -55,7 +55,7 @@ def find_all_snippet_directories():
                     "directory is reserved for snipMate snippets. Use another "
                     "directory for UltiSnips snippets."
                 )
-            pth = os.path.realpath(os.path.expanduser(os.path.join(rtp, snippet_dir)))
+            pth = os.path.expanduser(os.path.join(rtp, snippet_dir))
             all_dirs.append(pth)
     return all_dirs
 

--- a/pythonx/UltiSnips/vim_helper.py
+++ b/pythonx/UltiSnips/vim_helper.py
@@ -224,10 +224,10 @@ def get_dot_vim():
     candidates.append(os.path.join(home, ".vim"))
 
     my_vimrc = os.environ["MYVIMRC"]
-    candidates.append(os.path.realpath(os.path.dirname(my_vimrc)))
+    candidates.append(os.path.dirname(my_vimrc))
     for candidate in candidates:
         if os.path.isdir(candidate):
-            return os.path.realpath(candidate)
+            return candidate
     raise RuntimeError(
         "Unable to find user configuration directory. I tried '%s'." % candidates
     )


### PR DESCRIPTION
If a user has created symlinks, we have no real reason to abstract back to the real inode path.

Side effect of this could be that the same snippet file shows up multiple times in `:UltiSnipsEdit`, but under different paths if symlinks are involved. This however feels like it is working as intended.

Fixes #1153.