### PR TITLE
Adds function to test if cursor is in front of a full snippet

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -87,11 +87,16 @@ endfunction
 function! UltiSnips#SnippetsInCurrentScope(...) abort
     let g:current_ulti_dict = {}
     let all = get(a:, 1, 0)
+    let exact = get(a:, 2, 1)
     if all
       let g:current_ulti_dict_info = {}
     endif
-    py3 UltiSnips_Manager.snippets_in_current_scope(int(vim.eval("all")))
+    py3 UltiSnips_Manager.snippets_in_current_scope(int(vim.eval("all")), int(vim.eval("exact")))
     return g:current_ulti_dict
+endfunction
+
+function! UltiSnips#ExpandableExact() abort
+    return !!len(UltiSnips#SnippetsInCurrentScope(0, 0))
 endfunction
 
 function! UltiSnips#SaveLastVisualSelection() range abort

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -191,11 +191,11 @@ class SnippetManager:
             self._handle_failure(self.expand_trigger)
 
     @err_to_scratch_buffer.wrap
-    def snippets_in_current_scope(self, search_all):
+    def snippets_in_current_scope(self, search_all, exact=1):
         """Returns the snippets that could be expanded to Vim as a global
         variable."""
         before = "" if search_all else vim_helper.buf.line_till_cursor
-        snippets = self._snips(before, True)
+        snippets = self._snips(before, bool(exact))
 
         # Sort snippets alphabetically
         snippets.sort(key=lambda x: x.trigger)


### PR DESCRIPTION
This adds a `UltiSnips#ExpandableExact()` function that can be used to determine if the cursor is in front of a FULL snippet.
I'm using this to create the following mapping:
```viml
inoremap <silent><expr> <CR>
      \ UltiSnips#ExpandableExact() ? "<C-R>=UltiSnips#ExpandSnippet()<CR>":
      \ "\<CR>"
```
or
```viml
inoremap <silent><expr> <CR>
      \ (pumvisible() && UltiSnips#ExpandableExact()) ? "<C-R>=UltiSnips#ExpandSnippet()<CR>":
      \ "\<CR>"
```
This allows me to use `<TAB>`+`<S-TAB>` to cycle through results from my intellisense and use `<CR>` to expand a snippet when I press `Enter`, but only when I have the cursor on a complete snippet (and if the completion menu is open for the second one).

This is different from the answer to the FAQ question about "analog of neosnippet#expandable" in the documentation. The suggested `!empty(UltiSnips#SnippetsInCurrentScope())` in the answer will return true if the word under the cursor is the beginning of any snippet, but I don't want `<CR>` to expand a snippet that is only partially typed in.

I tried a couple different mappings but I wasn't able to create the mapping I wanted to without the new function, is there a way to get the desired mapping without the new code?