### PR TITLE
Added Stores for python interpolations. Implements #1393

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -25,7 +25,8 @@ UltiSnips                                      *snippet* *snippets* *UltiSnips*
       3.4.4 UltiSnips#CanExpandSnippet          |UltiSnips#CanExpandSnippet|
       3.4.5 UltiSnips#CanJumpForwards           |UltiSnips#CanJumpForwards|
       3.4.6 UltiSnips#CanJumpBackwards          |UltiSnips#CanJumpBackwards|
-   3.5 Missing python support                   |UltiSnips-python-warning|
+   3.5 Store persistence directory              |UltiSnips-store-directory|
+   3.6 Missing python support                   |UltiSnips-python-warning|
 4. Authoring snippets                           |UltiSnips-authoring-snippets|
    4.1 Basics                                   |UltiSnips-basics|
       4.1.1 How snippets are loaded             |UltiSnips-how-snippets-are-loaded|
@@ -492,13 +493,15 @@ This function returns 1 if UltiSnips can jump backwards in the current
 situation. This is useful in conditional mappings.
 
 
-3.5 Store persistence directory                         *g:UltiSnipsStoreDir*
+3.5 Store persistence directory                   *UltiSnips-store-directory*
 -------------------------------
+                                                        *g:UltiSnipsStoreDir*
+Some interpolation data stores need persistence ('file' and 'common' stores).
+The g:UltiSnipsStoreDir should to be set to an absolute path string pointing
+to an existing directory to provide this functionality. If not set, or set
+to v:null, these stores will behave like 'buffer' and 'session'. >
 
-Some interpolation data stores need persistence ('file' and 'common' sotres).
-The g:UltiSnipsStoreDir should to be set to an existing directory to provide
-this functionnality. if not set, or set to v:null, these stores will behave
-like 'buffer' and 'session'.
+   let g:UltiSnipsSnippetDirectories="~/.vim/UltiSnips/stores"
 
 
 3.6 Warning about missing python support           *UltiSnips-python-warning*
@@ -509,9 +512,9 @@ python support.  If no support is detected, a warning will be displayed and
 loading of UltiSnips will be skipped.
 
 If you would like to suppress this warning message, you may add the following
-line to your vimrc file.
+line to your vimrc file. >
 
-    let g:UltiSnipsNoPythonWarning = 1
+   let g:UltiSnipsNoPythonWarning = 1
 
 This may be useful if your Vim configuration files are shared across several
 systems where some of them may not have Vim compiled with python support.
@@ -970,12 +973,13 @@ snippet executions: >
 
     snip.store.tmp:
         A temporary local store accessible only during the snippet execution
-        and updates in the same python code section. It is reset each time the snippet is called, but not
-        between updates.
+        and updates in the same python code section. It is reset each time the
+        snippet is called, but not between updates.
 
     snip.store.snippet:
         A temporary local store accessible only during the snippet execution
-        and updates in all python code sections. It is reset each time the snippet is called, but not
+        and updates in all python code sections. It is reset each time the snippet
+        is called, but not
         between updates.
 
     snip.store.buffer:
@@ -992,13 +996,21 @@ snippet executions: >
         similary to store.buffer.
 
     snip.store.common:
-        A persistent global store common to all snippet executions in all buffers and any
-        vim instance. If g:UltiSnipStoreDir is unset or set to v:null, then it behave
-        similary to store.session.
+        A persistent global store common to all snippet executions in all buffers
+        and any vim instance. If g:UltiSnipStoreDir is unset or set to v:null,
+        then it behave similary to store.session.
 
-The stores have some syntax sugars compared to built-in dicts : >
+Note : The stores are persisted as json. Keys and data stored are subject to the
+same limitations as the `json` python module (keys should be strings, and data
+should be made of 'None', 'bool' 'int', 'float', 'string', 'list' and 'dict').
+
+Note : Since JSON is a plain text file format, snippets should not store any
+sensitive information. If you are using this feature, please advise your users
+of this risk (e.g. Database passwords, private keys etc.).
+
+The stores have some syntax sugars in addition to built-in dict interface : >
     store['key', default]
-      where default is either a value either a factory is equivalent to:
+      where default is either a value either a factory, is equivalent to:
       if key not in store:
         store['key'] = default
       return store['key']

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -491,7 +491,17 @@ situation. This is useful in conditional mappings.
 This function returns 1 if UltiSnips can jump backwards in the current
 situation. This is useful in conditional mappings.
 
-3.5 Warning about missing python support           *UltiSnips-python-warning*
+
+3.5 Store persistence directory                         *g:UltiSnipsStoreDir*
+-------------------------------
+
+Some interpolation data stores need persistence ('file' and 'common' sotres).
+The g:UltiSnipsStoreDir should to be set to an existing directory to provide
+this functionnality. if not set, or set to v:null, these stores will behave
+like 'buffer' and 'session'.
+
+
+3.6 Warning about missing python support           *UltiSnips-python-warning*
 ----------------------------------------
 
 When UltiSnips is loaded, it will check that the running Vim was compiled with
@@ -954,6 +964,44 @@ The 'snip' object provides some properties as well: >
         'start' - placeholder start on the moment of selection;
         'end' - placeholder end on the moment of selection;
 
+
+The 'snip.store' object provides dict-like stores to remember variables accross
+snippet executions: >
+
+    snip.store.tmp:
+        A temporary local store accessible only during the snippet execution
+        and updates. It is reset each time the snippet is called, but not
+        between updates.
+
+    snip.store.buffer:
+        A store accessible to all snippets executed in the same buffer. Each
+        buffer has its own one.
+
+    snip.store.session:
+        A store accessible to all snippets in a same vim instance.
+
+    snip.store.file:
+        A persistent store attached to a file. Any snippet executed on the
+        same file (possibly on different vim instances) will access the same
+        store. If g:UltiSnipStoreDir is unset or set to v:null, then it behave
+        similary to store.buffer.
+
+    snip.store.common:
+        A persistent global store common to all snippet executions in all buffers and any
+        vim instance. If g:UltiSnipStoreDir is unset or set to v:null, then it behave
+        similary to store.session.
+
+The stores have some syntax sugars compared to built-in dicts : >
+    store['key', default]
+      where default is either a value either a factory is equivalent to:
+      if key not in store:
+        store['key'] = default
+      return store['key']
+
+    store.key
+      is equivalent to store['key']. Limitation : key should not start with an
+      underscore '_'
+
 For your convenience, the 'snip' object also provides the following
 operators: >
 
@@ -980,6 +1028,37 @@ endsnippet
 ------------------- SNAP -------------------
 wow<tab>Hello World ->
 Hello World                                                     HELLO WORLD
+
+
+The following snippet uses the file store to remember the last test suite used
+
+------------------- SNIP -------------------
+snippet test
+TEST(${1:`!psnip.rv=snip.store.file['test_suite', '']`}, $2){
+    $0
+}`!p
+snip.store.file.test_suite = t[1]
+`
+endsnippet
+
+
+The following snippet implements a counter. It uses the 'tmp' store to make
+sure the counter is incremented only once (else, the snippet update would run the
+code again)
+
+------------------- SNIP -------------------
+snippet inc "increment"
+`!p
+if snip.store.tmp['todo', True]:
+    snip.rv = snip.store.file['i', 1]
+    snip.store.file.i += 1
+    snip.store.tmp.todo = False
+`
+endsnippet
+------------------- SNAP -------------------
+inc<tab> inc<tab> inc<tab> ->
+1 2 3
+
 
 The following snippet uses the regular expression option and illustrates
 regular expression grouping using python's match object. It shows that the

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -970,7 +970,12 @@ snippet executions: >
 
     snip.store.tmp:
         A temporary local store accessible only during the snippet execution
-        and updates. It is reset each time the snippet is called, but not
+        and updates in the same python code section. It is reset each time the snippet is called, but not
+        between updates.
+
+    snip.store.snippet:
+        A temporary local store accessible only during the snippet execution
+        and updates in all python code sections. It is reset each time the snippet is called, but not
         between updates.
 
     snip.store.buffer:

--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -10,6 +10,11 @@ if version < 704
    finish
 endif
 
+" Where to save the stores
+if !exists("g:UltiSnipsStoreDir")
+   let g:UltiSnipsStoreDir = v:null
+endif
+
 " The Commands we define.
 command! -bang -nargs=? -complete=customlist,UltiSnips#FileTypeComplete UltiSnipsEdit
     \ :call UltiSnips#Edit(<q-bang>, <q-args>)

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -537,7 +537,7 @@ class SnippetManager:
 
     def _current_snippet_is_done(self):
         """The current snippet should be terminated."""
-        self._active_snippets.pop()
+        self._active_snippets.pop().done()
         if not self._active_snippets:
             self._teardown_inner_state()
 

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -145,7 +145,7 @@ class SnippetManager:
         self._should_update_textobjects = False
         self._should_reset_visual = False
 
-        self._storeManager = StoreManager()
+        self._store_manager = StoreManager()
 
         self._reinit()
 
@@ -469,7 +469,7 @@ class SnippetManager:
             "silent doautocmd <nomodeline> User UltiSnipsEnterFirstSnippet"
         )
 
-        self._storeManager._setup_state()
+        self._store_manager._setup_state()
 
         self._inner_state_up = True
 
@@ -477,7 +477,7 @@ class SnippetManager:
         """Reverse _setup_inner_state."""
         if not self._inner_state_up:
             return
-        self._storeManager._teardown_state()
+        self._store_manager._teardown_state()
         try:
             vim_helper.command(
                 "silent doautocmd <nomodeline> User UltiSnipsExitLastSnippet"

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -26,6 +26,7 @@ from UltiSnips.snippet.source import (
 from UltiSnips.text import escape
 from UltiSnips.vim_state import VimState, VisualContentPreserver
 from UltiSnips.buffer_proxy import use_proxy_buffer, suspend_proxy_edits
+from UltiSnips.store import StoreManager
 
 
 def _ask_user(a, formatted):
@@ -143,6 +144,8 @@ class SnippetManager:
 
         self._should_update_textobjects = False
         self._should_reset_visual = False
+
+        self._storeManager = StoreManager()
 
         self._reinit()
 
@@ -465,12 +468,16 @@ class SnippetManager:
         vim_helper.command(
             "silent doautocmd <nomodeline> User UltiSnipsEnterFirstSnippet"
         )
+
+        self._storeManager._setup_state()
+
         self._inner_state_up = True
 
     def _teardown_inner_state(self):
         """Reverse _setup_inner_state."""
         if not self._inner_state_up:
             return
+        self._storeManager._teardown_state()
         try:
             vim_helper.command(
                 "silent doautocmd <nomodeline> User UltiSnipsExitLastSnippet"

--- a/pythonx/UltiSnips/store.py
+++ b/pythonx/UltiSnips/store.py
@@ -15,13 +15,7 @@ class Store(object):
         if isinstance(key, tuple) :
             key, _default = key
             key = str(key)
-            if key not in self._dict :
-                try :
-                    default = _default()
-                except :
-                    default = _default
-                self[key] = default
-                return default
+            return self.setdefault(key, _default)
         else :
             key = str(key)
         return self._dict[key]
@@ -43,6 +37,8 @@ class Store(object):
             self[key] = val
 
     def __setitem__(self, key, val):
+        if isinstance(key, tuple) :
+          key, _default = key
         key = str(key)
         return self._dict.__setitem__(key, val)
     def __delitem__(self, *args, **kwargs):
@@ -59,6 +55,26 @@ class Store(object):
 
     def save(self):
         pass
+
+    def get(self, *args):
+        """
+        get(key[, default[, assigned_val]])
+        Return for key if key is in the dictionary, else defaut.
+        If assigned_val is present and key is not in the dict,
+        assigned_val is assigned for the key, else nothing is inserted.
+        """
+        # If the call corresponds to dict.get() signature, forward
+        arg_count = len(args)
+        if arg_count <= 2:
+            return self._dict.get(*args)
+        if arg_count > 3 :
+            raise TypeError(f'get expected at most 3 arguments, got {arg_count}')
+        # else Do assign machinery
+        if args[0] in self._dict :
+          return self._dict[args[0]]
+        self._dict[args[0]] = args[2]
+        return args[1]
+        
 
 
 class BufferStore(Store):

--- a/pythonx/UltiSnips/store.py
+++ b/pythonx/UltiSnips/store.py
@@ -205,13 +205,13 @@ class StoreManager(object):
     """
     def __init__(self):
         self._reset()
-        self._tmp = []
 
     def _reset(self):
         self.buffer = None
         self.session = None
         self.file = None
         self.common = None
+        self._snippet = []
 
     def _setup_state(self):
         number = vim_helper.buf.number
@@ -224,4 +224,14 @@ class StoreManager(object):
         self.file.save()
         self.common.save()
         self._reset()
+
+    def _pushSnippet(self):
+        self._snippet.append(BufferStore())
+
+    def _popSnippet(self):
+        self._snippet.pop()
+
+    @property
+    def snippet(self):
+        return self._snippet[-1]
 

--- a/pythonx/UltiSnips/store.py
+++ b/pythonx/UltiSnips/store.py
@@ -1,0 +1,227 @@
+from UltiSnips import vim_helper
+from pathlib import Path
+import json
+from collections import defaultdict
+
+class Store(object):
+    """
+    A dict-like supporting supporting the obj[key, default] synthax
+    """
+    def __init__(self):
+        self._dict = dict()
+
+    def __getitem__(self, key):
+        if isinstance(key, tuple) :
+            key, _default = key
+            key = str(key)
+            if key not in self._dict :
+                try :
+                    default = _default()
+                except :
+                    default = _default
+                self[key] = default
+                return default
+        else :
+            key = str(key)
+        return self._dict[key]
+
+    def __getattr__(self, key):
+        try :
+            return getattr(self._dict, key)
+        except :
+            try :
+                return self[key]
+            except :
+                pass
+            raise
+
+    def __setattr__(self, key, val):
+        if key[0] == '_' :
+            return super().__setattr__(key, val)
+        else :
+            self[key] = val
+
+    def __setitem__(self, key, val):
+        key = str(key)
+        return self._dict.__setitem__(key, val)
+    def __delitem__(self, *args, **kwargs):
+        return self._dict.__delitem__(*args, **kwargs)
+    def __len__(self, *args, **kwargs):
+        return self._dict.__len__(*args, **kwargs)
+    def __iter__(self, *args, **kwargs):
+        return self._dict.__iter__(*args, **kwargs)
+    def __iter__(self, *args, **kwargs):
+        return self._dict.__iter__(*args, **kwargs)
+
+    def load(self):
+        pass
+
+    def save(self):
+        pass
+
+
+class BufferStore(Store):
+    """
+    A data store local to a buffer. Any python interpolation in a snippet running the same buffer
+    access the same instance through `snip.store.buffer`
+    """
+    def __init__(self):
+        self._dict = dict()
+
+    _stores = defaultdict(lambda : BufferStore())
+
+    @classmethod
+    def bufferStore(cls, buffer_number):
+        return cls._stores[buffer_number]
+
+
+    @classmethod
+    def currentBufferStore(cls):
+        """
+        Gets or create the store for the current buffer.
+        """
+        return cls.bufferStore(vim_helper.buf.number)
+
+    @classmethod
+    def clean(cls):
+        """
+        Check each buffer if it is alive, else delete it.
+        """
+        keys = set(cls._stores.keys())
+        alive = { b.number for b in vim_helper.vim.buffers if b.valid }
+        for k in keys - alive:
+            del cls._stores[k]
+
+
+class SessionStore(Store):
+    """
+    A Store common to a vim instance. Any python interpolation of any snippet in any buffer can access
+    the same instance through `snip.store.session`
+    """
+    def __init__(self):
+        self._dict = dict()
+
+    _store = None
+    @classmethod
+    def get(cls):
+        if cls._store is None :
+            cls._store = cls()
+        return cls._store
+
+
+class _PersistentStore(Store):
+    """
+    A Store persistent saved to json format.
+    """
+    def __init__(self, path):
+        self._path = path
+        self.load()
+        self._changed = False
+
+    def load(self):
+        try :
+            with open(self._path, 'r') as f :
+                self._dict = json.load(f)
+        except :
+            self._dict = dict()
+
+    def save(self):
+        if self._changed :
+            with open(self._path, 'w') as f :
+                json.dump(self._dict, f)
+
+    def __setitem__(self, key, val):
+        self._changed = True
+        super().__setitem__(key, val)
+
+
+def _encodeFilePath(path):
+    return str(Path(path).resolve()).replace('%', '_%%_').replace('/', '%')
+
+def _storeDir():
+    p = vim_helper.eval('g:UltiSnipsStoreDir')
+    if p is not None :
+        return Path(p).expanduser().resolve()
+    return None
+
+
+class FileStore(_PersistentStore):
+    """
+    Utility class to create a PersitantStore for a file accessible via `snip.store.file`.
+    If the user do not provide a Store directory save path, it uses BufferStore as an alternate option (persistant only across the same vim session.
+    """
+    _alternate = dict()
+
+    @classmethod
+    def get(cls, path):
+        path = Path(path).resolve()
+        base = _storeDir()
+        if base is None :
+            return cls._getAlternate(path)
+        return cls(base / _encodeFilePath(path))
+
+    @classmethod
+    def _getAlternate(cls, path):
+        rv = cls._alternate.get(path)
+        if rv is None :
+            rv = BufferStore()
+            cls._alternate[path] = rv
+        return rv
+
+    @classmethod
+    def bufferStore(cls, buffer_number):
+        return cls.get(vim_helper.vim.buffers[buffer_number].name)
+
+    @classmethod
+    def currentBufferStore(cls):
+        """
+        Gets or create the store for the current buffer.
+        """
+        return cls.bufferStore(vim_helper.buf.number)
+
+
+class CommonStore(_PersistentStore):
+    """
+    Persitent common accross all instances store accessible via `snip.store.common`.
+    """
+    _alternate = None
+
+    @classmethod
+    def get(cls):
+        base = _storeDir()
+        if base is None :
+            return cls._getAlternate()
+        return cls(base / 'common')
+
+    @classmethod
+    def _getAlternate(cls):
+        if cls._alternate is None :
+            cls._alternate = BufferStore()
+        return cls._alternate
+
+class StoreManager(object):
+    """
+    A manager to synchronize current stores
+    """
+    def __init__(self):
+        self._reset()
+        self._tmp = []
+
+    def _reset(self):
+        self.buffer = None
+        self.session = None
+        self.file = None
+        self.common = None
+
+    def _setup_state(self):
+        number = vim_helper.buf.number
+        self.buffer = BufferStore.bufferStore(number)
+        self.session = SessionStore.get()
+        self.file = FileStore.bufferStore(number)
+        self.common = CommonStore.get()
+
+    def _teardown_state(self):
+        self.file.save()
+        self.common.save()
+        self._reset()
+

--- a/pythonx/UltiSnips/store.py
+++ b/pythonx/UltiSnips/store.py
@@ -1,11 +1,12 @@
 from UltiSnips import vim_helper
 from pathlib import Path
+import hashlib
 import json
 from collections import defaultdict
 
 class Store(object):
     """
-    A dict-like supporting supporting the obj[key, default] synthax
+    A dict-like supporting supporting the obj[key, default] syntax
     """
     def __init__(self):
         self._dict = dict()
@@ -135,10 +136,10 @@ class _PersistentStore(Store):
         super().__setitem__(key, val)
 
 
-def _encodeFilePath(path):
-    return str(Path(path).resolve()).replace('%', '_%%_').replace('/', '%')
+def _encode_file_path(path):
+    return hashlib.sha1(str(path))
 
-def _storeDir():
+def _store_dir():
     p = vim_helper.eval('g:UltiSnipsStoreDir')
     if p is not None :
         return Path(p).expanduser().resolve()
@@ -155,10 +156,10 @@ class FileStore(_PersistentStore):
     @classmethod
     def get(cls, path):
         path = Path(path).resolve()
-        base = _storeDir()
+        base = _store_dir()
         if base is None :
             return cls._getAlternate(path)
-        return cls(base / _encodeFilePath(path))
+        return cls(base / _encode_file_path(path))
 
     @classmethod
     def _getAlternate(cls, path):
@@ -188,7 +189,7 @@ class CommonStore(_PersistentStore):
 
     @classmethod
     def get(cls):
-        base = _storeDir()
+        base = _store_dir()
         if base is None :
             return cls._getAlternate()
         return cls(base / 'common')

--- a/pythonx/UltiSnips/text_objects/python_code.py
+++ b/pythonx/UltiSnips/text_objects/python_code.py
@@ -11,6 +11,7 @@ from UltiSnips.indent_util import IndentUtil
 from UltiSnips.text_objects.base import NoneditableTextObject
 from UltiSnips.vim_state import _Placeholder
 import UltiSnips.snippet_manager
+from UltiSnips.store import BufferStore
 
 
 class _Tabs:
@@ -46,6 +47,34 @@ class SnippetUtilForAction(dict):
         UltiSnips.snippet_manager.UltiSnips_Manager.expand_anon(*args, **kwargs)
         self.cursor.preserve()
 
+class StoreProxy:
+    """
+    Provide access to the stores
+    """
+    def __init__(self):
+        self._tmp = BufferStore()
+        self._store = UltiSnips.snippet_manager.UltiSnips_Manager._storeManager
+
+    @property
+    def buffer(self):
+        return self._store.buffer
+
+    @property
+    def session(self):
+        return self._store.session
+
+    @property
+    def file(self):
+        return self._store.file
+
+    @property
+    def common(self):
+        return self._store.common
+
+    @property
+    def tmp(self):
+        return self._tmp
+ 
 
 class SnippetUtil:
 
@@ -64,6 +93,7 @@ class SnippetUtil:
         self._start = parent.start
         self._end = parent.end
         self._parent = parent
+        self._store = StoreProxy()
 
     def _reset(self, cur):
         """Gets the snippet ready for another update.
@@ -179,6 +209,10 @@ class SnippetUtil:
     @property
     def context(self):
         return self._context
+
+    @property
+    def store(self):
+        return self._store
 
     def opt(self, option, default=None):  # pylint:disable=no-self-use
         """Gets a Vim variable."""

--- a/pythonx/UltiSnips/text_objects/python_code.py
+++ b/pythonx/UltiSnips/text_objects/python_code.py
@@ -53,8 +53,8 @@ class StoreProxy:
     """
     def __init__(self):
         self._tmp = BufferStore()
-        self._store = UltiSnips.snippet_manager.UltiSnips_Manager._storeManager
-        self._snippet = UltiSnips.snippet_manager.UltiSnips_Manager._storeManager.snippet
+        self._store = UltiSnips.snippet_manager.UltiSnips_Manager._store_manager
+        self._snippet = UltiSnips.snippet_manager.UltiSnips_Manager._store_manager.snippet
 
     @property
     def buffer(self):

--- a/pythonx/UltiSnips/text_objects/python_code.py
+++ b/pythonx/UltiSnips/text_objects/python_code.py
@@ -54,6 +54,7 @@ class StoreProxy:
     def __init__(self):
         self._tmp = BufferStore()
         self._store = UltiSnips.snippet_manager.UltiSnips_Manager._storeManager
+        self._snippet = UltiSnips.snippet_manager.UltiSnips_Manager._storeManager.snippet
 
     @property
     def buffer(self):
@@ -74,6 +75,10 @@ class StoreProxy:
     @property
     def tmp(self):
         return self._tmp
+
+    @property
+    def snippet(self):
+        return self._snippet
  
 
 class SnippetUtil:

--- a/pythonx/UltiSnips/text_objects/snippet_instance.py
+++ b/pythonx/UltiSnips/text_objects/snippet_instance.py
@@ -47,7 +47,7 @@ class SnippetInstance(EditableTextObject):
         self.globals = globals
         self.visual_content = visual_content
         self.current_placeholder = None
-        UltiSnips.snippet_manager.UltiSnips_Manager._storeManager._pushSnippet()
+        UltiSnips.snippet_manager.UltiSnips_Manager._store_manager._pushSnippet()
 
         EditableTextObject.__init__(self, parent, start, end, initial_text)
 
@@ -167,7 +167,7 @@ class SnippetInstance(EditableTextObject):
         return self._tabstops
 
     def done(self):
-        UltiSnips.snippet_manager.UltiSnips_Manager._storeManager._popSnippet()
+        UltiSnips.snippet_manager.UltiSnips_Manager._store_manager._popSnippet()
 
 
 class _VimCursor(NoneditableTextObject):

--- a/pythonx/UltiSnips/text_objects/snippet_instance.py
+++ b/pythonx/UltiSnips/text_objects/snippet_instance.py
@@ -14,6 +14,7 @@ from UltiSnips.error import PebkacError
 from UltiSnips.position import Position, JumpDirection
 from UltiSnips.text_objects.base import EditableTextObject, NoneditableTextObject
 from UltiSnips.text_objects.tabstop import TabStop
+import UltiSnips.snippet_manager
 
 
 class SnippetInstance(EditableTextObject):
@@ -46,6 +47,7 @@ class SnippetInstance(EditableTextObject):
         self.globals = globals
         self.visual_content = visual_content
         self.current_placeholder = None
+        UltiSnips.snippet_manager.UltiSnips_Manager._storeManager._pushSnippet()
 
         EditableTextObject.__init__(self, parent, start, end, initial_text)
 
@@ -163,6 +165,9 @@ class SnippetInstance(EditableTextObject):
 
     def get_tabstops(self):
         return self._tabstops
+
+    def done(self):
+        UltiSnips.snippet_manager.UltiSnips_Manager._storeManager._popSnippet()
 
 
 class _VimCursor(NoneditableTextObject):

--- a/test/test_Store.py
+++ b/test/test_Store.py
@@ -1,0 +1,238 @@
+# encoding: utf-8
+import os
+
+from test.vim_test_case import VimTestCase as _VimTest
+from test.constant import EX, JF, ESC
+from test.util import running_on_windows
+
+
+class Store_TmpSimple(_VimTest):
+  snippets = (
+      ('test', '`!p snip.store.tmp["Test"]="tt"``!p snip.rv=snip.store.tmp["Test", ""]`'),
+      ('test2', '`!p snip.rv=snip.store.tmp["Test", ""]`'),
+  )
+  keys = 'test' + EX + ' test2' + EX
+  wanted = ' '
+    
+class Store_TmpPlaceHolderAssign(_VimTest):
+  """Store should remember last value in current python code block (and increment assign should work too)"""
+  sleeptime = 0.05 # this one needs to have some time betweend inputs
+  snippets = (
+      ('test','$1`!p\n'
+          'if snip.store.tmp["t1", None] != t[1]:\n'
+          '  snip.store.tmp["Test",""] +=t[1]\n'
+          '  snip.store.tmp["t1"] = t[1]\n'
+          'snip.rv=snip.store.tmp["Test"]`'
+          '`!p snip.rv=snip.store.tmp["Test","_"]`'
+      ),
+      ('test2', '`!p snip.rv=snip.store.tmp["Test", ""]`'),
+  )
+  keys = 'test' + EX + 'ab' + JF + ' test2' + EX
+  # first block do the increment :  (t[1]='') '' -> (t[1]='a') 'a' -> (t[1]='a') 'aab'
+  # second block has a different store and the key is not present, so print default
+  # second snippet neither
+  wanted = 'abaab_ ' 
+  
+class Store_TmpCalledTwice(_VimTest):
+  """Store should be reset the second time the snip is called"""
+  snippets = ('test', '$1`!p snip.rv=snip.store.tmp["Test",""]; snip.store.tmp["Test"]=t[1]`')
+  keys = 'test' + EX + 'ab' + JF + '\ntest' + EX
+  wanted = 'abab\n'
+  
+  
+
+
+class Store_SnippetSimple(_VimTest):
+  snippets = (
+      ('test', '`!p snip.store.snippet["Test"]="tt"``!p snip.rv=snip.store.snippet["Test", ""]`'),
+      ('test2', '`!p snip.rv=snip.store.snippet["Test", ""]`'),
+  )
+  keys = 'test' + EX + ' test2' + EX
+  wanted = 'tt '
+    
+class Store_SnippetPlaceHolderAssign(_VimTest):
+  """Store should remember last value in current python code block (and increment assign should work too)"""
+  sleeptime = 0.05 # this one needs to have some time betweend inputs
+  snippets = (
+      ('test','$1`!p\n'
+          'if snip.store.snippet["t1", None] != t[1]:\n'
+          '  snip.store.snippet["Test",""] +=t[1]\n'
+          '  snip.store.snippet["t1"] = t[1]\n'
+          'snip.rv=snip.store.snippet["Test"]`'
+          '`!p snip.rv=snip.store.snippet["Test","_"]`'
+      ),
+      ('test2', '`!p snip.rv=snip.store.snippet["Test", ""]`'),
+  )
+  keys = 'test' + EX + 'ab' + JF + ' test2' + EX
+  # first block do the increment :  (t[1]='') '' -> (t[1]='a') 'a' -> (t[1]='a') 'aab'
+  # second block has access to the value, and print the final value at the end
+  # second snippet has a different store and the key is not present, so print default
+  wanted = 'abaabaab '
+  
+  
+class Store_SnippetCalledTwice(_VimTest):
+  """Store should be reset the second time  the snip is called"""
+  snippets = ('test', '$1`!p if t[1]:snip.store.snippet["Test"]=t[1]``!p snip.rv=snip.store.snippet["Test",""]`')
+  keys = 'test' + EX + 'tt' + JF + '\ntest' + EX
+  wanted = 'tttt\n'
+  
+  
+  
+  
+class Store_BufferSimple(_VimTest):
+  snippets = (
+      ('test', '`!p snip.store.buffer["Test"]="tt"``!p snip.rv=snip.store.buffer["Test", ""]`'),
+      ('test2', '`!p snip.rv=snip.store.buffer["Test", ""]`'),
+  )
+  keys = 'test' + EX + ' test2' + EX
+  wanted = 'tt tt'
+    
+class Store_BufferPlaceHolderAssign(_VimTest):
+  """Store should remember last value in current python code block (and increment assign should work too)"""
+  sleeptime = 0.05 # this one needs to have some time betweend inputs
+  snippets = (
+      ('test','$1`!p\n'
+          'if snip.store.buffer["t1", None] != t[1]:\n'
+          '  snip.store.buffer["Test",""] +=t[1]\n'
+          '  snip.store.buffer["t1"] = t[1]\n'
+          'snip.rv=snip.store.buffer["Test"]`'
+          '`!p snip.rv=snip.store.buffer["Test","_"]`'
+      ),
+      ('test2', '`!p snip.rv=snip.store.buffer["Test", ""]`'),
+  )
+  keys = 'test' + EX + 'ab' + JF + ' test2' + EX
+  # first block do the increment :  (t[1]='') '' -> (t[1]='a') 'a' -> (t[1]='a') 'aab'
+  # second block has access to the value, and print the final value at the end
+  # second snippet has also the the same store and print the final value
+  wanted = 'abaabaab aab'
+  
+class Store_BufferCalledTwice(_VimTest):
+  """Store should be reset the second time the snip is called"""
+  snippets = ('test', '$1`!p snip.rv=snip.store.buffer["Test",""]; snip.store.buffer["Test"]=t[1]`')
+  keys = 'test' + EX + 'ab' + JF + '\ntest' + EX
+  wanted = 'abab\n'
+
+
+
+
+class Store_SessionSimple(_VimTest):
+  snippets = (
+      ('test', '`!p snip.store.session["Test"]="tt"``!p snip.rv=snip.store.session["Test", ""]`'),
+      ('test2', '`!p snip.rv=snip.store.session["Test", ""]`'),
+  )
+  keys = 'test' + EX + ' test2' + EX
+  wanted = 'tt tt'
+    
+class Store_SessionPlaceHolderAssign(_VimTest):
+  """Store should remember last value in current python code block (and increment assign should work too)"""
+  sleeptime = 0.05 # this one needs to have some time betweend inputs
+  snippets = (
+      ('test','$1`!p\n'
+          'if snip.store.session["t1", None] != t[1]:\n'
+          '  snip.store.session["Test",""] +=t[1]\n'
+          '  snip.store.session["t1"] = t[1]\n'
+          'snip.rv=snip.store.session["Test"]`'
+          '`!p snip.rv=snip.store.session["Test","_"]`'
+      ),
+      ('test2', '`!p snip.rv=snip.store.session["Test", ""]`'),
+  )
+  keys = 'test' + EX + 'ab' + JF + ' test2' + EX
+  # same as buffer
+  wanted = 'abaabaab aab'
+  
+class Store_SessionCalledTwice(_VimTest):
+  """Store should be reset the second time the snip is called"""
+  snippets = ('test', '$1`!p snip.rv=snip.store.session["Test",""]; snip.store.session["Test"]=t[1]`')
+  keys = 'test' + EX + 'ab' + JF + '\ntest' + EX
+  wanted = 'abab\n'
+  
+
+
+
+
+class Store_FileSimple(_VimTest):
+  snippets = (
+      ('test', '`!p snip.store.file["Test"]="tt"``!p snip.rv=snip.store.file["Test", ""]`'),
+      ('test2', '`!p snip.rv=snip.store.file["Test", ""]`'),
+  )
+  keys = 'test' + EX + ' test2' + EX
+  wanted = 'tt tt'
+    
+class Store_FilePlaceHolderAssign(_VimTest):
+  """Store should remember last value in current python code block (and increment assign should work too)"""
+  sleeptime = 0.05 # this one needs to have some time betweend inputs
+  snippets = (
+      ('test','$1`!p\n'
+          'if snip.store.file["t1", None] != t[1]:\n'
+          '  snip.store.file["Test",""] +=t[1]\n'
+          '  snip.store.file["t1"] = t[1]\n'
+          'snip.rv=snip.store.file["Test"]`'
+          '`!p snip.rv=snip.store.file["Test","_"]`'
+      ),
+      ('test2', '`!p snip.rv=snip.store.file["Test", ""]`'),
+  )
+  keys = 'test' + EX + 'ab' + JF + ' test2' + EX
+  # same as buffer
+  wanted = 'abaabaab aab'
+  
+class Store_FileCalledTwice(_VimTest):
+  """Store should be reset the second time the snip is called"""
+  snippets = ('test', '$1`!p snip.rv=snip.store.file["Test",""]; snip.store.file["Test"]=t[1]`')
+  keys = 'test' + EX + 'ab' + JF + '\ntest' + EX
+  wanted = 'abab\n'
+  
+
+
+
+
+class Store_CommonSimple(_VimTest):
+  snippets = (
+      ('test', '`!p snip.store.common["Test"]="tt"``!p snip.rv=snip.store.common["Test", ""]`'),
+      ('test2', '`!p snip.rv=snip.store.common["Test", ""]`'),
+  )
+  keys = 'test' + EX + ' test2' + EX
+  wanted = 'tt tt'
+    
+class Store_CommonPlaceHolderAssign(_VimTest):
+  """Store should remember last value in current python code block (and increment assign should work too)"""
+  sleeptime = 0.05 # this one needs to have some time betweend inputs
+  snippets = (
+      ('test','$1`!p\n'
+          'if snip.store.common["t1", None] != t[1]:\n'
+          '  snip.store.common["Test",""] +=t[1]\n'
+          '  snip.store.common["t1"] = t[1]\n'
+          'snip.rv=snip.store.common["Test"]`'
+          '`!p snip.rv=snip.store.common["Test","_"]`'
+      ),
+      ('test2', '`!p snip.rv=snip.store.common["Test", ""]`'),
+  )
+  keys = 'test' + EX + 'ab' + JF + ' test2' + EX
+  # same as buffer
+  wanted = 'abaabaab aab'
+  
+class Store_CommonCalledTwice(_VimTest):
+  """Store should be reset the second time the snip is called"""
+  snippets = ('test', '$1`!p snip.rv=snip.store.common["Test",""]; snip.store.common["Test"]=t[1]`')
+  keys = 'test' + EX + 'ab' + JF + '\ntest' + EX
+  wanted = 'abab\n'
+  
+
+
+
+class Store_StoreAreDifferent(_VimTest):
+  """Each store should be able to hold its own value for a same key"""
+  snippets = ('test', '`!p\n'
+      'snip.store.tmp["Test"]="t1"\n'
+      'snip.store.snippet["Test"]="t2"\n'
+      'snip.store.buffer["Test"]="t3"\n'
+      'snip.store.session["Test"]="t4"\n'
+      'snip.store.file["Test"]="t5"\n'
+      'snip.store.common["Test"]="t6"\n'
+      'snip.rv = '
+        'snip.store.tmp.Test + snip.store.snippet.Test +'
+        'snip.store.buffer.Test + snip.store.session.Test +'
+        'snip.store.file.Test + snip.store.common.Test'
+      '`'
+  )
+  keys = 'test' + EX
+  wanted = 't1t2t3t4t5t6'

--- a/test/vim_test_case.py
+++ b/test/vim_test_case.py
@@ -64,11 +64,12 @@ class VimTestCase(unittest.TestCase, TempFileManager):
         """Adds extra lines to the vim_config list."""
 
     def _before_test(self):
-        """Send these keys before the test runs.
-
-        Used for buffer local variables and other options.
-
-        """
+        """Run before the test, once vim is launched
+        Used for buffer local variables and other options."""
+        
+    def _after_test(self):
+        """Run after the test, before vim is exited
+        Used to check additionnal behaviors"""
 
     def _create_file(self, file_path, content):
         """Creates a file in the runtimepath that is created for this test.
@@ -203,6 +204,8 @@ class VimTestCase(unittest.TestCase, TempFileManager):
                 time.sleep(self.sleeptime)
                 text = text[len(to_send) :]
             self.output = self.vim.get_buffer_data()
+         
+        self._after_test()
 
     def tearDown(self):
         if self.interrupt:


### PR DESCRIPTION
(See the diff in the doc for a full explanation)

Adds dict-like stores to the python interpolation `snip` object to implement #1393 : 

- `snip.store.tmp` : a store reset at each snippet run, but that stay alive across a snippet updates. Accessible only on the same python code part
- `snip.store.snippet` : a store reset at each snippet run, but that stay alive across a snippet updates. Accessible in all python code parts
- `snip.store.buffer` : a store common to all snippet executing in a same buffer
- `snip.store.session` : a store common to all snippet in a same vim instance
- `snip.store.file` : Same as buffer, but persisted to hard drive, and synced with other vim instances
- `snip.store.common` : Same as session, but persisted to hard drive, and synced with other vim instances

In addition a g:UltiSnipsStoreDir is added choose the directory where the persistent stores are saved. If this variable is not provided by the user, the stores are not persisted