### PR TITLE
Attempted fix for #1144.

### DIFF
--- a/pythonx/UltiSnips/vim_helper.py
+++ b/pythonx/UltiSnips/vim_helper.py
@@ -224,7 +224,7 @@ def get_dot_vim():
 
     candidates.append(os.path.join(home, ".vim"))
 
-    my_vimrc = os.environ["MYVIMRC"]
+    my_vimrc = os.path.expandvars(os.environ["MYVIMRC"])
     candidates.append(normalize_file_path(os.path.dirname(my_vimrc)))
     for candidate in candidates:
         if os.path.isdir(candidate):


### PR DESCRIPTION
Expand shell variables in MYVIMRC environment variable, because apparently Vim does it too.