### PR TITLE
Resolve paths to avoid duplicates in UltiSnipsEdit

### DIFF
--- a/pythonx/UltiSnips/snippet/source/file/common.py
+++ b/pythonx/UltiSnips/snippet/source/file/common.py
@@ -8,6 +8,7 @@ import os.path
 
 def normalize_file_path(path: str) -> str:
     """Calls normpath and normcase on path"""
+    path = os.path.realpath(path)
     return os.path.normcase(os.path.normpath(path))
 
 

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -23,6 +23,9 @@ from UltiSnips.snippet.source import (
     find_all_snippet_files,
     find_snippet_files,
 )
+from UltiSnips.snippet.source.file.common import (
+    normalize_file_path,
+)
 from UltiSnips.text import escape
 from UltiSnips.vim_state import VimState, VisualContentPreserver
 from UltiSnips.buffer_proxy import use_proxy_buffer, suspend_proxy_edits
@@ -97,7 +100,9 @@ def _get_potential_snippet_filenames_to_edit(
         potentials.update(ft_snippets_files)
         if not ft_snippets_files:
             # If there is no snippet file yet, we just default to `ft.snippets`.
-            potentials.add(os.path.join(snippet_dir, ft + ".snippets"))
+            fpath = os.path.join(snippet_dir, ft + ".snippets")
+            fpath = normalize_file_path(fpath)
+            potentials.add(fpath)
     return potentials
 
 


### PR DESCRIPTION
Use realpath to get the actual path so symlink directories are counted
as equal and excluded from the set of output.

When dotfiles are symlinked:

> dir c:\users\idbrii\.vim
...
2020-12-08  04:01 PM    <SYMLINKD>     .vim [C:\dotfiles\vim]

`:UltiSnipsEdit!` outputs:
```
    1: C:\Users\idbrii/.vim/bundle/david-snippets/UltiSnips/fugitive.snippets
  * 2: c:\dotfiles\vim\bundle\david-snippets\ultisnips\all.snippets
  * 3: c:\dotfiles\vim\bundle\david-snippets\ultisnips\all\shebang.snippets
  * 4: c:\dotfiles\vim\bundle\snippets\ultisnips\all.snippets
  * 5: c:\dotfiles\vim\bundle\project\ultisnips\all.snippets
  * 6: c:\users\idbrii\.vim\bundle\david-snippets\ultisnips\all.snippets
  * 7: c:\users\idbrii\.vim\bundle\david-snippets\ultisnips\all\shebang.snippets
    8: c:\users\idbrii\.vim\ultisnips\all.snippets
    9: c:\users\idbrii\.vim\ultisnips\fugitive.snippets
```
2,6 and 3,7 are duplicates.

This fixes the same issue on linux with similar symlink setup:
```
  $ ls -l ~/.vim
  lrwxrwxrwx 1 idbrii idbrii 49 Jan 24  2021 /home/idbrii/.vim -> /home/idbrii/dotfiles/vim
```

