### PR TITLE
Added remote debug facilities (remote pdb server)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,13 @@ In this shell we can then trigger the test execution:
     ... now inside container
     # ./test_all.py
 
+### Enable the remote debug server
+
+The test suite provides `--remote-pdb*` options equivalent to the config variables to enable the debug server during the test suite.
+Note that some tests may fail because the post-mortem will catch an expected exceptions and that these options are mainly useful for single test case debugging. 
+
+Check `./test_all.py --help` for more informations.
+
 ## Documenting
 
 User documentation goes into [`doc/UltiSnips.txt`](https://github.com/SirVer/ultisnips/blob/00_contributing/doc/UltiSnips.txt).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ When enabled (by setting `let g:UltiSnipsDebugServerEnable=1`), whenever an exce
 and you will be able to connect to the debug server with netcat or telnet.
 By default, the server listens on 'localhost:8080' (it can be changed).
 
-See `:help UltiSnips-Debugging` for more informations
+See `:help UltiSnips-Advanced-Debugging` for more informations
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,15 @@ There are several ways of doing this:
 
 Should there be agreement that your feature idea adds enough value to offset the maintenance burden, you can go ahead and implement it, including tests and documentation.
 
+## Debugging
+
+UltiSnips embeds some remote debugging facilities in the `UltiSnips.remote_pdb` module.
+When enabled (by setting `let g:UltiSnipsDebugServerEnable=1`), whenever an exception is raised, vim will pause
+and you will be able to connect to the debug server with netcat or telnet.
+By default, the server listens on 'localhost:8080' (it can be changed).
+
+See `:help UltiSnips-Debugging` for more informations
+
 ## Testing
 
 UltiSnips has a rigorous test suite and every new feature or bug fix is expected to come with a new test.

--- a/doc/UltiSnips-advanced.txt
+++ b/doc/UltiSnips-advanced.txt
@@ -1,0 +1,92 @@
+*UltiSnips-advanced.txt*    Advanced topics for UltiSnips
+
+
+1. Debugging                                    |UltiSnips-Advanced-Debugging|
+   1.1 Setting breakpoints                      |UltiSnips-Advanced-breakpoints|
+   1.2 Accessing Pdb                            |UltiSnips-Advanced-Pdb|
+
+=============================================================================
+1. Debugging                                   *UltiSnips-Advanced-Debugging*
+                                               *g:UltiSnipsDebugServerEnable*
+UltiSnips comes with a remote debugger disabled        *g:UltiSnipsDebugHost*
+by default. When authoring a complex snippet           *g:UltiSnipsDebugPort*
+with python code, you may want to be able to     *g:UltiSnipsPMDebugBlocking*
+set breakpoints to inspect variables.
+It is also useful when debugging UltiSnips itself.
+
+Note: Due to some technical limitations, it is not possible for pdb to print
+the code of the snippet with the `l`/`ll` commands.
+
+You can enable it and configure it with the folowing variables: >
+
+    let g:UltiSnipsDebugServerEnable=0
+        (bool) Set to 1 to Enable the debug server. If an exception occurs or
+        a breakpoint (see below) is set, a Pdb server is launched, and you can
+        connect to it through telnet.
+
+    let g:UltiSnipsDebugHost='localhost'
+        (string) The host the server listens on
+
+    let g:UltiSnipsDebugPort=8080
+        (int) The port the server listens to
+
+    let g:UltiSnipsPMDebugBlocking=0
+        (bool) Set whether the post mortem debugger should freeze vim.
+        If set to 0, vim will continue to run if an exception
+        arises while expanding a snippet and the error message describing the
+        error will be printed with the directives to connect to the remote
+        debug server. Internally, Pdb will run in another thread and the session
+        will use the python trace back object stored at the moment the error
+        was caught. The variable values and the application state may not reflect
+        the exact state at the moment of the error.
+        If set to 1, vim will simply freeze on the error and will resume
+        only after quiting the debugging session (you must connect via telnet
+        to type the Pdb's `quit` command to resume vim). However, the
+        execution is paused right after caughting the exception, reflecting
+        the exact state when the error occured.
+
+NOTE: Do not run vim as root with `g:UltiSnipsDebugServerEnable=1` since anything
+can connect to it and do anything with root privileges.
+Try to use these features only for...  debugging... and turn it off when you
+are done.
+
+These variables can be set at any moment. The debug server will be active
+only when an exception arises (or a breakpoint set as below is reached),
+and only if `g:UltiSnipsDebugServerEnable` is set at the moment of the
+error. It will be innactive as soon as the `quit` command is issued
+from telnet.
+
+1.1 Setting breakpoints                      *UltiSnips-Advanced-breakpoints*
+-----------------------
+
+The easiest way of setting a breakpoint inside a snippet or UltiSnips
+internal code is the following: >
+
+    from UltiSnips.remote_pdb import RemotePDB
+    RemotePDB.breakpoint()
+
+...You can also raise an exception since it will be caught, and then will
+launch the post-mortem session. However, using the breakpoint method allows
+to continue the execution once the debugger quit.
+
+1.2 Accessing Pdb                                    *UltiSnips-Advanced-Pdb*
+-----------------
+
+Even though it's possible to use the builtin Pdb, (or any other compatible
+debugger), the best experience is achived with Pdb++.
+You can install it this way: >
+
+    pip install pdbpp
+
+It is a no-configuration replacement of the built-in pdb.
+
+To connect to the pdb server, simply use a telnet-like client.
+To have readline support (arrow keys working and history), you can use socat: >
+
+    socat READLINE,history=$HOME/.ultisnips-dbg-history TCP:localhost:8080
+
+(Change `localhost` and `8080` to match your configuration)
+To leave the server and continue the execution, run Pdb's `quit` command
+
+Known issue: Tab completion is not supported yet.
+

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -1888,13 +1888,15 @@ You can install it this way: >
 
 It is a no-configuration replacement of the built-in pdb.
 
-To connect to the pdb server, simply run telnet: >
+To connect to the pdb server, simply use a telnet-like client.
+To have readline support (arrow keys working and history), you can use socat: >
 
-    telnet host:port
+    socat READLINE,history=$HOME/.ultisnips-dbg-history TCP:localhost:8080
 
+(Change `localhost` and `8080` to match your configuration)
 To leave the server and continue the execution, run Pdb's `quit` command
 
-Known issues : The arrow and tab keys (for completion) are not supported yet
+Known issue: Tab completion is not supported yet.
 
 =============================================================================
 7. FAQ                                                        *UltiSnips-FAQ*
@@ -1921,7 +1923,7 @@ A: Yes there is, try
   endfunction
 
 =============================================================================
-7. Helping Out                                            *UltiSnips-helping*
+8. Helping Out                                            *UltiSnips-helping*
 
 UltiSnips needs the help of the Vim community to keep improving. Please
 consider joining this effort by providing new features or bug reports.

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -56,8 +56,6 @@ UltiSnips                                      *snippet* *snippets* *UltiSnips*
    5.1 Existing Integrations                    |UltiSnips-integrations|
    5.2 Extending UltiSnips                      |UltiSnips-extending|
 6. Debugging                                    |UltiSnips-Debugging|
-   6.1 Setting breakpoints                      |UltiSnips-breakpoints|
-   6.2 Accessing Pdb                            |UltiSnips-Pdb|
 7. FAQ                                          |UltiSnips-FAQ|
 8. Helping Out                                  |UltiSnips-helping|
 9. Contributors                                 |UltiSnips-contributors|
@@ -1815,88 +1813,14 @@ with your plugin so it can be listed in the docs.
 
 =============================================================================
 6. Debugging                                            *UltiSnips-Debugging*
-                                               *g:UltiSnipsDebugServerEnable*
-UltiSnips comes with a remote debugger disabled        *g:UltiSnipsDebugHost*
-by default. When authoring a complex snippet           *g:UltiSnipsDebugPort*
-with python code, you may want to be able to     *g:UltiSnipsPMDebugBlocking*
+
+UltiSnips comes with a remote debugger disabled
+by default. When authoring a complex snippet
+with python code, you may want to be able to
 set breakpoints to inspect variables.
 It is also useful when debugging UltiSnips itself.
 
-Note: Due to some technical limitations, it is not possible for pdb to print
-the code of the snippet with the `l`/`ll` commands.
-
-You can enable it and configure it with the folowing variables: >
-
-    let g:UltiSnipsDebugServerEnable=0
-        (bool) Set to 1 to Enable the debug server. If an exception occurs or
-        a breakpoint (see below) is set, a Pdb server is launched, and you can
-        connect to it through telnet.
-
-    let g:UltiSnipsDebugHost='localhost'
-        (string) The host the server listens on
-
-    let g:UltiSnipsDebugPort=8080
-        (int) The port the server listens to
-
-    let g:UltiSnipsPMDebugBlocking=0
-        (bool) Set whether the post mortem debugger should freeze vim.
-        If set to 0, vim will continue to run if an exception
-        arises while expanding a snippet and the error message describing the
-        error will be printed with the directives to connect to the remote
-        debug server. Internally, Pdb will run in another thread and the session
-        will use the python trace back object stored at the moment the error
-        was caught. The variable values and the application state may not reflect
-        the exact state at the moment of the error.
-        If set to 1, vim will simply freeze on the error and will resume
-        only after quiting the debugging session (you must connect via telnet
-        to type the Pdb's `quit` command to resume vim). However, the
-        execution is paused right after caughting the exception, reflecting
-        the exact state when the error occured.
-
-NOTE: Do not run vim as root with `g:UltiSnipsDebugServerEnable=1` since anything
-can connect to it and do anything with root privileges.
-Try to use these features only for...  debugging... and turn it off when you
-are done.
-
-These variables can be set at any moment. The debug server will be active
-only when an exception arises (or a breakpoint set as below is reached),
-and only if `g:UltiSnipsDebugServerEnable` is set at the moment of the
-error. It will be innactive as soon as the `quit` command is issued
-from telnet.
-
-6.1 Setting breakpoints                               *UltiSnips-breakpoints*
------------------------
-
-The easiest way of setting a breakpoint inside a snippet or UltiSnips
-internal code is the following: >
-
-    from UltiSnips.remote_pdb import RemotePDB
-    RemotePDB.breakpoint()
-
-...You can also raise an exception since it will be caught, and then will
-launch the post-mortem session. However, using the breakpoint method allows
-to continue the execution once the debugger quit.
-
-6.2 Accessing Pdb                                             *UltiSnips-Pdb*
------------------
-
-Even though it's possible to use the builtin Pdb, (or any other compatible
-debugger), the best experience is achived with Pdb++.
-You can install it this way: >
-
-    pip install pdbpp
-
-It is a no-configuration replacement of the built-in pdb.
-
-To connect to the pdb server, simply use a telnet-like client.
-To have readline support (arrow keys working and history), you can use socat: >
-
-    socat READLINE,history=$HOME/.ultisnips-dbg-history TCP:localhost:8080
-
-(Change `localhost` and `8080` to match your configuration)
-To leave the server and continue the execution, run Pdb's `quit` command
-
-Known issue: Tab completion is not supported yet.
+See |UltiSnips-Advanced-Debugging| for more informations
 
 =============================================================================
 7. FAQ                                                        *UltiSnips-FAQ*

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -55,9 +55,12 @@ UltiSnips                                      *snippet* *snippets* *UltiSnips*
 5. UltiSnips and Other Plugins                  |UltiSnips-other-plugins|
    5.1 Existing Integrations                    |UltiSnips-integrations|
    5.2 Extending UltiSnips                      |UltiSnips-extending|
-6. FAQ                                          |UltiSnips-FAQ|
-7. Helping Out                                  |UltiSnips-helping|
-8. Contributors                                 |UltiSnips-contributors|
+6. Debugging                                    |UltiSnips-Debugging|
+   6.1 Setting breakpoints                      |UltiSnips-breakpoints|
+   6.2 Accessing Pdb                            |UltiSnips-Pdb|
+7. FAQ                                          |UltiSnips-FAQ|
+8. Helping Out                                  |UltiSnips-helping|
+9. Contributors                                 |UltiSnips-contributors|
 
 This plugin only works if 'compatible' is not set.
 {Vi does not have any of these features}
@@ -1811,7 +1814,90 @@ AddNewSnippetSource. Please contact us on github if you integrate UltiSnips
 with your plugin so it can be listed in the docs.
 
 =============================================================================
-6. FAQ                                                        *UltiSnips-FAQ*
+6. Debugging                                            *UltiSnips-Debugging*
+                                               *g:UltiSnipsDebugServerEnable*
+UltiSnips comes with a remote debugger disabled        *g:UltiSnipsDebugHost*
+by default. When authoring a complex snippet           *g:UltiSnipsDebugPort*
+with python code, you may want to be able to     *g:UltiSnipsPMDebugBlocking*
+set breakpoints to inspect variables.
+It is also useful when debugging UltiSnips itself.
+
+Note: Due to some technical limitations, it is not possible for pdb to print
+the code of the snippet with the `l`/`ll` commands.
+
+You can enable it and configure it with the folowing variables: >
+
+    let g:UltiSnipsDebugServerEnable=0
+        (bool) Set to 1 to Enable the debug server. If an exception occurs or
+        a breakpoint (see below) is set, a Pdb server is launched, and you can
+        connect to it through telnet.
+
+    let g:UltiSnipsDebugHost='localhost'
+        (string) The host the server listens on
+
+    let g:UltiSnipsDebugPort=8080
+        (int) The port the server listens to
+
+    let g:UltiSnipsPMDebugBlocking=0
+        (bool) Set whether the post mortem debugger should freeze vim.
+        If set to 0, vim will continue to run if an exception
+        arises while expanding a snippet and the error message describing the
+        error will be printed with the directives to connect to the remote
+        debug server. Internally, Pdb will run in another thread and the session
+        will use the python trace back object stored at the moment the error
+        was caught. The variable values and the application state may not reflect
+        the exact state at the moment of the error.
+        If set to 1, vim will simply freeze on the error and will resume
+        only after quiting the debugging session (you must connect via telnet
+        to type the Pdb's `quit` command to resume vim). However, the
+        execution is paused right after caughting the exception, reflecting
+        the exact state when the error occured.
+
+NOTE: Do not run vim as root with `g:UltiSnipsDebugServerEnable=1` since anything
+can connect to it and do anything with root privileges.
+Try to use these features only for...  debugging... and turn it off when you
+are done.
+
+These variables can be set at any moment. The debug server will be active
+only when an exception arises (or a breakpoint set as below is reached),
+and only if `g:UltiSnipsDebugServerEnable` is set at the moment of the
+error. It will be innactive as soon as the `quit` command is issued
+from telnet.
+
+6.1 Setting breakpoints                               *UltiSnips-breakpoints*
+-----------------------
+
+The easiest way of setting a breakpoint inside a snippet or UltiSnips
+internal code is the following: >
+
+    from UltiSnips.remote_pdb import RemotePDB
+    RemotePDB.breakpoint()
+
+...You can also raise an exception since it will be caught, and then will
+launch the post-mortem session. However, using the breakpoint method allows
+to continue the execution once the debugger quit.
+
+6.2 Accessing Pdb                                             *UltiSnips-Pdb*
+-----------------
+
+Even though it's possible to use the builtin Pdb, (or any other compatible
+debugger), the best experience is achived with Pdb++.
+You can install it this way: >
+
+    pip install pdbpp
+
+It is a no-configuration replacement of the built-in pdb.
+
+To connect to the pdb server, simply run telnet: >
+
+    telnet host:port
+
+To leave the server and continue the execution, run Pdb's `quit` command
+
+Known issues : The arrow and tab keys (for completion) are not supported yet
+
+=============================================================================
+7. FAQ                                                        *UltiSnips-FAQ*
 
 Q: Do I have to call UltiSnips#ExpandSnippet() to check if a snippet is
    expandable? Is there instead an analog of neosnippet#expandable?
@@ -1849,7 +1935,7 @@ You can contribute by fixing or reporting bugs in our issue tracker:
 https://github.com/sirver/ultisnips/issues
 
 =============================================================================
-8. Contributors                                      *UltiSnips-contributors*
+9. Contributors                                      *UltiSnips-contributors*
 
 UltiSnips has been started and maintained from Jun 2009 - Dec 2015 by Holger
 Rapp (@SirVer, SirVer@gmx.de). Up to April 2018 it was maintained by Stanislav

--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -10,6 +10,24 @@ if version < 704
    finish
 endif
 
+" Enable Post debug server config
+if !exists("g:UltiSnipsDebugServerEnable")
+   let g:UltiSnipsDebugServerEnable = 0
+endif
+
+if !exists("g:UltiSnipsDebugHost")
+   let g:UltiSnipsDebugHost = 'localhost'
+endif
+
+if !exists("g:UltiSnipsDebugPort")
+   let g:UltiSnipsDebugPort = 8080
+endif
+
+if !exists("g:UltiSnipsPMDebugBlocking")
+   let g:UltiSnipsPMDebugBlocking = 0
+endif
+
+
 " The Commands we define.
 command! -bang -nargs=? -complete=customlist,UltiSnips#FileTypeComplete UltiSnipsEdit
     \ :call UltiSnips#Edit(<q-bang>, <q-args>)

--- a/pythonx/UltiSnips/err_to_scratch_buffer.py
+++ b/pythonx/UltiSnips/err_to_scratch_buffer.py
@@ -4,9 +4,12 @@ from functools import wraps
 import traceback
 import re
 import sys
+import time
+from bdb import BdbQuit
 
 from UltiSnips import vim_helper
 from UltiSnips.error import PebkacError
+from UltiSnips.remote_pdb import RemotePDB
 
 
 def _report_exception(self, msg, e):
@@ -42,11 +45,20 @@ def wrap(func):
     def wrapper(self, *args, **kwds):
         try:
             return func(self, *args, **kwds)
+        except BdbQuit :
+            pass # A debugger stopped, but it's not really an error
         except PebkacError as e:
+            if RemotePDB.is_enable() :
+                RemotePDB.pm()
             msg = "UltiSnips Error:\n\n"
             msg += str(e).strip()
+            if RemotePDB.is_enable() :
+                host, port = RemotePDB.get_host_port()
+                msg += f'\nUltisnips\' post mortem debug server caught the error. Run `telnet {host}:{port}` to inspect it with pdb\n'
             _report_exception(self, msg, e)
         except Exception as e:  # pylint: disable=bare-except
+            if RemotePDB.is_enable() :
+                RemotePDB.pm()
             msg = """An error occured. This is either a bug in UltiSnips or a bug in a
 snippet definition. If you think this is a bug, please report it to
 https://github.com/SirVer/ultisnips/issues/new
@@ -56,6 +68,10 @@ https://github.com/SirVer/ultisnips/blob/master/CONTRIBUTING.md#reproducing-bugs
 Following is the full stack trace:
 """
             msg += traceback.format_exc()
+            if RemotePDB.is_enable() :
+                host, port = RemotePDB.get_host_port()
+                msg += f'\nUltisnips\' post mortem debug server caught the error. Run `telnet {host}:{port}` to inspect it with pdb\n'
+              
             _report_exception(self, msg, e)
 
     return wrapper

--- a/pythonx/UltiSnips/err_to_scratch_buffer.py
+++ b/pythonx/UltiSnips/err_to_scratch_buffer.py
@@ -54,7 +54,7 @@ def wrap(func):
             msg += str(e).strip()
             if RemotePDB.is_enable() :
                 host, port = RemotePDB.get_host_port()
-                msg += f'\nUltisnips\' post mortem debug server caught the error. Run `telnet {host}:{port}` to inspect it with pdb\n'
+                msg += '\nUltisnips\' post mortem debug server caught the error. Run `telnet {}:{}` to inspect it with pdb\n'.format(host, port)
             _report_exception(self, msg, e)
         except Exception as e:  # pylint: disable=bare-except
             if RemotePDB.is_enable() :
@@ -70,7 +70,7 @@ Following is the full stack trace:
             msg += traceback.format_exc()
             if RemotePDB.is_enable() :
                 host, port = RemotePDB.get_host_port()
-                msg += f'\nUltisnips\' post mortem debug server caught the error. Run `telnet {host}:{port}` to inspect it with pdb\n'
+                msg += '\nUltisnips\' post mortem debug server caught the error. Run `telnet {}:{}` to inspect it with pdb\n'.format(host, port)
               
             _report_exception(self, msg, e)
 

--- a/pythonx/UltiSnips/remote_pdb.py
+++ b/pythonx/UltiSnips/remote_pdb.py
@@ -1,0 +1,111 @@
+import sys
+import threading
+from bdb import BdbQuit
+
+from UltiSnips import vim_helper
+
+class RemotePDB(object):
+    """
+    Launch a pdb instance listening on (host, port).
+    Used to provide debug facilities you can access with netcat or telnet.
+    """
+    
+    singleton = None
+
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+        self._pdb = None
+
+    def start_server(self):
+        """
+        Create an instance of Pdb bound to a socket
+        """
+        if self._pdb is not None :
+          return
+        import pdb 
+        import socket
+
+        self.server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
+        self.server.bind((self.host, self.port))
+        self.server.listen(1)
+        self.connection, address = self.server.accept()
+        io = self.connection.makefile("rw")
+        parent = self
+        
+        class Pdb(pdb.Pdb):
+            """Patch quit to close the connection"""
+            def set_quit(self):
+                parent._shutdown()
+                super().set_quit()
+                
+        self._pdb = Pdb(stdin=io, stdout=io)
+
+    def _pm(self, tb):
+        """
+        Launch the server as post mortem on the currently handled exception
+        """
+        try:
+            self._pdb.interaction(None, tb) 
+        except: # Ignore all exceptions part of debugger shutdown (and bugs... https://bugs.python.org/issue44461 )
+            pass
+
+    def set_trace(self, frame):
+        self._pdb.set_trace(frame)
+
+    def _shutdown(self):
+        if self._pdb is not None :
+            import socket
+            self.connection.shutdown(socket.SHUT_RDWR)
+            self.connection.close()
+            self.server.close()
+            self._pdb = None
+
+    @staticmethod
+    def get_host_port(host=None, port=None):
+        if host is None :
+            host = vim_helper.eval('g:UltiSnipsDebugHost')
+        if port is None :
+            port = int(vim_helper.eval('g:UltiSnipsDebugPort'))
+        return host, port
+
+    @staticmethod
+    def is_enable():
+        return bool(int(vim_helper.eval('g:UltiSnipsDebugServerEnable')))
+
+    @staticmethod
+    def is_blocking():
+        return bool(int(vim_helper.eval('g:UltiSnipsPMDebugBlocking')))
+
+    @classmethod
+    def _create(cls):
+        if cls.singleton is None:
+            cls.singleton = cls(*cls.get_host_port())
+        
+    @classmethod
+    def breakpoint(cls, host=None, port=None):
+        if cls.singleton is None and not cls.is_enable() :
+            return
+        cls._create()
+        cls.singleton.start_server()
+        cls.singleton.set_trace(sys._getframe().f_back)
+
+    @classmethod
+    def pm(cls):
+        """
+        Launch the server as post mortem on the currently handled exception
+        """
+        if cls.singleton is None and not cls.is_enable() :
+            return
+        cls._create()
+        t, val, tb = sys.exc_info()
+        def _thread_run():
+            cls.singleton.start_server()
+            cls.singleton._pm(tb)
+        if cls.is_blocking() :
+          _thread_run()
+        else :
+          thread = threading.Thread(target=_thread_run)
+          thread.start()
+

--- a/test/vim_test_case.py
+++ b/test/vim_test_case.py
@@ -135,6 +135,12 @@ class VimTestCase(unittest.TestCase, TempFileManager):
         vim_config.append('let g:UltiSnipsJumpForwardTrigger="?"')
         vim_config.append('let g:UltiSnipsJumpBackwardTrigger="+"')
         vim_config.append('let g:UltiSnipsListSnippets="@"')
+        
+        vim_config.append('let g:UltiSnipsDebugServerEnable={}'.format(1 if self.pdb_enable else 0))
+        vim_config.append('let g:UltiSnipsDebugHost="{}"'.format(self.pdb_host))
+        vim_config.append('let g:UltiSnipsDebugPort={}'.format(self.pdb_port))
+        vim_config.append('let g:UltiSnipsPMDebugBlocking={}'.format(1 if self.pdb_block else 0))
+
 
         # Work around https://github.com/vim/vim/issues/3117 for testing >
         # py3.7 on Vim 8.1. Actually also reported against UltiSnips

--- a/test_all.py
+++ b/test_all.py
@@ -156,6 +156,32 @@ if __name__ == "__main__":
             help="If set, each test will check sys.version inside of vim to "
             "verify we are testing against the expected Python version.",
         )
+        p.add_option(
+            "--remote-pdb",
+            dest="pdb_enable",
+            action="store_true",
+            help="If set, The remote pdb server will be run"
+        )
+        p.add_option(
+            "--remote-pdb-host",
+            dest="pdb_host",
+            type=str,
+            default="localhost",
+            help="Remote pdb server host"
+        )
+        p.add_option(
+            "--remote-pdb-port",
+            dest="pdb_port",
+            type=int,
+            default=8080,
+            help="Remote pdb server port"
+        )
+        p.add_option(
+            "--remote-pdb-non-blocking",
+            dest="pdb_block",
+            action="store_false",
+            help="If set, the server will not freeze vim on error"
+        )
 
         o, args = p.parse_args()
         return o, args
@@ -203,6 +229,10 @@ if __name__ == "__main__":
             test.expected_python_version = options.expected_python_version
             test.vim = vim
             test.vim_flavor = vim_flavor
+            test.pdb_enable = options.pdb_enable
+            test.pdb_host = options.pdb_host
+            test.pdb_port = options.pdb_port
+            test.pdb_block = options.pdb_block
             all_other_plugins.update(test.plugins)
 
             if len(selected_tests):


### PR DESCRIPTION
As discussed in #1403, and since you seemed enthusiast about it, I polished the remote debugger / post-mortem in something quite usable even though some stuff are still missing (like handling correctly arrow and completion keys...)

I am a bit sorry the code is somewhat messy, it was not that easy to make sure issuing a quit command would close the socket with vim resuming as if no debugger were launched, but at least, I tested it with pdb and pdb++ with all configuration possibility and it does what it is asked for, without altering UltiSnips when not enabled (I ran the test suite, and I have no fails).

Please don't ask me to provide a test case, I have truly no idea of how I would implement it =D