### PR TITLE
[WIP] tiebreaker fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,13 @@ In this shell we can then trigger the test execution:
     ... now inside container
     # ./test_all.py
 
+### Enable the remote debug server
+
+The test suite provides `--remote-pdb*` options equivalent to the config variables to enable the debug server during the test suite.
+Note that some tests may fail because the post-mortem will catch an expected exceptions and that these options are mainly useful for single test case debugging. 
+
+Check `./test_all.py --help` for more informations.
+
 ## Documenting
 
 User documentation goes into [`doc/UltiSnips.txt`](https://github.com/SirVer/ultisnips/blob/00_contributing/doc/UltiSnips.txt).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,15 @@ There are several ways of doing this:
 
 Should there be agreement that your feature idea adds enough value to offset the maintenance burden, you can go ahead and implement it, including tests and documentation.
 
+## Debugging
+
+UltiSnips embeds some remote debugging facilities in the `UltiSnips.remote_pdb` module.
+When enabled (by setting `let g:UltiSnipsDebugServerEnable=1`), whenever an exception is raised, vim will pause
+and you will be able to connect to the debug server with netcat or telnet.
+By default, the server listens on 'localhost:8080' (it can be changed).
+
+See `:help UltiSnips-Debugging` for more informations
+
 ## Testing
 
 UltiSnips has a rigorous test suite and every new feature or bug fix is expected to come with a new test.

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -1888,13 +1888,15 @@ You can install it this way: >
 
 It is a no-configuration replacement of the built-in pdb.
 
-To connect to the pdb server, simply run telnet: >
+To connect to the pdb server, simply use a telnet-like client.
+To have readline support (arrow keys working and history), you can use socat: >
 
-    telnet host:port
+    socat READLINE,history=$HOME/.ultisnips-dbg-history TCP:localhost:8080
 
+(Change `localhost` and `8080` to match your configuration)
 To leave the server and continue the execution, run Pdb's `quit` command
 
-Known issues : The arrow and tab keys (for completion) are not supported yet
+Known issue: Tab completion is not supported yet.
 
 =============================================================================
 7. FAQ                                                        *UltiSnips-FAQ*
@@ -1921,7 +1923,7 @@ A: Yes there is, try
   endfunction
 
 =============================================================================
-7. Helping Out                                            *UltiSnips-helping*
+8. Helping Out                                            *UltiSnips-helping*
 
 UltiSnips needs the help of the Vim community to keep improving. Please
 consider joining this effort by providing new features or bug reports.

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -55,9 +55,12 @@ UltiSnips                                      *snippet* *snippets* *UltiSnips*
 5. UltiSnips and Other Plugins                  |UltiSnips-other-plugins|
    5.1 Existing Integrations                    |UltiSnips-integrations|
    5.2 Extending UltiSnips                      |UltiSnips-extending|
-6. FAQ                                          |UltiSnips-FAQ|
-7. Helping Out                                  |UltiSnips-helping|
-8. Contributors                                 |UltiSnips-contributors|
+6. Debugging                                    |UltiSnips-Debugging|
+   6.1 Setting breakpoints                      |UltiSnips-breakpoints|
+   6.2 Accessing Pdb                            |UltiSnips-Pdb|
+7. FAQ                                          |UltiSnips-FAQ|
+8. Helping Out                                  |UltiSnips-helping|
+9. Contributors                                 |UltiSnips-contributors|
 
 This plugin only works if 'compatible' is not set.
 {Vi does not have any of these features}
@@ -1811,7 +1814,90 @@ AddNewSnippetSource. Please contact us on github if you integrate UltiSnips
 with your plugin so it can be listed in the docs.
 
 =============================================================================
-6. FAQ                                                        *UltiSnips-FAQ*
+6. Debugging                                            *UltiSnips-Debugging*
+                                               *g:UltiSnipsDebugServerEnable*
+UltiSnips comes with a remote debugger disabled        *g:UltiSnipsDebugHost*
+by default. When authoring a complex snippet           *g:UltiSnipsDebugPort*
+with python code, you may want to be able to     *g:UltiSnipsPMDebugBlocking*
+set breakpoints to inspect variables.
+It is also useful when debugging UltiSnips itself.
+
+Note: Due to some technical limitations, it is not possible for pdb to print
+the code of the snippet with the `l`/`ll` commands.
+
+You can enable it and configure it with the folowing variables: >
+
+    let g:UltiSnipsDebugServerEnable=0
+        (bool) Set to 1 to Enable the debug server. If an exception occurs or
+        a breakpoint (see below) is set, a Pdb server is launched, and you can
+        connect to it through telnet.
+
+    let g:UltiSnipsDebugHost='localhost'
+        (string) The host the server listens on
+
+    let g:UltiSnipsDebugPort=8080
+        (int) The port the server listens to
+
+    let g:UltiSnipsPMDebugBlocking=0
+        (bool) Set whether the post mortem debugger should freeze vim.
+        If set to 0, vim will continue to run if an exception
+        arises while expanding a snippet and the error message describing the
+        error will be printed with the directives to connect to the remote
+        debug server. Internally, Pdb will run in another thread and the session
+        will use the python trace back object stored at the moment the error
+        was caught. The variable values and the application state may not reflect
+        the exact state at the moment of the error.
+        If set to 1, vim will simply freeze on the error and will resume
+        only after quiting the debugging session (you must connect via telnet
+        to type the Pdb's `quit` command to resume vim). However, the
+        execution is paused right after caughting the exception, reflecting
+        the exact state when the error occured.
+
+NOTE: Do not run vim as root with `g:UltiSnipsDebugServerEnable=1` since anything
+can connect to it and do anything with root privileges.
+Try to use these features only for...  debugging... and turn it off when you
+are done.
+
+These variables can be set at any moment. The debug server will be active
+only when an exception arises (or a breakpoint set as below is reached),
+and only if `g:UltiSnipsDebugServerEnable` is set at the moment of the
+error. It will be innactive as soon as the `quit` command is issued
+from telnet.
+
+6.1 Setting breakpoints                               *UltiSnips-breakpoints*
+-----------------------
+
+The easiest way of setting a breakpoint inside a snippet or UltiSnips
+internal code is the following: >
+
+    from UltiSnips.remote_pdb import RemotePDB
+    RemotePDB.breakpoint()
+
+...You can also raise an exception since it will be caught, and then will
+launch the post-mortem session. However, using the breakpoint method allows
+to continue the execution once the debugger quit.
+
+6.2 Accessing Pdb                                             *UltiSnips-Pdb*
+-----------------
+
+Even though it's possible to use the builtin Pdb, (or any other compatible
+debugger), the best experience is achived with Pdb++.
+You can install it this way: >
+
+    pip install pdbpp
+
+It is a no-configuration replacement of the built-in pdb.
+
+To connect to the pdb server, simply run telnet: >
+
+    telnet host:port
+
+To leave the server and continue the execution, run Pdb's `quit` command
+
+Known issues : The arrow and tab keys (for completion) are not supported yet
+
+=============================================================================
+7. FAQ                                                        *UltiSnips-FAQ*
 
 Q: Do I have to call UltiSnips#ExpandSnippet() to check if a snippet is
    expandable? Is there instead an analog of neosnippet#expandable?
@@ -1849,7 +1935,7 @@ You can contribute by fixing or reporting bugs in our issue tracker:
 https://github.com/sirver/ultisnips/issues
 
 =============================================================================
-8. Contributors                                      *UltiSnips-contributors*
+9. Contributors                                      *UltiSnips-contributors*
 
 UltiSnips has been started and maintained from Jun 2009 - Dec 2015 by Holger
 Rapp (@SirVer, SirVer@gmx.de). Up to April 2018 it was maintained by Stanislav

--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -10,6 +10,24 @@ if version < 704
    finish
 endif
 
+" Enable Post debug server config
+if !exists("g:UltiSnipsDebugServerEnable")
+   let g:UltiSnipsDebugServerEnable = 0
+endif
+
+if !exists("g:UltiSnipsDebugHost")
+   let g:UltiSnipsDebugHost = 'localhost'
+endif
+
+if !exists("g:UltiSnipsDebugPort")
+   let g:UltiSnipsDebugPort = 8080
+endif
+
+if !exists("g:UltiSnipsPMDebugBlocking")
+   let g:UltiSnipsPMDebugBlocking = 0
+endif
+
+
 " The Commands we define.
 command! -bang -nargs=? -complete=customlist,UltiSnips#FileTypeComplete UltiSnipsEdit
     \ :call UltiSnips#Edit(<q-bang>, <q-args>)

--- a/pythonx/UltiSnips/buffer_proxy.py
+++ b/pythonx/UltiSnips/buffer_proxy.py
@@ -190,15 +190,11 @@ class VimBufferProxy(vim_helper.VimBuffer):
         line_before = line_number <= self._snippets_stack[0]._start.line
         column_before = column_number <= self._snippets_stack[0]._start.col
         if line_before and column_before:
-            direction = 1
-            if change_type == "D":
-                direction = -1
-
-            diff = Position(direction, 0)
-            if len(change) != 5:
-                diff = Position(0, direction * len(change_text))
-
-            self._snippets_stack[0]._move(Position(line_number, column_number), diff)
+            if len(change) == 5: # if len == 5, then it's a full line change (see _get_diff() and _get_line_diff() return values)
+                pivot, delta = Position._create_pivot_delta_for_line_change(change)
+            else :
+                pivot, delta = Position._create_pivot_delta_for_edit_cmd(change)
+            self._snippets_stack[0]._move(pivot, delta)
         else:
             if line_number > self._snippets_stack[0]._end.line:
                 return

--- a/pythonx/UltiSnips/err_to_scratch_buffer.py
+++ b/pythonx/UltiSnips/err_to_scratch_buffer.py
@@ -4,9 +4,12 @@ from functools import wraps
 import traceback
 import re
 import sys
+import time
+from bdb import BdbQuit
 
 from UltiSnips import vim_helper
 from UltiSnips.error import PebkacError
+from UltiSnips.remote_pdb import RemotePDB
 
 
 def _report_exception(self, msg, e):
@@ -42,11 +45,20 @@ def wrap(func):
     def wrapper(self, *args, **kwds):
         try:
             return func(self, *args, **kwds)
+        except BdbQuit :
+            pass # A debugger stopped, but it's not really an error
         except PebkacError as e:
+            if RemotePDB.is_enable() :
+                RemotePDB.pm()
             msg = "UltiSnips Error:\n\n"
             msg += str(e).strip()
+            if RemotePDB.is_enable() :
+                host, port = RemotePDB.get_host_port()
+                msg += f'\nUltisnips\' post mortem debug server caught the error. Run `telnet {host}:{port}` to inspect it with pdb\n'
             _report_exception(self, msg, e)
         except Exception as e:  # pylint: disable=bare-except
+            if RemotePDB.is_enable() :
+                RemotePDB.pm()
             msg = """An error occured. This is either a bug in UltiSnips or a bug in a
 snippet definition. If you think this is a bug, please report it to
 https://github.com/SirVer/ultisnips/issues/new
@@ -56,6 +68,10 @@ https://github.com/SirVer/ultisnips/blob/master/CONTRIBUTING.md#reproducing-bugs
 Following is the full stack trace:
 """
             msg += traceback.format_exc()
+            if RemotePDB.is_enable() :
+                host, port = RemotePDB.get_host_port()
+                msg += f'\nUltisnips\' post mortem debug server caught the error. Run `telnet {host}:{port}` to inspect it with pdb\n'
+              
             _report_exception(self, msg, e)
 
     return wrapper

--- a/pythonx/UltiSnips/position.py
+++ b/pythonx/UltiSnips/position.py
@@ -11,66 +11,126 @@ class JumpDirection(Enum):
 
 class Position:
     """Represents a Position in a text file: (0 based line index, 0 based column
-    index) and provides methods for moving them around."""
+    index, z to order Positions at the same locations) and provides methods for moving them around."""
 
-    def __init__(self, line, col):
+    def __init__(self, line, col, z=0):
         self.line = line
         self.col = col
+        self.z = z
 
     def move(self, pivot, delta):
         """'pivot' is the position of the first changed character, 'delta' is
-        how text after it moved."""
-        if self < pivot:
-            return
-        if delta.line == 0:
-            if self.line == pivot.line:
-                self.col += delta.col
-        elif delta.line > 0:
-            if self.line == pivot.line:
-                self.col += delta.col - pivot.col
+        how text after it moved. Return True if the position has been deleted"""
+        
+        if pivot.line <= self.line :
+            if pivot.line == self.line :
+                if pivot.col <= self.col :
+                    if pivot.col == self.col :
+                        if pivot.z <= self.z :
+                            self.z += pivot.z
+                        elif pivot.z + delta.z < self.z :
+                            return True
+                    self.col += delta.col
+                elif pivot.col + delta.col < self.col :
+                    return True
             self.line += delta.line
-        else:
-            self.line += delta.line
-            if self.line == pivot.line:
-                self.col += -delta.col + pivot.col
+        elif pivot.line + delta.line < self.line :
+            return True
+        return False
+                    
+    @property
+    def tuple(self):
+        return (self.line, self.col, self.z)
 
-    def delta(self, pos):
-        """Returns the difference that the cursor must move to come from 'pos'
-        to us."""
-        assert isinstance(pos, Position)
-        if self.line == pos.line:
-            return Position(0, self.col - pos.col)
-        if self > pos:
-            return Position(self.line - pos.line, self.col)
-        return Position(self.line - pos.line, pos.col)
+    def __iter__(self):
+        return self.tuple.__iter__()
 
     def __add__(self, pos):
         assert isinstance(pos, Position)
-        return Position(self.line + pos.line, self.col + pos.col)
+        return Position(self.line + pos.line, self.col + pos.col, self.z + pos.z)
 
     def __sub__(self, pos):
         assert isinstance(pos, Position)
-        return Position(self.line - pos.line, self.col - pos.col)
+        return Position(self.line - pos.line, self.col - pos.col, self.z - pos.z)
 
     def __eq__(self, other):
-        return (self.line, self.col) == (other.line, other.col)
+        return self.tuple == other.tuple
 
     def __ne__(self, other):
-        return (self.line, self.col) != (other.line, other.col)
+        return self.tuple != other.tuple
 
     def __lt__(self, other):
-        return (self.line, self.col) < (other.line, other.col)
+        return self.tuple < other.tuple
 
     def __le__(self, other):
-        return (self.line, self.col) <= (other.line, other.col)
+        return self.tuple <= other.tuple
 
+    def __neg__(self):
+        return Position(-self.line, -self.col, -self.z)
+      
     def __repr__(self):
-        return "(%i,%i)" % (self.line, self.col)
+        return "(%i,%i,%i)" % self.tuple
 
     def __getitem__(self, index):
-        if index > 1:
-            raise IndexError("position can be indexed only 0 (line) and 1 (column)")
-        if index == 0:
-            return self.line
+        if not (0 <=  index < 3):
+            raise IndexError("position can be indexed only 0 (line), 1 (column) and 2 (z)")
+        return self.tuple[index]
+
+    def get_text_end(self, text):
+        """Calculate the end position of the 'text' (list of lines) starting at self."""
+        if len(text) == 1:
+            new_end = self + Position(0, len(text[0]))
         else:
-            return self.col
+            new_end = Position(self.line + len(text) - 1, len(text[-1]))
+        return new_end
+        
+
+    @classmethod
+    def zero(cls):
+      return Position(0, 0)
+
+    @classmethod
+    def _create_pivot_delta_for_edit_cmd(cls, cmd):
+        """
+        Create the delta between the cursor position in the command
+        and the resulting position after
+        """
+        ctype, line, col, text = cmd
+        delta = (
+            Position(1, -col) # new line inserted, then cursor go at line start
+            if text == '\n' else
+            Position(0, len(text)) # Only the column moves
+        )
+        start = Position(line, col)
+        if ctype == 'I' :
+            return start, delta
+        else :
+            return start + delta, -delta
+          
+    @classmethod
+    def _create_pivot_delta_for_line_change(cls, change):
+        """
+        Create the delta for a full line removal
+        """
+        ctype, line, _, text, *_ = change # col should be 0...
+        start = Position(line, 0)
+        delta = Position(1, 0)
+        if ctype == 'I' :
+            return start, delta
+        else :
+            return start + delta, -delta
+
+    @classmethod
+    def _create_edit_start_end_pos(cls, line, col, text):
+        start = Position(line, col)
+        end = (
+            Position(line + 1, 0)
+            if text == '\n' else
+            Position(line, col + len(text))
+        )
+        return start, end
+
+    @classmethod
+    def _create_same_line_pivot_delta(cls, line, col_old, col_new):
+        return Position(line, col_old), Position(0, col_new - col_old)
+          

--- a/pythonx/UltiSnips/remote_pdb.py
+++ b/pythonx/UltiSnips/remote_pdb.py
@@ -1,0 +1,111 @@
+import sys
+import threading
+from bdb import BdbQuit
+
+from UltiSnips import vim_helper
+
+class RemotePDB(object):
+    """
+    Launch a pdb instance listening on (host, port).
+    Used to provide debug facilities you can access with netcat or telnet.
+    """
+    
+    singleton = None
+
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+        self._pdb = None
+
+    def start_server(self):
+        """
+        Create an instance of Pdb bound to a socket
+        """
+        if self._pdb is not None :
+          return
+        import pdb 
+        import socket
+
+        self.server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
+        self.server.bind((self.host, self.port))
+        self.server.listen(1)
+        self.connection, address = self.server.accept()
+        io = self.connection.makefile("rw")
+        parent = self
+        
+        class Pdb(pdb.Pdb):
+            """Patch quit to close the connection"""
+            def set_quit(self):
+                parent._shutdown()
+                super().set_quit()
+                
+        self._pdb = Pdb(stdin=io, stdout=io)
+
+    def _pm(self, tb):
+        """
+        Launch the server as post mortem on the currently handled exception
+        """
+        try:
+            self._pdb.interaction(None, tb) 
+        except: # Ignore all exceptions part of debugger shutdown (and bugs... https://bugs.python.org/issue44461 )
+            pass
+
+    def set_trace(self, frame):
+        self._pdb.set_trace(frame)
+
+    def _shutdown(self):
+        if self._pdb is not None :
+            import socket
+            self.connection.shutdown(socket.SHUT_RDWR)
+            self.connection.close()
+            self.server.close()
+            self._pdb = None
+
+    @staticmethod
+    def get_host_port(host=None, port=None):
+        if host is None :
+            host = vim_helper.eval('g:UltiSnipsDebugHost')
+        if port is None :
+            port = int(vim_helper.eval('g:UltiSnipsDebugPort'))
+        return host, port
+
+    @staticmethod
+    def is_enable():
+        return bool(int(vim_helper.eval('g:UltiSnipsDebugServerEnable')))
+
+    @staticmethod
+    def is_blocking():
+        return bool(int(vim_helper.eval('g:UltiSnipsPMDebugBlocking')))
+
+    @classmethod
+    def _create(cls):
+        if cls.singleton is None:
+            cls.singleton = cls(*cls.get_host_port())
+        
+    @classmethod
+    def breakpoint(cls, host=None, port=None):
+        if cls.singleton is None and not cls.is_enable() :
+            return
+        cls._create()
+        cls.singleton.start_server()
+        cls.singleton.set_trace(sys._getframe().f_back)
+
+    @classmethod
+    def pm(cls):
+        """
+        Launch the server as post mortem on the currently handled exception
+        """
+        if cls.singleton is None and not cls.is_enable() :
+            return
+        cls._create()
+        t, val, tb = sys.exc_info()
+        def _thread_run():
+            cls.singleton.start_server()
+            cls.singleton._pm(tb)
+        if cls.is_blocking() :
+          _thread_run()
+        else :
+          thread = threading.Thread(target=_thread_run)
+          thread.start()
+

--- a/pythonx/UltiSnips/snippet/definition/base.py
+++ b/pythonx/UltiSnips/snippet/definition/base.py
@@ -485,6 +485,7 @@ class SnippetDefinition:
             context=self._context,
         )
         self.instantiate(snippet_instance, initial_text, indent)
+        snippet_instance._sort_children_rec()
         snippet_instance.replace_initial_text(vim_helper.buf)
         snippet_instance.update_textobjects(vim_helper.buf)
         return snippet_instance

--- a/pythonx/UltiSnips/snippet/parsing/base.py
+++ b/pythonx/UltiSnips/snippet/parsing/base.py
@@ -24,7 +24,6 @@ def resolve_ambiguity(all_tokens, seen_ts):
             else:
                 Mirror(parent, seen_ts[token.number], token)
 
-
 def tokenize_snippet_text(
     snippet_instance,
     text,

--- a/pythonx/UltiSnips/snippet/parsing/lexer.py
+++ b/pythonx/UltiSnips/snippet/parsing/lexer.py
@@ -116,11 +116,12 @@ class Token:
 
     """Represents a Token as parsed from a snippet definition."""
 
-    def __init__(self, gen, indent):
+    def __init__(self, gen, indent, tiebreaker):
         self.initial_text = ""
         self.start = gen.pos
         self._parse(gen, indent)
         self.end = gen.pos
+        self.tiebreaker = tiebreaker
 
     def _parse(self, stream, indent):
         """Parses the token from 'stream' with the current 'indent'."""
@@ -421,14 +422,16 @@ def tokenize(text, indent, offset, allowed_tokens):
     'allowed_tokens' are considered to be valid tokens."""
     stream = _TextIterator(text, offset)
     try:
+        tiebreaker = 0
         while True:
             done_something = False
             for token in allowed_tokens:
                 if token.starts_here(stream):
-                    yield token(stream, indent)
+                    yield token(stream, indent, tiebreaker)
+                    tiebreaker += 1
                     done_something = True
                     break
             if not done_something:
                 next(stream)
     except StopIteration:
-        yield EndOfTextToken(stream, indent)
+        yield EndOfTextToken(stream, indent, tiebreaker)

--- a/pythonx/UltiSnips/test_position.py
+++ b/pythonx/UltiSnips/test_position.py
@@ -49,7 +49,10 @@ class MovePosition_DelSecondLine(_MPBase, unittest.TestCase):
     # *a, was            ach nix
     # ach nix
     obj = (1, 0)
-    steps = (((0, 12), (0, -4), (1, 0)), ((0, 12), (-1, 0), (0, 12)))
+    steps = (
+        ((0, 12), (0, -4), (1, 0)),
+        ((0, 12), (-1, 0), (0, 12))
+    )
 
 
 class MovePosition_DelSecondLine1(_MPBase, unittest.TestCase):

--- a/pythonx/UltiSnips/text_objects/choices.py
+++ b/pythonx/UltiSnips/text_objects/choices.py
@@ -15,6 +15,8 @@ class Choices(TabStop):
     """See module docstring."""
 
     def __init__(self, parent, token: ChoicesToken):
+        TabStop.__init__(self, parent, token)
+        
         self._number = token.number  # for TabStop property 'number'
         self._initial_text = token.initial_text
 
@@ -24,7 +26,6 @@ class Choices(TabStop):
         self._input_chars = list(self._initial_text)
         self._has_been_updated = False
 
-        TabStop.__init__(self, parent, token)
 
     def _get_choices_placeholder(self) -> str:
         # prefix choices with index number
@@ -37,7 +38,7 @@ class Choices(TabStop):
         text = "|".join(text_segs)
         return text
 
-    def _update(self, done, buf):
+    def _update(self, todo, buf):
         if self._done:
             return True
 
@@ -137,10 +138,15 @@ class Choices(TabStop):
             self.overwrite(buf, overwrite_text)
 
             # notify all tabstops those in the same line and after this to adjust their positions
-            pivot = Position(line, old_end_col)
-            diff_col = displayed_text_end_col - old_end_col
+            pivot, delta = Position._create_same_line_pivot_delta(
+                line,
+                old_end_col,
+                displayed_text_end_col
+            )
             self._parent._child_has_moved(
-                self._parent.children.index(self), pivot, Position(0, diff_col)
+                self._parent.children.index(self),
+                pivot,
+                delta
             )
 
             vim_helper.set_cursor_from_pos([buf_num, cursor_line, self._end.col + 1])

--- a/pythonx/UltiSnips/text_objects/mirror.py
+++ b/pythonx/UltiSnips/text_objects/mirror.py
@@ -14,13 +14,13 @@ class Mirror(NoneditableTextObject):
         NoneditableTextObject.__init__(self, parent, token)
         self._ts = tabstop
 
-    def _update(self, done, buf):
+    def _update(self, todo, buf):
         if self._ts.is_killed:
             self.overwrite(buf, "")
             self._parent._del_child(self)  # pylint:disable=protected-access
             return True
 
-        if self._ts not in done:
+        if self._ts in todo:
             return False
 
         self.overwrite(buf, self._get_text())

--- a/pythonx/UltiSnips/text_objects/python_code.py
+++ b/pythonx/UltiSnips/text_objects/python_code.py
@@ -227,7 +227,7 @@ class PythonCode(NoneditableTextObject):
     """See module docstring."""
 
     def __init__(self, parent, token):
-
+        NoneditableTextObject.__init__(self, parent, token)
         # Find our containing snippet for snippet local data
         snippet = parent
         while snippet:
@@ -246,9 +246,8 @@ class PythonCode(NoneditableTextObject):
             "\n".join(snippet.globals.get("!p", [])).replace("\r\n", "\n"),
             token.code.replace("\\`", "`"),
         )
-        NoneditableTextObject.__init__(self, parent, token)
 
-    def _update(self, done, buf):
+    def _update(self, todo, buf):
         path = vim_helper.eval('expand("%")') or ""
         ct = self.current_text
         self._locals.update(

--- a/pythonx/UltiSnips/text_objects/shell_code.py
+++ b/pythonx/UltiSnips/text_objects/shell_code.py
@@ -70,7 +70,7 @@ class ShellCode(NoneditableTextObject):
         self._code = token.code.replace("\\`", "`")
         self._tmpdir = _get_tmp()
 
-    def _update(self, done, buf):
+    def _update(self, todo, buf):
         if not self._tmpdir:
             output = "Unable to find executable tmp directory, check noexec on /tmp"
         else:

--- a/pythonx/UltiSnips/text_objects/viml_code.py
+++ b/pythonx/UltiSnips/text_objects/viml_code.py
@@ -12,10 +12,9 @@ class VimLCode(NoneditableTextObject):
     """See module docstring."""
 
     def __init__(self, parent, token):
+        NoneditableTextObject.__init__(self, parent, token)
         self._code = token.code.replace("\\`", "`").strip()
 
-        NoneditableTextObject.__init__(self, parent, token)
-
-    def _update(self, done, buf):
+    def _update(self, todo, buf):
         self.overwrite(buf, vim_helper.eval(self._code))
         return True

--- a/pythonx/UltiSnips/text_objects/visual.py
+++ b/pythonx/UltiSnips/text_objects/visual.py
@@ -23,6 +23,9 @@ class Visual(NoneditableTextObject, TextObjectTransformation):
     """See module docstring."""
 
     def __init__(self, parent, token):
+        NoneditableTextObject.__init__(self, parent, token)
+        TextObjectTransformation.__init__(self, token)
+        
         # Find our containing snippet for visual_content
         snippet = parent
         while snippet:
@@ -36,10 +39,8 @@ class Visual(NoneditableTextObject, TextObjectTransformation):
             self._text = token.alternative_text
             self._mode = "v"
 
-        NoneditableTextObject.__init__(self, parent, token)
-        TextObjectTransformation.__init__(self, token)
 
-    def _update(self, done, buf):
+    def _update(self, todo, buf):
         if self._mode == "v":  # Normal selection.
             text = self._text
         else:  # Block selection or line selection.

--- a/pythonx/UltiSnips/vim_helper.py
+++ b/pythonx/UltiSnips/vim_helper.py
@@ -31,7 +31,7 @@ class VimBuffer:
     @property
     def line_till_cursor(self):  # pylint:disable=no-self-use
         """Returns the text before the cursor."""
-        _, col = self.cursor
+        col = self.cursor.col
         return vim.current.line[:col]
 
     @property

--- a/test/test_ZeroLength.py
+++ b/test/test_ZeroLength.py
@@ -1,0 +1,106 @@
+"""
+These tests are checking what was once a NON-DETERMINISTIC bug.
+An error on any run should be interpreted as a fail.
+You should run them a huge amont of times before concluding they passed.
+
+If most of the tests of other files passes but some of this one don't,
+then it is highly probable it is a problem with zero length text object ordering.
+"""
+
+from test.vim_test_case import VimTestCase as _VimTest
+from test.constant import *
+
+class ZeroLength_Simple(_VimTest):
+    snippets = ("test", "$1$2")
+    keys = "test" + EX + "a" + JF + "b" + JF + "c"
+    wanted = "abc"
+
+
+class ZeroLength_ManyTabs(_VimTest):
+    snippets = ("test", "$3$1$5$2$4$6")
+    keys = "test" + EX + "a" + JF + "b" + JF + "c" + JF + "d" + JF + "e" + JF + "f" + JF + "g"
+    wanted = "caebdfg"
+
+
+class ZeroLength_SimpleWithMirror(_VimTest):
+    snippets = ("test", "$1$1")
+    keys = "test" + EX + "a" + JF + "b"
+    wanted = "aab"
+
+
+class ZeroLength_SimpleWithMirrorDefaultEmpty1(_VimTest):
+    snippets = ("test", "${1:}$1")
+    keys = "test" + EX + "a" + JF + "b"
+    wanted = "aab"
+
+
+class ZeroLength_SimpleWithMirrorDefaultEmpty2(_VimTest):
+    snippets = ("test", "$1${1:}")
+    keys = "test" + EX + "a" + JF + "b"
+    wanted = "aab"
+
+
+class ZeroLength_ManyTabsWithMirrors(_VimTest):
+    snippets = ("test", "$3$1$5$1$5$2$2$4$2$6$1")
+    keys = "test" + EX + "a" + JF + "b" + JF + "c" + JF + "d" + JF + "e" + JF + "f" + JF + "g"
+    wanted = "caeaebbdbfag"
+
+
+class ZeroLength_ManyTabsWithMirrorsDefaultEmpty(_VimTest):
+    snippets = ("test", "$3$1$5${1:}$5$2$2${4:}$2${6:}$1")
+    keys = "test" + EX + "a" + JF + "b" + JF + "c" + JF + "d" + JF + "e" + JF + "f" + JF + "g"
+    wanted = "caeaebbdbfag"
+
+
+class ZeroLength_ManyTabsWithMirrorsDefaultNonEmpty(_VimTest):
+    snippets = ("test", "$3$1$5${1:}$5$2$2${4:tdsgq}$2${6:ezgezg}$1")
+    keys = "test" + EX + "a" + JF + "b" + JF + "c" + JF + "d" + JF + "e" + JF + "f" + JF + "g"
+    wanted = "caeaebbdbfag"
+
+
+class ZeroLength_ManyTabsWithMirrorsAndPythonMirrors(_VimTest):
+    snippets = ("test", "$3$1`!p snip.rv=t[5]`$1$5$2`!p snip.rv=t[2]`$4$2$6$1")
+    keys = "test" + EX + "a" + JF + "b" + JF + "c" + JF + "d" + JF + "e" + JF + "f" + JF + "g"
+    wanted = "caeaebbdbfag"
+
+class ZeroLength_OriginalBug1(_VimTest):
+    snippets = ("test", 
+        "`!p\n"
+        "import sys\n"
+        "if 'dummy' not in sys.modules:\n"
+        "	sys.modules['dummy'] = 'tt'\n"
+        "	snip.rv=''\n"
+        "else:\n"
+        "	snip.rv='tt'\n"
+        "`"
+    )
+    keys = "test" + EX + "a"
+    wanted = "tta"
+
+class ZeroLength_OriginalBug2(_VimTest):
+    snippets = ("test", 
+        "`!p\n"
+        "import sys\n"
+        "if 'dummy' not in sys.modules:\n"
+        "	sys.modules['dummy'] = 'tt'\n"
+        "	# snip.rv is not mutated\n"
+        "else:\n"
+        "	snip.rv='tt'\n"
+        "`\n"
+    )
+    keys = "test" + EX + "a"
+    wanted = "tta"
+
+class ZeroLength_OriginalBug3(_VimTest):
+    snippets = ("test", "`!p import sys;sys.modules['dummy'] = 'tt';snip.rv=''``!p snip.rv=sys.modules.get('dummy', '')`")
+    keys = "test" + EX + "a"
+    wanted = "tta"
+    
+
+class ZeroLength_OriginalBug3bis(_VimTest):
+    snippets = ("test", "`!p import sys;sys.modules['dummy'] = 'tt'``!p snip.rv=sys.modules.get('dummy', '')`")
+    keys = "test" + EX + "a"
+    wanted = "tta"
+
+
+

--- a/test/vim_test_case.py
+++ b/test/vim_test_case.py
@@ -135,6 +135,12 @@ class VimTestCase(unittest.TestCase, TempFileManager):
         vim_config.append('let g:UltiSnipsJumpForwardTrigger="?"')
         vim_config.append('let g:UltiSnipsJumpBackwardTrigger="+"')
         vim_config.append('let g:UltiSnipsListSnippets="@"')
+        
+        vim_config.append('let g:UltiSnipsDebugServerEnable={}'.format(1 if self.pdb_enable else 0))
+        vim_config.append('let g:UltiSnipsDebugHost="{}"'.format(self.pdb_host))
+        vim_config.append('let g:UltiSnipsDebugPort={}'.format(self.pdb_port))
+        vim_config.append('let g:UltiSnipsPMDebugBlocking={}'.format(1 if self.pdb_block else 0))
+
 
         # Work around https://github.com/vim/vim/issues/3117 for testing >
         # py3.7 on Vim 8.1. Actually also reported against UltiSnips

--- a/test_all.py
+++ b/test_all.py
@@ -156,6 +156,32 @@ if __name__ == "__main__":
             help="If set, each test will check sys.version inside of vim to "
             "verify we are testing against the expected Python version.",
         )
+        p.add_option(
+            "--remote-pdb",
+            dest="pdb_enable",
+            action="store_true",
+            help="If set, The remote pdb server will be run"
+        )
+        p.add_option(
+            "--remote-pdb-host",
+            dest="pdb_host",
+            type=str,
+            default="localhost",
+            help="Remote pdb server host"
+        )
+        p.add_option(
+            "--remote-pdb-port",
+            dest="pdb_port",
+            type=int,
+            default=8080,
+            help="Remote pdb server port"
+        )
+        p.add_option(
+            "--remote-pdb-non-blocking",
+            dest="pdb_block",
+            action="store_false",
+            help="If set, the server will not freeze vim on error"
+        )
 
         o, args = p.parse_args()
         return o, args
@@ -203,6 +229,10 @@ if __name__ == "__main__":
             test.expected_python_version = options.expected_python_version
             test.vim = vim
             test.vim_flavor = vim_flavor
+            test.pdb_enable = options.pdb_enable
+            test.pdb_host = options.pdb_host
+            test.pdb_port = options.pdb_port
+            test.pdb_block = options.pdb_block
             all_other_plugins.update(test.plugins)
 
             if len(selected_tests):


### PR DESCRIPTION
This is a work in progress.
This pr fixes most of the problems we get with the tie breaker. (yet, it may not be polished yet)
Unfortunately, some unit tests won't pass because of #1405.

But since I use this commit as start point for fixing #1405 by implementing the algorithm described in #1407, I think it deserves also a review =)

Basically, I reversed the logic of the "done" argument of the update method.

Then child of each parent are sorted lazily (first sorted at the end of the parsing, the add are perform as an insert-sort).


The only draw-back as it is, is that parent are tagged as "done" only on the next iteration, and that makes snippet recursion easily hitting the cyclic dependency check. To fix that, I'm thinking about either making the SnippetInstance not exposing its children and it's update function to do a similar algorithm as update_textobjects.

...But I prefer to first show this PR to get some reviews before pushing it further


I also cleaned and refactored the Position class, because some parts about the move/delta function pair were a bit obscure. Now, the delta is simply the difference between two positions. I also moved code constructing or dealing with delta from outside of the Position class to class methods of Position so that changing the internals of this class could all be made in only one file. That also ease tracking bugs or usage of the class by simple doing a usage search on these class methods.

These changes in the Position class make obsolete the unit tests (outside the tmux based test suite) because they were assessing the details of the class and not the actual public feature.
Thus, my confidence of these changes being right is based on the fact that all test cases which passed on the previous implementation still with this one (except as I said earlier the one or two that fail because of the tiebreaker fix and the selection/cursor getting out of sync)