### PR TITLE
Fix snipSnippetContextP syntax to match the ending double quote

### DIFF
--- a/syntax/snippets.vim
+++ b/syntax/snippets.vim
@@ -80,7 +80,7 @@ syn match snipSnippetTriggerInvalid ,\S\@=.\{-}\S\ze\%(\s\+"[^"]*\%("\s\+[^"[:sp
 syn match snipSnippetDocString ,"[^"]*", contained nextgroup=snipSnippetOptions skipwhite
 syn match snipSnippetDocContextString ,"[^"]*", contained nextgroup=snipSnippetContext skipwhite
 syn match snipSnippetContext ,"[^"]\+", contained skipwhite contains=snipSnippetContextP
-syn region snipSnippetContextP start=,"\@<=., end=,\ze", contained contains=@Python nextgroup=snipSnippetOptions skipwhite keepend
+syn region snipSnippetContextP start=,"\@<=., end=,", contained contains=@Python nextgroup=snipSnippetOptions skipwhite keepend
 syn match snipSnippetOptions ,\S\+, contained contains=snipSnippetOptionFlag
 syn match snipSnippetOptionFlag ,[biwrtsmxAe], contained
 


### PR DESCRIPTION
Excluding the double quote from match in `snipSnippetContextP` groups
can result in a wrong syntax highlight.

Therefore the ending `"` should be included in the syntax group.

Before:

<img width="515" alt="image" src="https://user-images.githubusercontent.com/1009873/168934694-b18618d8-7890-4000-95b5-697531a8ed7b.png">

After:

<img width="520" alt="image" src="https://user-images.githubusercontent.com/1009873/168934675-efd02e54-afca-42ba-a2f0-82dfe868c868.png">
