### PR TITLE
Issue1252

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -858,6 +858,7 @@ class SnippetManager:
 
         potentials = set()
 
+        dot_vim_dirs = vim_helper.get_dot_vim()
         all_snippet_directories = find_all_snippet_directories()
         has_storage_dir = (
             vim_helper.eval(
@@ -888,13 +889,13 @@ class SnippetManager:
             # Likely the array contains things like ["UltiSnips",
             # "mycoolsnippets"] There is no more obvious way to edit than in
             # the users vim config directory.
-            dot_vim_dir = vim_helper.get_dot_vim()
             for snippet_dir in all_snippet_directories:
-                if Path(dot_vim_dir) != Path(snippet_dir).parent:
-                    continue
-                potentials.update(
-                    _get_potential_snippet_filenames_to_edit(snippet_dir, filetypes)
-                )
+                for dot_vim_dir in dot_vim_dirs:
+                    if Path(dot_vim_dir) != Path(snippet_dir).parent:
+                        continue
+                    potentials.update(
+                        _get_potential_snippet_filenames_to_edit(snippet_dir, filetypes)
+                    )
 
         if bang:
             for ft in filetypes:

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -904,7 +904,10 @@ class SnippetManager:
             if not potentials:
                 _show_user_warning(
                     "UltiSnips was not able to find a default directory for snippets. "
-                    "Do you have a .vim directory? Try :UltiSnipsEdit! instead of :UltiSnipsEdit."
+                    "Do any of " + dot_vim_dirs.__str__() + " exist AND contain "
+                    "any of the folders in g:UltiSnipsSnippetDirectories ? "
+                    "With default vim settings that would be: ~/.vim/UltiSnips "
+                    "Try :UltiSnipsEdit! instead of :UltiSnipsEdit."
                 )
                 return ""
         return _select_and_create_file_to_edit(potentials)

--- a/pythonx/UltiSnips/vim_helper.py
+++ b/pythonx/UltiSnips/vim_helper.py
@@ -214,7 +214,7 @@ def select(start, end):
 
 
 def get_dot_vim():
-    """Returns the likely place for ~/.vim for the current setup."""
+    """Returns the likely places for ~/.vim for the current setup."""
     home = vim.eval("$HOME")
     candidates = []
     if platform.system() == "Windows":
@@ -225,12 +225,19 @@ def get_dot_vim():
 
     candidates.append(os.path.join(home, ".vim"))
 
+    # Note: this potentially adds a duplicate on nvim
+    # I assume nvim sets the MYVIMRC env variable (to beconfirmed)
     if "MYVIMRC" in os.environ:
         my_vimrc = os.path.expandvars(os.environ["MYVIMRC"])
         candidates.append(normalize_file_path(os.path.dirname(my_vimrc)))
+
+    candidates_normalized = []
     for candidate in candidates:
         if os.path.isdir(candidate):
-            return normalize_file_path(candidate)
+            candidates_normalized.append(normalize_file_path(candidate))
+    if candidates_normalized:
+        # We remove duplicates on return
+        return sorted(set(candidates_normalized))
     raise PebkacError(
         "Unable to find user configuration directory. I tried '%s'." % candidates
     )


### PR DESCRIPTION
get_dot_vim() function uses an array `candidates` to find potential files but in the end only returns *one*.

This PR makes
* get_dot_vim handle multiple files (i.e.: ~/.vim and ~/.config/nvim )
* make error message more descriptive

Fixes #1252

Special thanks to [Allane Mobilty Group](https://allane-mobility-group.com/en) for sponsoring work on this

