### PR TITLE
Drop support for Py 3.6, also test Vim 9.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,12 +13,6 @@ jobs:
      fail-fast: false
      matrix:
       include:
-        # 80 does not build with py37 and py38. The build errors out with
-        # "Require native threads".
-        - { vim_version: "8.0", python_image: "3.6-stretch", tag: "vim_80_py36" }
-        - { vim_version: "8.1", python_image: "3.6-stretch", tag: "vim_81_py36" }
-        - { vim_version: "git", python_image: "3.6-stretch", tag: "vim_git_py36" }
-
         - { vim_version: "8.1", python_image: "3.7-stretch", tag: "vim_81_py37" }
         - { vim_version: "8.2", python_image: "3.7-stretch", tag: "vim_82_py37" }
         - { vim_version: "git", python_image: "3.7-stretch", tag: "vim_git_py37" }
@@ -29,9 +23,11 @@ jobs:
 
         - { vim_version: "8.1", python_image: "3.9-buster", tag: "vim_81_py39" }
         - { vim_version: "8.2", python_image: "3.9-buster", tag: "vim_82_py39" }
+        - { vim_version: "8.3", python_image: "3.9-buster", tag: "vim_83_py39" }
         - { vim_version: "git", python_image: "3.8-buster", tag: "vim_git_py39" }
 
-        # Vim 8.1 and 8.2 do not build with python 3.10, so only git is viable.
+        # Vim 8.1 and 8.2 do not build with python 3.10.
+        - { vim_version: "8.3", python_image: "3.10-buster", tag: "vim_83_py310" }
         - { vim_version: "git", python_image: "3.10-buster", tag: "vim_git_py310" }
 
     name: Build & Test using Docker

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,11 +23,11 @@ jobs:
 
         - { vim_version: "8.1", python_image: "3.9-buster", tag: "vim_81_py39" }
         - { vim_version: "8.2", python_image: "3.9-buster", tag: "vim_82_py39" }
-        - { vim_version: "8.3", python_image: "3.9-buster", tag: "vim_83_py39" }
+        - { vim_version: "9.0", python_image: "3.9-buster", tag: "vim_90_py39" }
         - { vim_version: "git", python_image: "3.8-buster", tag: "vim_git_py39" }
 
         # Vim 8.1 and 8.2 do not build with python 3.10.
-        - { vim_version: "8.3", python_image: "3.10-buster", tag: "vim_83_py310" }
+        - { vim_version: "9.0", python_image: "3.10-buster", tag: "vim_90_py310" }
         - { vim_version: "git", python_image: "3.10-buster", tag: "vim_git_py310" }
 
     name: Build & Test using Docker


### PR DESCRIPTION
- Python 3.6 is end of lifed, so no longer run this.
- Adds Vim 9.0 which recently released.