### PR TITLE
Use a valid unite kind variable

### DIFF
--- a/autoload/unite/sources/ultisnips.vim
+++ b/autoload/unite/sources/ultisnips.vim
@@ -67,7 +67,7 @@ function! s:unite_source.gather_candidates(args, context) abort
     let curr_val = copy(default_val)
     let curr_val['word'] = printf('%-*s', max_len, snip[0]) . "     " . snip[1]
     let curr_val['trigger'] = snip[0]
-    let curr_val['kind'] = 'snippet'
+    let curr_val['kind'] = 'common'
     call add(canditates, curr_val)
   endfor
   return canditates


### PR DESCRIPTION
Fix #1337.

Unite defines a list of valid values for 'kind' in
`:help unite-kind-variables`. UltiSnips was using a custom one, but
doesn't seem to be adding a custom implementation for it. Instead, use
the default 'common' one. This allows
s:unite_source.action_table.expand.func to be called when the snippet is
invoked.

Test
Follow steps and minimal vimrc on issue #1337: invoke unite and expand
first snippet.