### PR TITLE
Expand snipMate snippets with 'w' instead of 'i'

### DIFF
--- a/pythonx/UltiSnips/snippet/definition/snipmate.py
+++ b/pythonx/UltiSnips/snippet/definition/snipmate.py
@@ -20,7 +20,7 @@ class SnipMateSnippetDefinition(SnippetDefinition):
             trigger,
             value,
             description,
-            "i",
+            "w",
             {},
             location,
             None,

--- a/test/test_SnipMate.py
+++ b/test/test_SnipMate.py
@@ -242,6 +242,6 @@ snippet .
 \tself.
 """.rstrip()
     }
-    keys = "os." + EX + "foo"
-    wanted = "os.\tfoo"
+    keys = "os." + EX + "foo\n." + EX
+    wanted = "os.\tfoo\nself."
 

--- a/test/test_SnipMate.py
+++ b/test/test_SnipMate.py
@@ -233,3 +233,15 @@ snippet frac \\frac{}{}
     }
     keys = "$frac" + EX + JF + JF + "blub"
     wanted = r"$\frac{num}{denom} blub"
+
+class snipMate_Issue1344(_VimTest):
+    # https://github.com/SirVer/ultisnips/issues/144
+    files = {
+        "snippets/_.snippets": """
+snippet .
+\tself.
+""".rstrip()
+    }
+    keys = "os." + EX + "foo"
+    wanted = "os.\tfoo"
+


### PR DESCRIPTION
This restores correct snipMate expansion behavior for esoteric snippets like `.` as trigger.

Fixes #1344, #1345

