### PR TITLE
expose text in line before snippet to context conditions (faster on neovim)

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -1466,6 +1466,12 @@ Global variable `snip` will be available with following properties:
         - 'current_text' - text in the placeholder on the moment of selection;
         - 'start' - placeholder start on the moment of selection;
         - 'end' - placeholder end on the moment of selection;
+    'snip.before' - contains the text in the current line up to and including
+        the matched snippet. Since 'snip.column' counts bytes, not characters,
+        this is **not** equivalent to 'snip.buffer[snip.line][:snip.column+1]'.
+        This property is only available in the scope of contexts but not in
+        that of actions.
+
 
 For regular expression triggered snippets the variable `match` will contain
 the return value of the match of the regular expression. See http://docs.python.org/library/re.html#match-objects.
@@ -1565,7 +1571,7 @@ There are three types of actions:
 
 Specified code will be evaluated at stages defined above and same global
 variables and modules will be available that are stated in
-the |UltiSnips-custom-context-snippets| section.
+the |UltiSnips-custom-context-snippets| section (except 'snip.before').
 
                                                 *UltiSnips-buffer-proxy*
 

--- a/pythonx/UltiSnips/snippet/definition/base.py
+++ b/pythonx/UltiSnips/snippet/definition/base.py
@@ -156,7 +156,7 @@ class SnippetDefinition:
             return match
         return False
 
-    def _context_match(self, visual_content):
+    def _context_match(self, visual_content, before):
         # skip on empty buffer
         if len(vim.current.buffer) == 1 and vim.current.buffer[0] == "":
             return
@@ -166,6 +166,7 @@ class SnippetDefinition:
             "visual_mode": "",
             "visual_text": "",
             "last_placeholder": None,
+            "before": before,
         }
 
         if visual_content:
@@ -354,7 +355,7 @@ class SnippetDefinition:
 
         self._context = None
         if match and self._context_code:
-            self._context = self._context_match(visual_content)
+            self._context = self._context_match(visual_content, before)
             if not self.context:
                 match = False
 

--- a/test/test_ContextSnippets.py
+++ b/test/test_ContextSnippets.py
@@ -48,6 +48,20 @@ class ContextSnippets_DoNotExpandOnFalse(_VimTest):
     wanted = keys
 
 
+class ContextSnippets_Before(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        context "len(snip.before) >= 5 and snip.before"
+        snippet dup "desc" i
+        [`!p snip.rv = snip.context[:-3]`]
+        endsnippet
+        """
+    }
+    word = 'Süßölgefäß'
+    keys = "adup" + EX + '\n' + word + 'dup' + EX
+    wanted = "adup" + EX + '\n' + word +'[' + word + ']'
+
+
 class ContextSnippets_UseContext(_VimTest):
     files = {
         "us/all.snippets": r"""


### PR DESCRIPTION
This would add a `before` attribute to the `snip` object in context conditions. `snip.before` should be equivalent to `snip.buffer[snip.line][:snip.column+1]`. **EDIT:** Actually, it's not because `vim.current.window.cursor` and by extension `snip.column` count bytes, not characters, see https://github.com/neovim/pynvim/issues/383.

However this implementation is faster on neovim (by ~ 0.7 ms) because it avoids an api call and the associated IPC overhead. An additional advantage is that it is more concise and avoids confusion about 1- and 0-based indexing.

If you decide you want to merge this I can write documentation for it.