### PR TITLE
Fix: bug in autojump-if-empty example

### DIFF
--- a/doc/examples/autojump-if-empty/README.md
+++ b/doc/examples/autojump-if-empty/README.md
@@ -44,7 +44,7 @@ def clean_first_placeholder(snip):
     # Jumper is a helper for performing jumps in UltiSnips.
     px.snippets.make_jumper(snip)
 
-    if snip.tabstop == 2 and not get_jumper_text(snip):
+    if snip.tabstop == 2 and not px.snippets.get_jumper_text(snip):
         line = snip.buffer[snip.cursor[0]]
         snip.buffer[snip.cursor[0]] = \
             line[:snip.tabstops[1].start[1]-2] + \


### PR DESCRIPTION
'get_jumper_text' was not defined in autojump-if-empty example.

11009e6eb6570dd36f55e26d75326dfcb5f533ba introduce a check on the text but it was looking for a local function `get_jumper_text` instead of `px.snippets.get_jumper_text` function.

Fixes #1250 