### PR TITLE
Fix: DeprecationWarning from unescaped regex

### DIFF
--- a/pythonx/UltiSnips/err_to_scratch_buffer.py
+++ b/pythonx/UltiSnips/err_to_scratch_buffer.py
@@ -29,7 +29,8 @@ Following is the full stack trace:
             msg += traceback.format_exc()
             if hasattr(e, "snippet_info"):
                 msg += "\nSnippet, caused error:\n"
-                msg += re.sub("^(?=\S)", "  ", e.snippet_info, flags=re.MULTILINE)
+                msg += re.sub(r"^(?=\S)", "  ", e.snippet_info,
+                              flags=re.MULTILINE)
             # snippet_code comes from _python_code.py, it's set manually for
             # providing error message with stacktrace of failed python code
             # inside of the snippet.


### PR DESCRIPTION
Opening vim immediately fires a DeprecationWarning if python3.8 is used
and this behavior can be stopped by simply prefixing the string with `r`