### PR TITLE
Report user errors without backtrace.

### DIFF
--- a/pythonx/UltiSnips/buffer_proxy.py
+++ b/pythonx/UltiSnips/buffer_proxy.py
@@ -2,8 +2,9 @@
 
 import vim
 from UltiSnips import vim_helper
-from UltiSnips.position import Position
 from UltiSnips.diff import diff
+from UltiSnips.error import PebkacError
+from UltiSnips.position import Position
 
 from contextlib import contextmanager
 
@@ -81,7 +82,7 @@ class VimBufferProxy(vim_helper.VimBuffer):
         Raises exception if buffer is changes beyound proxy object.
         """
         if self.is_buffer_changed_outside():
-            raise RuntimeError(
+            raise PebkacError(
                 "buffer was modified using vim.command or "
                 + "vim.current.buffer; that changes are untrackable and leads to "
                 + "errors in snippet expansion; use special variable `snip.buffer` "

--- a/pythonx/UltiSnips/error.py
+++ b/pythonx/UltiSnips/error.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+
+class PebkacError(RuntimeError):
+    """An error that was caused by a misconfiguration or error in a snippet,
+    i.e. caused by the user. Hence: "Problem exists between keyboard and
+    chair".
+    """
+
+    pass

--- a/pythonx/UltiSnips/snippet/definition/base.py
+++ b/pythonx/UltiSnips/snippet/definition/base.py
@@ -9,10 +9,11 @@ import vim
 import textwrap
 
 from UltiSnips import vim_helper
+from UltiSnips.error import PebkacError
 from UltiSnips.indent_util import IndentUtil
+from UltiSnips.position import Position
 from UltiSnips.text import escape
 from UltiSnips.text_objects import SnippetInstance
-from UltiSnips.position import Position
 from UltiSnips.text_objects.python_code import SnippetUtilForAction
 
 __WHITESPACE_SPLIT = re.compile(r"\s")
@@ -216,7 +217,7 @@ class SnippetDefinition:
                         cursor_invalid = True
 
                 if cursor_invalid:
-                    raise RuntimeError(
+                    raise PebkacError(
                         "line under the cursor was modified, but "
                         + '"snip.cursor" variable is not set; either set set '
                         + '"snip.cursor" to new cursor position, or do not '

--- a/pythonx/UltiSnips/snippet/parsing/lexer.py
+++ b/pythonx/UltiSnips/snippet/parsing/lexer.py
@@ -7,6 +7,7 @@ definitions into logical units called Tokens."""
 import string
 import re
 
+from UltiSnips.error import PebkacError
 from UltiSnips.position import Position
 from UltiSnips.text import unescape
 
@@ -184,7 +185,7 @@ class VisualToken(Token):
                 self.replace = _parse_till_unescaped_char(stream, "/")[0]
                 self.options = _parse_till_closing_brace(stream)
             except StopIteration:
-                raise RuntimeError(
+                raise PebkacError(
                     "Invalid ${VISUAL} transformation! Forgot to escape a '/'?"
                 )
         else:
@@ -272,7 +273,7 @@ class ChoicesToken(Token):
         self.number = _parse_number(stream)
 
         if self.number == 0:
-            raise RuntimeError("Choices selection is not supported on $0")
+            raise PebkacError("Choices selection is not supported on $0")
 
         next(stream)  # |
 

--- a/pythonx/UltiSnips/snippet/parsing/ulti_snips.py
+++ b/pythonx/UltiSnips/snippet/parsing/ulti_snips.py
@@ -30,6 +30,7 @@ from UltiSnips.text_objects import (
     Visual,
     Choices,
 )
+from UltiSnips.error import PebkacError
 
 _TOKEN_TO_TEXTOBJECT = {
     EscapeCharToken: EscapedChar,
@@ -58,7 +59,7 @@ def _create_transformations(all_tokens, seen_ts):
     for parent, token in all_tokens:
         if isinstance(token, TransformationToken):
             if token.number not in seen_ts:
-                raise RuntimeError(
+                raise PebkacError(
                     "Tabstop %i is not known but is used by a Transformation"
                     % token.number
                 )

--- a/pythonx/UltiSnips/snippet/source/file/base.py
+++ b/pythonx/UltiSnips/snippet/source/file/base.py
@@ -6,12 +6,13 @@
 from collections import defaultdict
 import os
 
-from UltiSnips import vim_helper
 from UltiSnips import compatibility
+from UltiSnips import vim_helper
+from UltiSnips.error import PebkacError
 from UltiSnips.snippet.source.base import SnippetSource
 
 
-class SnippetSyntaxError(RuntimeError):
+class SnippetSyntaxError(PebkacError):
 
     """Thrown when a syntax error is found in a file."""
 

--- a/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
+++ b/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
@@ -9,6 +9,7 @@ import os
 from typing import Set, List
 
 from UltiSnips import vim_helper
+from UltiSnips.error import PebkacError
 from UltiSnips.snippet.definition import UltiSnipsSnippetDefinition
 from UltiSnips.snippet.source.file.base import SnippetFileSource
 from UltiSnips.snippet.source.file.common import (
@@ -52,7 +53,7 @@ def find_all_snippet_directories() -> List[str]:
     for rtp in check_dirs:
         for snippet_dir in snippet_dirs:
             if snippet_dir == "snippets":
-                raise RuntimeError(
+                raise PebkacError(
                     "You have 'snippets' in UltiSnipsSnippetDirectories. This "
                     "directory is reserved for snipMate snippets. Use another "
                     "directory for UltiSnips snippets."

--- a/pythonx/UltiSnips/text_objects/snippet_instance.py
+++ b/pythonx/UltiSnips/text_objects/snippet_instance.py
@@ -10,6 +10,7 @@ also a TextObject.
 """
 
 from UltiSnips import vim_helper
+from UltiSnips.error import PebkacError
 from UltiSnips.position import Position, JumpDirection
 from UltiSnips.text_objects.base import EditableTextObject, NoneditableTextObject
 from UltiSnips.text_objects.tabstop import TabStop
@@ -100,7 +101,7 @@ class SnippetInstance(EditableTextObject):
                     done.add(obj)
             counter -= 1
         if not counter:
-            raise RuntimeError(
+            raise PebkacError(
                 "The snippets content did not converge: Check for Cyclic "
                 "dependencies or random strings in your snippet. You can use "
                 "'if not snip.c' to make sure to only expand random output "

--- a/pythonx/UltiSnips/vim_helper.py
+++ b/pythonx/UltiSnips/vim_helper.py
@@ -7,9 +7,10 @@ from contextlib import contextmanager
 import os
 import platform
 
-from UltiSnips.snippet.source.file.common import normalize_file_path
 from UltiSnips.compatibility import col2byte, byte2col
+from UltiSnips.error import PebkacError
 from UltiSnips.position import Position
+from UltiSnips.snippet.source.file.common import normalize_file_path
 from vim import error  # pylint:disable=import-error,unused-import
 import vim  # pylint:disable=import-error
 
@@ -230,7 +231,7 @@ def get_dot_vim():
     for candidate in candidates:
         if os.path.isdir(candidate):
             return normalize_file_path(candidate)
-    raise RuntimeError(
+    raise PebkacError(
         "Unable to find user configuration directory. I tried '%s'." % candidates
     )
 


### PR DESCRIPTION
Report user errors like configuration mistakes or syntax errors in snippet files without lengthy backtrace (that is irrelevant to the user), instead just report the actual error as identified by UltiSnips.

These errors are named Pebkac in the code (Problem exists between keyboard and chair).