### PR TITLE
Remove Python 3.5 and add 3.10.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,7 @@ jobs:
         - { vim_version: "8.2", python_image: "3.9-buster", tag: "vim_82_py39" }
         - { vim_version: "git", python_image: "3.8-buster", tag: "vim_git_py39" }
 
-        - { vim_version: "8.1", python_image: "3.10-buster", tag: "vim_81_py310" }
-        - { vim_version: "8.2", python_image: "3.10-buster", tag: "vim_82_py310" }
+        # Vim 8.1 and 8.2 do not build with python 3.10, so only git is viable.
         - { vim_version: "git", python_image: "3.10-buster", tag: "vim_git_py310" }
 
     name: Build & Test using Docker

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,6 @@ jobs:
     strategy:
      matrix:
       include:
-        - { vim_version: "7.4", python_image: "3.5-stretch", tag: "vim_74_py35" }
-        - { vim_version: "8.0", python_image: "3.5-stretch", tag: "vim_80_py35" }
-        - { vim_version: "8.1", python_image: "3.5-stretch", tag: "vim_81_py35" }
-        - { vim_version: "git", python_image: "3.5-stretch", tag: "vim_git_py35" }
-
         - { vim_version: "7.4", python_image: "3.6-stretch", tag: "vim_74_py36" }
         - { vim_version: "8.0", python_image: "3.6-stretch", tag: "vim_80_py36" }
         - { vim_version: "8.1", python_image: "3.6-stretch", tag: "vim_81_py36" }
@@ -33,6 +28,10 @@ jobs:
         - { vim_version: "8.1", python_image: "3.9-buster", tag: "vim_81_py39" }
         - { vim_version: "8.2", python_image: "3.9-buster", tag: "vim_82_py39" }
         - { vim_version: "git", python_image: "3.8-buster", tag: "vim_git_py39" }
+
+        - { vim_version: "8.1", python_image: "3.10-buster", tag: "vim_81_py310" }
+        - { vim_version: "8.2", python_image: "3.10-buster", tag: "vim_82_py310" }
+        - { vim_version: "git", python_image: "3.10-buster", tag: "vim_git_py310" }
 
     name: Build & Test using Docker
     steps:


### PR DESCRIPTION
Official 3.5 support has ended in January and Python 3.10 is a thing now.