### PR TITLE
Fix race condition in checking vim startup.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,10 @@
-on: [push, pull_request]
+on:  
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-on:  
+on:
   push:
     branches:
       - master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,6 @@ jobs:
     name: Build & Test using Docker
     steps:
       - uses: actions/checkout@v2
-      # We only cache non-git versions of the build, otherwise we will never reclone.
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        if: ${{ matrix.vim_version != 'git' }}
       - name: Build the image
         run: docker build -t ultisnips:${{ matrix.tag }} --build-arg PYTHON_IMAGE=${{ matrix.python_image }} --build-arg VIM_VERSION=${{ matrix.vim_version }} .
       - name: Run the tests

--- a/test/vim_interface.py
+++ b/test/vim_interface.py
@@ -137,7 +137,7 @@ class VimInterface(TempFileManager):
         post_config.append("with open('%s', 'w') as version_file:" % version_file)
         post_config.append("    version_file.write('%i.%i.%i' % sys.version_info[:3])")
         post_config.append("with open('%s', 'w') as done_file:" % done_file)
-        post_config.append("    done_file.write('all_done!'")
+        post_config.append("    done_file.write('all_done!')")
         post_config.append("EOF")
 
         config_path = self.write_temp(

--- a/test/vim_interface.py
+++ b/test/vim_interface.py
@@ -120,6 +120,9 @@ class VimInterface(TempFileManager):
     def launch(self, config=[]):
         """Returns the python version in Vim as a string, e.g. '3.7'"""
         pid_file = self.name_temp("vim.pid")
+        version_file = self.name_temp("vim_version")
+        if os.path.exists(version_file):
+            os.remove(version_file)
         done_file = self.name_temp("loading_done")
         if os.path.exists(done_file):
             os.remove(done_file)
@@ -131,8 +134,10 @@ class VimInterface(TempFileManager):
             "with open('%s', 'w') as pid_file: pid_file.write(vim.eval('getpid()'))"
             % pid_file
         )
+        post_config.append("with open('%s', 'w') as version_file:" % version_file)
+        post_config.append("    version_file.write('%i.%i.%i' % sys.version_info[:3])")
         post_config.append("with open('%s', 'w') as done_file:" % done_file)
-        post_config.append("    done_file.write('%i.%i.%i' % sys.version_info[:3])")
+        post_config.append("    done_file.write('all_done!'")
         post_config.append("EOF")
 
         config_path = self.write_temp(
@@ -149,7 +154,7 @@ class VimInterface(TempFileManager):
         )
         wait_until_file_exists(done_file)
         self._vim_pid = int(_read_text_file(pid_file))
-        return _read_text_file(done_file).strip()
+        return _read_text_file(version_file).strip()
 
     def leave_with_wait(self):
         self.send_to_vim(3 * ESC + ":qa!\n")


### PR DESCRIPTION
Apparently, the new test runners are non-atomic in creating & writing to the done file. Since it contains the vim version that we expect to see this leads to us sometimes reading an empty string.

This fixes this race condition by having one version file (written first) and one done file where we do not care about the content.