### PR TITLE
Send the correct trigger key to _handle_failure()

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -241,7 +241,7 @@ class SnippetManager:
         snippets = self._snips(before, True)
 
         if len(snippets) == 0:
-            self._handle_failure(self.backward_trigger)
+            self._handle_failure(vim.eval("g:UltiSnipsListSnippets"))
             return True
 
         # Sort snippets alphabetically


### PR DESCRIPTION
Currently, "SnippetManager._handle_failure()" receives the backward
trigger key instead of the list trigger key when listing fails
because there are no snippets for the current buffer.

If "g:UltiSnipsJumpBackwardTrigger" is set to, for example
"<S-Tab>", failing to list any snippets will send that key to the
type-ahead instead of the value of "g:UltiSnipsListSnippets".

In my Vim configuration, I have the following settings:

  let g:UltiSnipsJumpBackwardTrigger = '<S-Tab>'
  let g:UltiSnipsListSnippets = '<C-L>'

I get the following behavior before this commit:

  1. Enter Insert mode
  2. Press <C-L> to list snippets, listing fails b/c no snippets
  3. A tab character is inserted when nothing should happen

This commit uses _handle_verify() properly so that no useless
characters are inserted into the buffer when there are no snippets.

The only deficiency here may be that we don't check for the existence of `g:UltiSnipsListSnippets` before evaluating it.  Given that the user is using UltiSnips, I don't think that assuming the existence of this variable is unreasonable.