### PR TITLE
Python 3.5 Compatibility: Fix crash when snippet for current file does not exist 

### DIFF
--- a/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
+++ b/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
@@ -23,7 +23,7 @@ def find_snippet_files(ft, directory):
     """Returns all matching snippet files for 'ft' in 'directory'."""
     patterns = ["%s.snippets", "%s_*.snippets", os.path.join("%s", "*")]
     ret = set()
-    directory = os.path.expanduser(str(directory))
+    directory = os.path.expanduser(directory)
     for pattern in patterns:
         for fn in glob.glob(os.path.join(directory, pattern % ft)):
             ret.add(normalize_file_path(fn))
@@ -42,7 +42,7 @@ def find_all_snippet_directories():
     if len(snippet_dirs) == 1:
         # To reduce confusion and increase consistency with
         # `UltiSnipsSnippetsDir`, we expand ~ here too.
-        full_path = os.path.expanduser(str(snippet_dirs[0]))
+        full_path = os.path.expanduser(snippet_dirs[0])
         if os.path.isabs(full_path):
             return [full_path]
 
@@ -57,7 +57,7 @@ def find_all_snippet_directories():
                     "directory for UltiSnips snippets."
                 )
             pth = normalize_file_path(
-                os.path.expanduser(str(os.path.join(rtp, snippet_dir)))
+                os.path.expanduser(os.path.join(rtp, snippet_dir))
             )
             all_dirs.append(pth)
     return all_dirs

--- a/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
+++ b/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
@@ -6,6 +6,7 @@
 from collections import defaultdict
 import glob
 import os
+from typing import Set, List
 
 from UltiSnips import vim_helper
 from UltiSnips.snippet.definition import UltiSnipsSnippetDefinition
@@ -19,7 +20,7 @@ from UltiSnips.snippet.source.file.common import (
 from UltiSnips.text import LineIterator, head_tail
 
 
-def find_snippet_files(ft, directory):
+def find_snippet_files(ft, directory: str) -> Set[str]:
     """Returns all matching snippet files for 'ft' in 'directory'."""
     patterns = ["%s.snippets", "%s_*.snippets", os.path.join("%s", "*")]
     ret = set()
@@ -30,7 +31,7 @@ def find_snippet_files(ft, directory):
     return ret
 
 
-def find_all_snippet_directories():
+def find_all_snippet_directories() -> List[str]:
     """Returns a list of the absolute path of all potential snippet
     directories, no matter if they exist or not."""
 
@@ -63,7 +64,7 @@ def find_all_snippet_directories():
     return all_dirs
 
 
-def find_all_snippet_files(ft):
+def find_all_snippet_files(ft) -> Set[str]:
     """Returns all snippet files matching 'ft' in the given runtime path
     directory."""
     patterns = ["%s.snippets", "%s_*.snippets", os.path.join("%s", "*")]

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -843,10 +843,9 @@ class SnippetManager:
             # Likely the array contains things like ["UltiSnips",
             # "mycoolsnippets"] There is no more obvious way to edit than in
             # the users vim config directory.
-            dot_vim_dir = Path(vim_helper.get_dot_vim())
+            dot_vim_dir = vim_helper.get_dot_vim()
             for snippet_dir in all_snippet_directories:
-                snippet_dir = Path(snippet_dir)
-                if dot_vim_dir != snippet_dir.parent:
+                if Path(dot_vim_dir) != Path(snippet_dir).parent:
                     continue
                 potentials.update(
                     _get_potential_snippet_filenames_to_edit(snippet_dir, filetypes)

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -88,7 +88,7 @@ def _select_and_create_file_to_edit(potentials: Set[str]) -> str:
     return file_to_edit
 
 
-def _get_potential_snippet_filenames_to_edit(snippet_dir, filetypes):
+def _get_potential_snippet_filenames_to_edit(snippet_dir: str, filetypes: str) -> Set[str]:
     potentials = set()
     for ft in filetypes:
         ft_snippets_files = find_snippet_files(ft, snippet_dir)


### PR DESCRIPTION
I found another case, where ultisnips crashed. Again it is because of
the incompatibility between pathlib and os.path in python v3.5.

The problem came, when there is no snippet file for the current file
type, cf. `snippet_manager.py`, line 98.

Instead of casting every `os.path` argument to str, I just avoided to
cast to `pathlib.Path` in the first place.

Also I added some type hints.
