### PR TITLE
precompile python code in snippets

### DIFF
--- a/pythonx/UltiSnips/snippet/definition/base.py
+++ b/pythonx/UltiSnips/snippet/definition/base.py
@@ -500,6 +500,7 @@ class SnippetDefinition:
             last_re=self._last_re,
             globals=self._globals,
             context=self._context,
+            _compiled_globals = self._compiled_globals,
         )
         self.instantiate(snippet_instance, initial_text, indent)
         snippet_instance.replace_initial_text(vim_helper.buf)

--- a/pythonx/UltiSnips/snippet/definition/base.py
+++ b/pythonx/UltiSnips/snippet/definition/base.py
@@ -111,7 +111,7 @@ class SnippetDefinition:
         self._globals = globals
         self._compiled_globals = compile("\n".join([
                     "import re, os, vim, string, random",
-                    "\n".join(self._globals.get("!p", [])).replace("\r\n", "\n")
+                    "\n".join(globals.get("!p", [])).replace("\r\n", "\n")
                 ]), '<global-snippets>', 'exec')
         self._location = location
         self._context_code = context

--- a/pythonx/UltiSnips/snippet/definition/base.py
+++ b/pythonx/UltiSnips/snippet/definition/base.py
@@ -14,13 +14,8 @@ from UltiSnips.indent_util import IndentUtil
 from UltiSnips.position import Position
 from UltiSnips.text import escape
 from UltiSnips.text_objects import SnippetInstance
-from UltiSnips.text_objects.python_code import SnippetUtilForAction
+from UltiSnips.text_objects.python_code import SnippetUtilForAction, cached_compile
 
-# We'll end up compiling the global snippets for every snippet so
-# caching compile() should pay off
-from functools import lru_cache
-
-cached_compile = lru_cache(compile)
 
 __WHITESPACE_SPLIT = re.compile(r"\s")
 

--- a/pythonx/UltiSnips/text_objects/python_code.py
+++ b/pythonx/UltiSnips/text_objects/python_code.py
@@ -247,11 +247,14 @@ class PythonCode(NoneditableTextObject):
         self._snip = SnippetUtil(token.indent, mode, text, context, snippet)
 
         self._codes = (
-            "import re, os, vim, string, random",
+            "import re, os, vim, string, random\n" +
             "\n".join(snippet.globals.get("!p", [])).replace("\r\n", "\n"),
             token.code.replace("\\`", "`"),
         )
-        self._compiled_codes = tuple(compile(code, '<exec-code>', 'exec') for code in self._codes)
+        self._compiled_codes = (
+            snippet._compiled_globals or compile(self._codes[0], '<exec-globals>', 'exec'),
+            compile(token.code.replace("\\`", "`"), '<exec-interpolation-code>', 'exec'),
+        )
         NoneditableTextObject.__init__(self, parent, token)
 
     def _update(self, done, buf):

--- a/pythonx/UltiSnips/text_objects/python_code.py
+++ b/pythonx/UltiSnips/text_objects/python_code.py
@@ -13,9 +13,10 @@ from UltiSnips.vim_state import _Placeholder
 import UltiSnips.snippet_manager
 
 # We'll end up compiling the global snippets for every snippet so
-# caching compile() shoud pay off
+# caching compile() should pay off
 from functools import lru_cache
-compile = lru_cache(compile)
+
+cached_compile = lru_cache(compile)
 
 
 class _Tabs:
@@ -247,13 +248,16 @@ class PythonCode(NoneditableTextObject):
         self._snip = SnippetUtil(token.indent, mode, text, context, snippet)
 
         self._codes = (
-            "import re, os, vim, string, random\n" +
-            "\n".join(snippet.globals.get("!p", [])).replace("\r\n", "\n"),
+            "import re, os, vim, string, random\n"
+            + "\n".join(snippet.globals.get("!p", [])).replace("\r\n", "\n"),
             token.code.replace("\\`", "`"),
         )
         self._compiled_codes = (
-            snippet._compiled_globals or compile(self._codes[0], '<exec-globals>', 'exec'),
-            compile(token.code.replace("\\`", "`"), '<exec-interpolation-code>', 'exec'),
+            snippet._compiled_globals
+            or cached_compile(self._codes[0], "<exec-globals>", "exec"),
+            cached_compile(
+                token.code.replace("\\`", "`"), "<exec-interpolation-code>", "exec"
+            ),
         )
         NoneditableTextObject.__init__(self, parent, token)
 

--- a/pythonx/UltiSnips/text_objects/python_code.py
+++ b/pythonx/UltiSnips/text_objects/python_code.py
@@ -16,7 +16,10 @@ import UltiSnips.snippet_manager
 # caching compile() should pay off
 from functools import lru_cache
 
-cached_compile = lru_cache(compile)
+
+@lru_cache(maxsize=None)
+def cached_compile(*args):
+    return compile(*args)
 
 
 class _Tabs:

--- a/pythonx/UltiSnips/text_objects/snippet_instance.py
+++ b/pythonx/UltiSnips/text_objects/snippet_instance.py
@@ -33,6 +33,7 @@ class SnippetInstance(EditableTextObject):
         last_re,
         globals,
         context,
+        _compiled_globals=None
     ):
         if start is None:
             start = Position(0, 0)
@@ -44,6 +45,7 @@ class SnippetInstance(EditableTextObject):
         self.context = context
         self.locals = {"match": last_re, "context": context}
         self.globals = globals
+        self._compiled_globals = _compiled_globals
         self.visual_content = visual_content
         self.current_placeholder = None
 

--- a/pythonx/UltiSnips/text_objects/snippet_instance.py
+++ b/pythonx/UltiSnips/text_objects/snippet_instance.py
@@ -33,7 +33,7 @@ class SnippetInstance(EditableTextObject):
         last_re,
         globals,
         context,
-        _compiled_globals=None
+        _compiled_globals=None,
     ):
         if start is None:
             start = Position(0, 0)


### PR DESCRIPTION
This commit changes the classes `SnippetDefinition` and `PythonCode` so that the code contained in Python interpolation, global snippets, snippet contexts and snippet actions is compiled (using Python's builtin `compile`) when an instance is created, instead of having `exec` compile the code every time it is executed.
This is (supposed to be) a non-functional change.

Compile times for Python code are very slow, e.g. compiling 63 lines of global snippets in my latex snippets file takes about 450 µs on my machine while executing the compiled code only takes 1.3 µs.