### PR TITLE
Handle wildcards in runtimepath entries. Fixes #1414.

### DIFF
--- a/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
+++ b/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
@@ -61,7 +61,8 @@ def find_all_snippet_directories() -> List[str]:
             pth = normalize_file_path(
                 os.path.expanduser(os.path.join(rtp, snippet_dir))
             )
-            all_dirs.append(pth)
+            # Runtimepath entries may contain wildcards.
+            all_dirs.extend(glob.glob(pth))
     return all_dirs
 
 


### PR DESCRIPTION
Single wildcards ("*") are allowed in runtimepath entries, so expand them.
See `:h rtp<cr>71j` in Vim or `:h rtp-packages` in Neovim.