### PR TITLE
Pass through trigger key if no expansion done

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -177,7 +177,7 @@ class SnippetManager:
         vim_helper.command("let g:ulti_expand_res = 1")
         if not self._try_expand():
             vim_helper.command("let g:ulti_expand_res = 0")
-            self._handle_failure(self.expand_trigger)
+            self._handle_failure(self.expand_trigger, True)
 
     @err_to_scratch_buffer.wrap
     def expand_or_jump(self):
@@ -195,7 +195,7 @@ class SnippetManager:
             rv = self._jump(JumpDirection.FORWARD)
         if not rv:
             vim_helper.command("let g:ulti_expand_or_jump_res = 0")
-            self._handle_failure(self.expand_trigger)
+            self._handle_failure(self.expand_trigger, True)
 
     @err_to_scratch_buffer.wrap
     def snippets_in_current_scope(self, search_all):
@@ -628,11 +628,14 @@ class SnippetManager:
         """Called whenever we leave the insert mode."""
         self._vstate.restore_unnamed_register()
 
-    def _handle_failure(self, trigger):
+    def _handle_failure(self, trigger, pass_through=False):
         """Mainly make sure that we play well with SuperTab."""
         if trigger.lower() == "<tab>":
             feedkey = "\\" + trigger
         elif trigger.lower() == "<s-tab>":
+            feedkey = "\\" + trigger
+        elif pass_through:
+            # pass through the trigger key if it did nothing
             feedkey = "\\" + trigger
         else:
             feedkey = None

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -106,6 +106,7 @@ class NonUnicodeDataInUnnamedRegister(_VimTest):
 
 # End: #171
 
+
 # Test for #1184
 # UltiSnips should pass through any mapping that it currently can't execute as
 # the trigger key

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -105,3 +105,19 @@ class NonUnicodeDataInUnnamedRegister(_VimTest):
 
 
 # End: #171
+
+# Test for #1184
+# UltiSnips should pass through any mapping that it currently can't execute as
+# the trigger key
+
+
+class PassThroughNonexecutedTrigger(_VimTest):
+    snippets = ("text", "Expand me!", "", "")
+    keys = (
+        "tex" + EX + # this should be passed through
+        "more\n" +
+        "text" + EX # this should be expanded
+    )
+    wanted = "tex" + EX + "more\nExpand me!"
+
+# End: #1184


### PR DESCRIPTION
Fixes #1184.

- if the trigger key does not expand a snippet, then pass it through
  like a normal key
- if the expand/jump key use the same trigger, then the key will be
  passed through if there is no expansion or jump
- added test cases