### PR TITLE
fix to JumpForwardTrigger works when snippets are used in two or more buffers

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -481,12 +481,13 @@ class SnippetManager:
             vim_helper.command("augroup UltiSnips")
             vim_helper.command("autocmd!")
             vim_helper.command("augroup END")
-            self._inner_state_up = False
         except vim_helper.error:
             # This happens when a preview window was opened. This issues
             # CursorMoved, but not BufLeave. We have no way to unmap, until we
             # are back in our buffer
             pass
+        finally:
+            self._inner_state_up = False
 
     @err_to_scratch_buffer.wrap
     def _save_last_visual_selection(self):


### PR DESCRIPTION
This PR closes #1187 .
if user switches buffer while filling placeholder, exception is throwd and `_teardown_inner_state` does not set `False` to  `_inner_state_up`. so `_setup_inner_state` does not configure keyboard mappings.
I moved  `_inner_state_up = False` statement to `finally` block in `_teardown_inner_state`.
It guarantees `_inner_state_up` is set to `False` even if throws while processing tear down.