### PR TITLE
Workaround for broken pre-3.6-pathlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: required
 services: docker
 
 env:
+  - VIM_VERSION="7.4" PYTHON_IMAGE=3.5-stretch TAG=vim_74_py35
+  - VIM_VERSION="8.0" PYTHON_IMAGE=3.5-stretch TAG=vim_80_py35
+  - VIM_VERSION="8.1" PYTHON_IMAGE=3.5-stretch TAG=vim_81_py35
+  - VIM_VERSION="git" PYTHON_IMAGE=3.5-stretch TAG=vim_git_py35
   - VIM_VERSION="7.4" PYTHON_IMAGE=3.6-stretch TAG=vim_74_py36
   - VIM_VERSION="8.0" PYTHON_IMAGE=3.6-stretch TAG=vim_80_py36
   - VIM_VERSION="8.1" PYTHON_IMAGE=3.6-stretch TAG=vim_81_py36

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,14 @@ MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MAKEFILE_DIR := $(dir ${MAKEFILE_PATH})
 
 # Test images as run on CI.
+image_vim_74_py35:
+	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.5-stretch --build-arg VIM_VERSION=7.4 .
+image_vim_80_py35:
+	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.5-stretch --build-arg VIM_VERSION=8.0 .
+image_vim_81_py35:
+	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.5-stretch --build-arg VIM_VERSION=8.1 .
+image_vim_git_py35:
+	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.5-stretch --build-arg VIM_VERSION=git .
 image_vim_74_py36:
 	docker build -t ultisnips:$@ --build-arg PYTHON_IMAGE=3.6-stretch --build-arg VIM_VERSION=7.4 .
 image_vim_80_py36:

--- a/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
+++ b/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
@@ -23,7 +23,7 @@ def find_snippet_files(ft, directory):
     """Returns all matching snippet files for 'ft' in 'directory'."""
     patterns = ["%s.snippets", "%s_*.snippets", os.path.join("%s", "*")]
     ret = set()
-    directory = os.path.expanduser(directory)
+    directory = os.path.expanduser(str(directory))
     for pattern in patterns:
         for fn in glob.glob(os.path.join(directory, pattern % ft)):
             ret.add(normalize_file_path(fn))
@@ -42,7 +42,7 @@ def find_all_snippet_directories():
     if len(snippet_dirs) == 1:
         # To reduce confusion and increase consistency with
         # `UltiSnipsSnippetsDir`, we expand ~ here too.
-        full_path = os.path.expanduser(snippet_dirs[0])
+        full_path = os.path.expanduser(str(snippet_dirs[0]))
         if os.path.isabs(full_path):
             return [full_path]
 
@@ -57,7 +57,7 @@ def find_all_snippet_directories():
                     "directory for UltiSnips snippets."
                 )
             pth = normalize_file_path(
-                os.path.expanduser(os.path.join(rtp, snippet_dir))
+                os.path.expanduser(str(os.path.join(rtp, snippet_dir)))
             )
             all_dirs.append(pth)
     return all_dirs


### PR DESCRIPTION
I think it is a good idea to re-establish the compatibility to
python 3.5, since it is widely used, e.g. in debian stretch.

`pathlib` in python 3.5 is missing some methods, like `startswith`.
In order to avoid using pathlib, the paths are cast to `str`.

See also here: https://bugs.python.org/issue27493

referencing #1201, #1190