### PR TITLE
Added CanExpandSnippet, CanJumpForwards, CanJumpBackwards

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -94,6 +94,21 @@ function! UltiSnips#SnippetsInCurrentScope(...) abort
     return g:current_ulti_dict
 endfunction
 
+function! UltiSnips#CanExpandSnippet() abort
+	py3 vim.command("let can_expand = %d" % UltiSnips_Manager.can_expand())
+	return can_expand
+endfunction
+
+function! UltiSnips#CanJumpForwards() abort
+	py3 vim.command("let can_jump_forwards = %d" % UltiSnips_Manager.can_jump_forwards())
+	return can_jump_forwards
+endfunction
+
+function! UltiSnips#CanJumpBackwards() abort
+	py3 vim.command("let can_jump_backwards = %d" % UltiSnips_Manager.can_jump_backwards())
+	return can_jump_backwards
+endfunction
+
 function! UltiSnips#SaveLastVisualSelection() range abort
     py3 UltiSnips_Manager._save_last_visual_selection()
     return ""

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -22,6 +22,9 @@ UltiSnips                                      *snippet* *snippets* *UltiSnips*
       3.4.1 UltiSnips#AddSnippetWithPriority    |UltiSnips#AddSnippetWithPriority|
       3.4.2 UltiSnips#Anon                      |UltiSnips#Anon|
       3.4.3 UltiSnips#SnippetsInCurrentScope    |UltiSnips#SnippetsInCurrentScope|
+      3.4.4 UltiSnips#CanExpandSnippet          |UltiSnips#CanExpandSnippet|
+      3.4.5 UltiSnips#CanJumpForwards           |UltiSnips#CanJumpForwards|
+      3.4.6 UltiSnips#CanJumpBackwards          |UltiSnips#CanJumpBackwards|
    3.5 Missing python support                   |UltiSnips-python-warning|
 4. Authoring snippets                           |UltiSnips-authoring-snippets|
    4.1 Basics                                   |UltiSnips-basics|
@@ -472,6 +475,21 @@ function! GetAllSnippets()
   endfor
   return list
 endfunction
+
+ 3.4.4 UltiSnips#CanExpandSnippet    *UltiSnips#CanExpandSnippet*
+
+This function returns 1 if UltiSnips can actually do a meaningful expansion in
+the current situation. This is useful in conditional mappings.
+
+ 3.4.5 UltiSnips#CanJumpForwards    *UltiSnips#CanJumpForwards*
+
+This function returns 1 if UltiSnips can jump forward in the current
+situation. This is useful in conditional mappings.
+
+ 3.4.6 UltiSnips#CanJumpBackwards    *UltiSnips#CanJumpBackwards*
+
+This function returns 1 if UltiSnips can jump backwards in the current
+situation. This is useful in conditional mappings.
 
 3.5 Warning about missing python support           *UltiSnips-python-warning*
 ----------------------------------------

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -808,6 +808,26 @@ class SnippetManager:
         vim_helper.command("let &undolevels = &undolevels")
         return True
 
+    def can_expand(self, autotrigger_only=False):
+        """Check if _try_expand would successfully find a snippet."""
+        before = vim_helper.buf.line_till_cursor
+        snippets = self._snips(before, False, autotrigger_only)
+        if snippets:
+            return True
+        else:
+            return False
+
+    def can_jump_direction(self, direction):
+        if self._current_snippet == None:
+            return False
+        return self._current_snippet.has_next_tab(direction)
+
+    def can_jump_forwards(self):
+        return self.can_jump_direction(JumpDirection.FORWARD)
+
+    def can_jump_backwards(self):
+        return self.can_jump_direction(JumpDirection.BACKWARD)
+
     @property
     def _current_snippet(self):
         """The current snippet or None."""

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -785,10 +785,13 @@ class SnippetManager:
             if self._inside_action:
                 self._snip_expanded_in_action = True
 
+    def _can_expand(self, autotrigger_only=False):
+        before = vim_helper.buf.line_till_cursor
+        return before, self._snips(before, False, autotrigger_only)
+
     def _try_expand(self, autotrigger_only=False):
         """Try to expand a snippet in the current place."""
-        before = vim_helper.buf.line_till_cursor
-        snippets = self._snips(before, False, autotrigger_only)
+        before, snippets = self._can_expand(autotrigger_only)
         if snippets:
             # prefer snippets with context if any
             snippets_with_context = [s for s in snippets if s.context]
@@ -809,24 +812,19 @@ class SnippetManager:
         return True
 
     def can_expand(self, autotrigger_only=False):
-        """Check if _try_expand would successfully find a snippet."""
-        before = vim_helper.buf.line_till_cursor
-        snippets = self._snips(before, False, autotrigger_only)
-        if snippets:
-            return True
-        else:
-            return False
+        """Check if we would be able to successfully find a snippet in the current position."""
+        return bool(self._can_expand(autotrigger_only)[1])
 
-    def can_jump_direction(self, direction):
+    def can_jump(self, direction):
         if self._current_snippet == None:
             return False
         return self._current_snippet.has_next_tab(direction)
 
     def can_jump_forwards(self):
-        return self.can_jump_direction(JumpDirection.FORWARD)
+        return self.can_jump(JumpDirection.FORWARD)
 
     def can_jump_backwards(self):
-        return self.can_jump_direction(JumpDirection.BACKWARD)
+        return self.can_jump(JumpDirection.BACKWARD)
 
     @property
     def _current_snippet(self):

--- a/pythonx/UltiSnips/text_objects/snippet_instance.py
+++ b/pythonx/UltiSnips/text_objects/snippet_instance.py
@@ -139,6 +139,14 @@ class SnippetInstance(EditableTextObject):
 
         return self._tabstops[self._cts]
 
+    def has_next_tab(self, jump_direction: JumpDirection):
+        # This is kind of a hack but it'll keep me from editing code I don't
+        # fully understand
+        cts_bf = self._cts
+        res = self.select_next_tab(jump_direction)
+        self._cts = cts_bf
+        return res != None
+
     def _get_tabstop(self, requester, no):
         # SnippetInstances are completely self contained, therefore, we do not
         # need to ask our parent for Tabstops

--- a/pythonx/UltiSnips/text_objects/snippet_instance.py
+++ b/pythonx/UltiSnips/text_objects/snippet_instance.py
@@ -109,11 +109,11 @@ class SnippetInstance(EditableTextObject):
             return
 
         if jump_direction == JumpDirection.BACKWARD:
-            cts_bf = self._cts
+            current_tabstop_backup = self._cts
 
             res = self._get_prev_tab(self._cts)
             if res is None:
-                self._cts = cts_bf
+                self._cts = current_tabstop_backup
                 return self._tabstops.get(self._cts, None)
             self._cts, ts = res
             return ts
@@ -137,15 +137,12 @@ class SnippetInstance(EditableTextObject):
         else:
             assert False, "Unknown JumpDirection: %r" % jump_direction
 
-        return self._tabstops[self._cts]
-
     def has_next_tab(self, jump_direction: JumpDirection):
-        # This is kind of a hack but it'll keep me from editing code I don't
-        # fully understand
-        cts_bf = self._cts
-        res = self.select_next_tab(jump_direction)
-        self._cts = cts_bf
-        return res != None
+        if jump_direction == JumpDirection.BACKWARD:
+            return self._get_prev_tab(self._cts) is not None
+        # There is always a next tabstop if we jump forward, since the snippet
+        # instance is deleted once we reach tabstop 0.
+        return True
 
     def _get_tabstop(self, requester, no):
         # SnippetInstances are completely self contained, therefore, we do not


### PR DESCRIPTION
Closes #786.

Adds three functions, `UltiSnips#CanExpandSnippet`, `UltiSnips#CanJumpForwards`, and `UltiSnips#CanJumpBackwards`, which *significantly* cleans up more complex expansion functions.

The issue with the current method is that it requires we actually *run* the `<C-R>=UltiSnips#ExpandSnippet()<CR>` then check the result. This makes actually doing anything after it very difficult if you're in an `<expr>` mapping. Now we can have `<expr>` mappings that look like this: 

```lua
function expand_or_jump()
    -- ...
    if vim.api.nvim_eval([[ UltiSnips#CanExpandSnippet() ]]) == 1 then
        return [[ <C-R>=UltiSnips#ExpandSnippet()<CR> ]]
    end
    -- ...
end
```

and etc.

Issue #786 was previously closed because it was said that `UltiSnips#SnippetsInCurrentScope()` has the same functionality, but it actually doesn't as I pointed out in the comments.