### PR TITLE
Normalize all paths before returning them

### DIFF
--- a/pythonx/UltiSnips/snippet/source/file/common.py
+++ b/pythonx/UltiSnips/snippet/source/file/common.py
@@ -3,6 +3,13 @@
 
 """Common code for snipMate and UltiSnips snippet files."""
 
+import os.path
+
+
+def normalize_file_path(path: str) -> str:
+    """Calls normpath and normcase on path"""
+    return os.path.normcase(os.path.normpath(path))
+
 
 def handle_extends(tail, line_index):
     """Handles an extends line in a snippet."""

--- a/pythonx/UltiSnips/snippet/source/file/snipmate.py
+++ b/pythonx/UltiSnips/snippet/source/file/snipmate.py
@@ -9,7 +9,7 @@ import glob
 from UltiSnips import vim_helper
 from UltiSnips.snippet.definition import SnipMateSnippetDefinition
 from UltiSnips.snippet.source.file.base import SnippetFileSource
-from UltiSnips.snippet.source.file.common import handle_extends
+from UltiSnips.snippet.source.file.common import handle_extends, normalize_file_path
 from UltiSnips.text import LineIterator, head_tail
 
 
@@ -44,7 +44,7 @@ def _snipmate_files_for(ft):
     ]
     ret = set()
     for rtp in vim_helper.eval("&runtimepath").split(","):
-        path = os.path.expanduser(os.path.join(rtp, "snippets"))
+        path = normalize_file_path(os.path.expanduser(os.path.join(rtp, "snippets")))
         for pattern in patterns:
             for fn in glob.glob(os.path.join(path, pattern)):
                 ret.add(fn)

--- a/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
+++ b/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
@@ -11,9 +11,10 @@ from UltiSnips import vim_helper
 from UltiSnips.snippet.definition import UltiSnipsSnippetDefinition
 from UltiSnips.snippet.source.file.base import SnippetFileSource
 from UltiSnips.snippet.source.file.common import (
-    handle_extends,
     handle_action,
     handle_context,
+    handle_extends,
+    normalize_file_path,
 )
 from UltiSnips.text import LineIterator, head_tail
 
@@ -25,7 +26,7 @@ def find_snippet_files(ft, directory):
     directory = os.path.expanduser(directory)
     for pattern in patterns:
         for fn in glob.glob(os.path.join(directory, pattern % ft)):
-            ret.add(fn)
+            ret.add(normalize_file_path(fn))
     return ret
 
 
@@ -55,7 +56,9 @@ def find_all_snippet_directories():
                     "directory is reserved for snipMate snippets. Use another "
                     "directory for UltiSnips snippets."
                 )
-            pth = os.path.expanduser(os.path.join(rtp, snippet_dir))
+            pth = normalize_file_path(
+                os.path.expanduser(os.path.join(rtp, snippet_dir))
+            )
             all_dirs.append(pth)
     return all_dirs
 
@@ -196,7 +199,7 @@ def _parse_snippets_file(data, filename):
             if head == "error":
                 yield (head, tail)
             else:
-                actions[head], = tail
+                (actions[head],) = tail
         elif head and not head.startswith("#"):
             yield "error", ("Invalid line %r" % line.rstrip(), lines.line_index)
 

--- a/pythonx/UltiSnips/vim_helper.py
+++ b/pythonx/UltiSnips/vim_helper.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 import os
 import platform
 
+from UltiSnips.snippet.source.file.common import normalize_file_path
 from UltiSnips.compatibility import col2byte, byte2col
 from UltiSnips.position import Position
 from vim import error  # pylint:disable=import-error,unused-import
@@ -224,10 +225,10 @@ def get_dot_vim():
     candidates.append(os.path.join(home, ".vim"))
 
     my_vimrc = os.environ["MYVIMRC"]
-    candidates.append(os.path.dirname(my_vimrc))
+    candidates.append(normalize_file_path(os.path.dirname(my_vimrc)))
     for candidate in candidates:
         if os.path.isdir(candidate):
-            return candidate
+            return normalize_file_path(candidate)
     raise RuntimeError(
         "Unable to find user configuration directory. I tried '%s'." % candidates
     )


### PR DESCRIPTION
This is a fix for a windows problem, but has semantic changes also for other platforms as `os.path.normpath` might change the meaning of a path that contains symbolic links.

Attempted fix for #1158.