### PR TITLE
Improve b:match_words pattern

### DIFF
--- a/ftplugin/snippets.vim
+++ b/ftplugin/snippets.vim
@@ -43,6 +43,7 @@ if exists("loaded_matchit") && !exists("b:match_words")
     " set to '}'.
     call add(pairs, ['\${\%(\%(\d\|VISUAL\)\:\ze\|\ze\%(\d\|VISUAL\)\).*\\\@<!}', '\\\@<!}']) " ${1:foo}, ${VISUAL:bar}, ... or ${1}, ${VISUAL}, ...
     call add(pairs, ['\${\%(\d\|VISUAL\)|\ze.*\\\@<!|}', '\\\@<!|}']) " ${1|baz,qux|}
+    call add(pairs, ['\${\%(\d\|VISUAL\)\/\ze.*\\\@<!\/[gima]*}', '\\\@<!\/[gima]*}']) " ${1/garply/waldo/g}
     call add(pairs, ['\\\@<!`\%(![pv]\|#!\/\f\+\)\%( \|$\)', '\\\@<!`']) " `!p quux`, `!v corge`, `#!/usr/bin/bash grault`, ... (indicators includes a whitespace or end-of-line)
 
     let pats = map(deepcopy(pairs), 'join(v:val, ":")')

--- a/ftplugin/snippets.vim
+++ b/ftplugin/snippets.vim
@@ -41,9 +41,9 @@ if exists("loaded_matchit") && !exists("b:match_words")
     " the same pattern, '}', matchit could fail to get corresponding '}' in
     " nested patterns like ${1:${VISUAL:bar}} when the end-pattern is simply
     " set to '}'.
-    call add(pairs, ['\${\%(\%(\d\|VISUAL\)\:\ze\|\ze\%(\d\|VISUAL\)\).*\\\@<!}', '\\\@<!}']) " ${1:foo}, ${VISUAL:bar}, ... or ${1}, ${VISUAL}, ...
     call add(pairs, ['\${\%(\d\|VISUAL\)|\ze.*\\\@<!|}', '\\\@<!|}']) " ${1|baz,qux|}
     call add(pairs, ['\${\%(\d\|VISUAL\)\/\ze.*\\\@<!\/[gima]*}', '\\\@<!\/[gima]*}']) " ${1/garply/waldo/g}
+    call add(pairs, ['\${\%(\%(\d\|VISUAL\)\:\ze\|\ze\%(\d\|VISUAL\)\).*\\\@<!}', '\\\@<!}']) " ${1:foo}, ${VISUAL:bar}, ... or ${1}, ${VISUAL}, ...
     call add(pairs, ['\\\@<!`\%(![pv]\|#!\/\f\+\)\%( \|$\)', '\\\@<!`']) " `!p quux`, `!v corge`, `#!/usr/bin/bash grault`, ... (indicators includes a whitespace or end-of-line)
 
     let pats = map(deepcopy(pairs), 'join(v:val, ":")')

--- a/ftplugin/snippets.vim
+++ b/ftplugin/snippets.vim
@@ -30,7 +30,11 @@ augroup END
 " http://www.vim.org/scripts/script.php?script_id=39
 if exists("loaded_matchit") && !exists("b:match_words")
   let b:match_ignorecase = 0
-  let b:match_words = '^snippet\>:^endsnippet\>,^global\>:^endglobal\>,\${:}'
+  function! s:set_match_words() abort
+    let b:match_words = '^snippet\>:^endsnippet\>,^global\>:^endglobal\>,\${:}'
+  endfunction
+  call s:set_match_words()
+  delfunction s:set_match_words
   let s:set_match_words = 1
 endif
 

--- a/ftplugin/snippets.vim
+++ b/ftplugin/snippets.vim
@@ -31,7 +31,13 @@ augroup END
 if exists("loaded_matchit") && !exists("b:match_words")
   let b:match_ignorecase = 0
   function! s:set_match_words() abort
-    let b:match_words = '^snippet\>:^endsnippet\>,^global\>:^endglobal\>,\${:}'
+    let pairs = [
+                \ ['^snippet\>', '^endsnippet\>'],
+                \ ['^global\>', '^endglobal\>'],
+                \ ['\${', '}'],
+                \ ]
+    let pats = map(pairs, 'join(v:val, ":")')
+    let b:match_words = join(pats, ',')
   endfunction
   call s:set_match_words()
   delfunction s:set_match_words

--- a/ftplugin/snippets.vim
+++ b/ftplugin/snippets.vim
@@ -43,6 +43,7 @@ if exists("loaded_matchit") && !exists("b:match_words")
     " set to '}'.
     call add(pairs, ['\${\%(\%(\d\|VISUAL\)\:\ze\|\ze\%(\d\|VISUAL\)\).*\\\@<!}', '\\\@<!}']) " ${1:foo}, ${VISUAL:bar}, ... or ${1}, ${VISUAL}, ...
     call add(pairs, ['\${\%(\d\|VISUAL\)|\ze.*\\\@<!|}', '\\\@<!|}']) " ${1|baz,qux|}
+    call add(pairs, ['\\\@<!`\%(![pv]\|#!\/\f\+\)\%( \|$\)', '\\\@<!`']) " `!p quux`, `!v corge`, `#!/usr/bin/bash grault`, ... (indicators includes a whitespace or end-of-line)
 
     let pats = map(deepcopy(pairs), 'join(v:val, ":")')
     let b:match_words = join(pats, ',')

--- a/ftplugin/snippets.vim
+++ b/ftplugin/snippets.vim
@@ -34,9 +34,17 @@ if exists("loaded_matchit") && !exists("b:match_words")
     let pairs = [
                 \ ['^snippet\>', '^endsnippet\>'],
                 \ ['^global\>', '^endglobal\>'],
-                \ ['\${', '}'],
                 \ ]
-    let pats = map(pairs, 'join(v:val, ":")')
+
+    " Note: Keep the related patterns into a pattern
+    " Because tabstop-patterns such as ${1}, ${1:foo}, ${VISUAL}, ..., end with
+    " the same pattern, '}', matchit could fail to get corresponding '}' in
+    " nested patterns like ${1:${VISUAL:bar}} when the end-pattern is simply
+    " set to '}'.
+    call add(pairs, ['\${\%(\%(\d\|VISUAL\)\:\ze\|\ze\%(\d\|VISUAL\)\).*\\\@<!}', '\\\@<!}']) " ${1:foo}, ${VISUAL:bar}, ... or ${1}, ${VISUAL}, ...
+    call add(pairs, ['\${\%(\d\|VISUAL\)|\ze.*\\\@<!|}', '\\\@<!|}']) " ${1|baz,qux|}
+
+    let pats = map(deepcopy(pairs), 'join(v:val, ":")')
     let b:match_words = join(pats, ',')
   endfunction
   call s:set_match_words()

--- a/ftplugin/snippets.vim
+++ b/ftplugin/snippets.vim
@@ -46,9 +46,10 @@ if exists("loaded_matchit") && !exists("b:match_words")
     call add(pairs, ['\\\@<!`\%(![pv]\|#!\/\f\+\)\%( \|$\)', '\\\@<!`']) " `!p quux`, `!v corge`, `#!/usr/bin/bash grault`, ... (indicators includes a whitespace or end-of-line)
 
     let pats = map(deepcopy(pairs), 'join(v:val, ":")')
-    let b:match_words = join(pats, ',')
+    let match_words = join(pats, ',')
+    return match_words
   endfunction
-  call s:set_match_words()
+  let b:match_words = s:set_match_words()
   delfunction s:set_match_words
   let s:set_match_words = 1
 endif


### PR DESCRIPTION
This PR makes editing tabstops in snippets easier esp. with the plugin, [vim-matchup](https://github.com/andymass/vim-matchup), which is a replacement of classic [matchit](http://ftp.vim.org/pub/vim/runtime/macros/matchit.txt).

## Example

```snippets
${1:fo|o} # "|" is cursor position.
```

then, `ci%`,

```snippets
${1:|}
```

Or,

```snippets                                                             
`!p snip.rv = b|ar`
```                                                                     
                                                            
then, `ci%`,
                                                                        
```snippets                                                             
`!p |`                                                                  
```                                                                     

                                                                        
## Note
It seems undesirable to add `snip.rv` to `b:match_words` as a middle pattern of `!p`-interpolation because it often disturbs to `ci%` to edit an interpolation, or even to `da%` to delete/move a whole interpolation, i.e., no middle pattern is included in `b:match_words` on this PR.