### PR TITLE
Correct snipGlobal syntax regions

### DIFF
--- a/syntax/snippets.vim
+++ b/syntax/snippets.vim
@@ -133,16 +133,16 @@ syn cluster snipTabStopTokens add=snipTransformation
 
 " Generic (non-Python) {{{4
 
-syn region snipGlobal start="^global\_s" end="^\zeendglobal\s*$" contains=snipGlobalHeader nextgroup=snipGlobalFooter fold keepend
+syn region snipGlobal start="^global\_s" end="^endglobal\s*$" contains=snipGlobalHeader fold keepend
 syn match snipGlobalHeader "^.*$" nextgroup=snipGlobalBody,snipGlobalFooter skipnl contained contains=snipGlobalHeaderKeyword
-syn region snipGlobalBody start="\_." end="^\zeendglobal\s*$" contained contains=snipLeadingSpaces
+syn region snipGlobalBody start="\_." end="^\zeendglobal\s*$" contained nextgroup=snipGlobalFooter contains=snipLeadingSpaces
 
 " Python (!p) {{{4
 
-syn region snipGlobal start=,^global\s\+!p\%(\s\+"[^"]*\%("\s\+[^"[:space:]]\+\|"\)\=\)\=\s*$, end=,^\zeendglobal\s*$, contains=snipGlobalPHeader nextgroup=snipGlobalFooter fold keepend
+syn region snipGlobal start=,^global\s\+!p\%(\s\+"[^"]*\%("\s\+[^"[:space:]]\+\|"\)\=\)\=\s*$, end=,^endglobal\s*$, contains=snipGlobalPHeader fold keepend
 syn match snipGlobalPHeader "^.*$" nextgroup=snipGlobalPBody,snipGlobalFooter skipnl contained contains=snipGlobalHeaderKeyword
 syn match snipGlobalHeaderKeyword "^global" contained nextgroup=snipSnippetTrigger skipwhite
-syn region snipGlobalPBody start="\_." end="^\zeendglobal\s*$" contained contains=@Python
+syn region snipGlobalPBody start="\_." end="^\zeendglobal\s*$" contained nextgroup=snipGlobalFooter contains=@Python
 
 " Common {{{4
 


### PR DESCRIPTION
The previous syntax group for snipGlobal was not matching and including
the endglobal keyword, resulting in a wrong folding region.

This commit fixes this, to make the endglobal keyword matched and
correctly included in the snipGlobal syntax region.


### Wrong (before fix):

<img width="1145" alt="image" src="https://user-images.githubusercontent.com/1009873/168933357-1622642b-ae02-43b3-a97d-06b069ca6cca.png">

Note L18 `endglobal` is excluded and therefore not folded (with `foldmethod=syntax`).

### Fixed (after):

<img width="1163" alt="image" src="https://user-images.githubusercontent.com/1009873/168933257-bc538b80-d8e2-41ce-8ef3-46b084b6ad14.png">
