### PR TITLE
Fix #1339 wrong cursor position in nested snippets

### DIFF
--- a/docker/snippets/all.snippets
+++ b/docker/snippets/all.snippets
@@ -1,7 +1,3 @@
-snippet test "test"
-$1$1 $0
-endsnippet
-
-snippet outer "outer"
-$1 $0
+snippet example "Repro case example"
+This is a simple snippet example
 endsnippet

--- a/docker/snippets/all.snippets
+++ b/docker/snippets/all.snippets
@@ -1,3 +1,7 @@
-snippet example "Repro case example"
-This is a simple snippet example
+snippet test "test"
+$1$1 $0
+endsnippet
+
+snippet outer "outer"
+$1 $0
 endsnippet

--- a/pythonx/UltiSnips/debug.py
+++ b/pythonx/UltiSnips/debug.py
@@ -21,13 +21,14 @@ with open(DUMP_FILENAME, "w"):
 def echo_to_hierarchy(text_object):
     """Outputs the given 'text_object' and its children hierarchically."""
     # pylint:disable=protected-access
+    orig = text_object
     parent = text_object
     while parent._parent:
         parent = parent._parent
 
     def _do_print(text_object, indent=""):
         """prints recursively."""
-        debug(indent + text_object)
+        debug(indent + ("MAIN: " if text_object == orig else "") + str(text_object))
         try:
             for child in text_object._children:
                 _do_print(child, indent=indent + "  ")
@@ -47,5 +48,5 @@ def print_stack():
     """Dump a stack trace into the debug file."""
     import traceback
 
-    with open(DUMP_FILENAME, "ab") as dump_file:
+    with open(DUMP_FILENAME, "a") as dump_file:
         traceback.print_stack(file=dump_file)

--- a/pythonx/UltiSnips/diff.py
+++ b/pythonx/UltiSnips/diff.py
@@ -139,7 +139,7 @@ def guess_edit(initial_line, last_text, current_text, vim_state):
                     if is_complete_edit(initial_line, last_text, current_text, es):
                         return True, es
         elif len(current_text) < len(last_text):
-            # where some lines deleted? (dd or so)
+            # were some lines deleted? (dd or so)
             es = []
             for i in range(len(last_text) - len(current_text)):
                 es.append(("D", pos.line, 0, last_text[pos.line - initial_line + i]))

--- a/test/test_Mirror.py
+++ b/test/test_Mirror.py
@@ -103,6 +103,31 @@ class SimpleMirrorSameLine_ExpectCorrectResult(_VimTest):
     keys = "test" + EX + "hallo"
     wanted = "hallo hallo"
 
+class SimpleMirrorSameLineNoSpace_ExpectCorrectResult(_VimTest):
+    snippets = ("test", "$1$1")
+    keys = "test" + EX + "hallo"
+    wanted = "hallohallo"
+
+class SimpleMirrorSameLineNoSpaceInsideOther_ExpectCorrectResult(_VimTest):
+    snippets = (
+        ("test", "$1$1"),
+        ("outer", "$1")
+    )
+    keys = "outer" + EX + "test" + EX + "hallo"
+    wanted = "hallohallo"
+
+class SimpleMirrorSameLineNoSpaceSpaceAfter_ExpectCorrectResult(_VimTest):
+    snippets = ("test", "$1$1 ")
+    keys = "test" + EX + "hallo"
+    wanted = "hallohallo "
+
+class SimpleMirrorSameLineNoSpaceInsideOtherSpaceAfter_ExpectCorrectResult(_VimTest):
+    snippets = (
+        ("test", "$1$1 "),
+        ("outer", "$1")
+    )
+    keys = "outer" + EX + "test" + EX + "hallo"
+    wanted = "hallohallo "
 
 class SimpleMirrorSameLine_InText_ExpectCorrectResult(_VimTest):
     snippets = ("test", "$1 $1")


### PR DESCRIPTION
This PR fixes the problem mentioned in issue #1339. _VimCursor dummy NoneditableTextObject is now created as a child of the EditableTextObject actually being edited at that time. Thereby it is ensured that it is unambiguous which mirrors should and should not move the cursor position further. It also resolves general issues when a snippet contains only tabstops and mirrors and no actual text.

Tests have been added to ensure that this remains functional and the test suite completes successfully.