### PR TITLE
Correctly handle escaping backslashes in Placeholder defaults

### DIFF
--- a/pythonx/UltiSnips/snippet/parsing/lexer.py
+++ b/pythonx/UltiSnips/snippet/parsing/lexer.py
@@ -75,7 +75,7 @@ def _parse_till_closing_brace(stream):
     rv = ""
     in_braces = 1
     while True:
-        if EscapeCharToken.starts_here(stream, "{}"):
+        if EscapeCharToken.starts_here(stream, "\\{}"):
             rv += next(stream) + next(stream)
         else:
             char = next(stream)

--- a/test/test_Expand.py
+++ b/test/test_Expand.py
@@ -75,3 +75,9 @@ class SimpleExpand_DoNotClobberDefaultRegister(_VimTest):
 
     def _extra_vim_config(self, vim_config):
         vim_config.append('let @"=""')
+
+class SimpleExpand_Issue1343(_VimTest):
+    snippets = ("test", r"${1:\Safe\\}")
+    keys = "test" + EX + JF + "foo"
+    wanted = r"\Safe\foo"
+


### PR DESCRIPTION
Fixes #1343.