### PR TITLE
Expose match object to python code in context conditions

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -1432,7 +1432,7 @@ In that case snippet should be defined using this syntax: >
 
     snippet trigger_word "description" "expression" options
 
-The context can be defined using a special header: >
+The context can also be defined using a special header: >
 
     context "python_expression"
     snippet trigger_word "description" options
@@ -1464,7 +1464,8 @@ Global variable `snip` will be available with following properties:
         - 'start' - placeholder start on the moment of selection;
         - 'end' - placeholder end on the moment of selection;
 
-
+For regular expression triggered snippets the variable `match` will contain
+the return value of the match of the regular expression. See http://docs.python.org/library/re.html#match-objects.
 
 ------------------- SNIP -------------------
 snippet r "return" "re.match('^\s+if err ', snip.buffer[snip.line-1])" be

--- a/pythonx/UltiSnips/snippet/definition/base.py
+++ b/pythonx/UltiSnips/snippet/definition/base.py
@@ -193,7 +193,7 @@ class SnippetDefinition:
         snip = SnippetUtilForAction(locals)
 
         try:
-            glob = {"snip": snip}
+            glob = {"snip": snip, "match": self._last_re}
             exec(self._compiled_globals, glob)
             exec(compiled_code or code, glob)
         except Exception as e:

--- a/test/test_ContextSnippets.py
+++ b/test/test_ContextSnippets.py
@@ -230,3 +230,18 @@ class ContextSnippets_Header_DoNotExpandOnFalse(_VimTest):
     }
     keys = "a" + EX
     wanted = keys
+
+
+class ContextSnippets_ContextHasAccessToReMatch(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        context "match.group(1) != 'no'"
+        snippet "(\w*) xxx" "desc" r
+        HERE
+        endsnippet
+        """
+    }
+    negative = "no xxx"
+    positive = "yes xxx"
+    keys = negative + EX + positive + EX
+    wanted = negative + EX + "HERE"


### PR DESCRIPTION
As the title says. Actually more because `match` will also be available inside the scope of snippet actions.

I implemented it so that it is the same as the `match` variable exposed to the code in python interpolation. (There is a tiny contradiction to the documentation here, also for the match variable in python interpolation. When a snippet is not re triggered, `match` is `None` and not undefined as the docs suggest. This is probably fine.)

I can also add an example use case to the documentation.