### PR TITLE
Expand snipMate snippets with 'i' option

### DIFF
--- a/pythonx/UltiSnips/snippet/definition/snipmate.py
+++ b/pythonx/UltiSnips/snippet/definition/snipmate.py
@@ -20,7 +20,7 @@ class SnipMateSnippetDefinition(SnippetDefinition):
             trigger,
             value,
             description,
-            "",
+            "i",
             {},
             location,
             None,

--- a/test/test_SnipMate.py
+++ b/test/test_SnipMate.py
@@ -222,3 +222,14 @@ snippet /*
  * 2
  */
 """
+
+class snipMate_Issue1325(_VimTest):
+    # https://github.com/SirVer/ultisnips/issues/1325
+    files = {
+        "snippets/_.snippets": """
+snippet frac \\frac{}{}
+\t\\\\frac{${1:num}}{${2:denom}} ${0}
+""".rstrip()
+    }
+    keys = "$frac" + EX + JF + JF + "blub"
+    wanted = r"$\frac{num}{denom} blub"

--- a/test_all.py
+++ b/test_all.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: utf-8
 #
 # See CONTRIBUTING.md for an explanation of this file.


### PR DESCRIPTION
This seems to be the default for recent versions of snipMate in the wild, and we follow suite to retain compatibility.

Fixes #1325.