### PR TITLE
fix: Handle exception occuring by keyboard interrupt in nvim

### DIFF
--- a/pythonx/UltiSnips/err_to_scratch_buffer.py
+++ b/pythonx/UltiSnips/err_to_scratch_buffer.py
@@ -13,7 +13,7 @@ from UltiSnips.remote_pdb import RemotePDB
 
 
 def _report_exception(self, msg, e):
-    if hasattr(e, 'args') and 'Keyboard interrupt' in e.args:
+    if 'pynvim' in str(type(e)) and hasattr(e, 'args') and 'Keyboard interrupt' in e.args:
         return
 
     if hasattr(e, "snippet_info"):

--- a/pythonx/UltiSnips/err_to_scratch_buffer.py
+++ b/pythonx/UltiSnips/err_to_scratch_buffer.py
@@ -62,7 +62,6 @@ def wrap(func):
                 )
             _report_exception(self, msg, e)
         except Exception as e:  # pylint: disable=bare-except
-
             if RemotePDB.is_enable():
                 RemotePDB.pm()
             msg = """An error occured. This is either a bug in UltiSnips or a bug in a

--- a/pythonx/UltiSnips/err_to_scratch_buffer.py
+++ b/pythonx/UltiSnips/err_to_scratch_buffer.py
@@ -13,6 +13,9 @@ from UltiSnips.remote_pdb import RemotePDB
 
 
 def _report_exception(self, msg, e):
+    if hasattr(e, 'args') and 'Keyboard interrupt' in e.args:
+        return
+
     if hasattr(e, "snippet_info"):
         msg += "\nSnippet, caused error:\n"
         msg += re.sub(r"^(?=\S)", "  ", e.snippet_info, flags=re.MULTILINE)
@@ -59,6 +62,7 @@ def wrap(func):
                 )
             _report_exception(self, msg, e)
         except Exception as e:  # pylint: disable=bare-except
+
             if RemotePDB.is_enable():
                 RemotePDB.pm()
             msg = """An error occured. This is either a bug in UltiSnips or a bug in a


### PR DESCRIPTION
This commit fixes the error having to do with pynvim's Keyboard interrupt exception.

Resolves: #763 

# Problem

 In NeoVim environment, there is an exception thrown by pynvim module when `<C-c>` has been pressed,
and the message below will be shown
```
Traceback (most recent call last):
   File "/home/xxx/.local/share/nvim/site/pack/packer/start/ultisnips/pythonx/UltiSnips/err_to_scratch_buffer.py", line 47, in wrapper
     return func(self, *args, **kwds)
   File "/home/xxx/.local/share/nvim/site/pack/packer/start/ultisnips/pythonx/UltiSnips/snippet_manager.py", line 947, in _track_change
     self._last_change = (inserted_char, vim_helper.buf.cursor)
   File "/home/xxx/.local/share/nvim/site/pack/packer/start/ultisnips/pythonx/UltiSnips/vim_helper.py", line 55, in cursor
     col = byte2col(line, nbyte)
   File "/home/xxx/.local/share/nvim/site/pack/packer/start/ultisnips/pythonx/UltiSnips/compatibility.py", line 38, in byte2col
     raw_bytes = _vim_enc(line)[:nbyte]
   File "/home/xxx/.local/share/nvim/site/pack/packer/start/ultisnips/pythonx/UltiSnips/compatibility.py", line 23, in _vim_enc
     return bytearray.encode(vim.eval("&encoding"), "replace")
   File "/home/xxx/.local/lib/python3.10/site-packages/pynvim/plugin/script_host.py", line 205, in eval
     obj = self.request("vim_eval", expr)
   File "/home/xxx/.local/lib/python3.10/site-packages/pynvim/api/nvim.py", line 182, in request
     res = self._session.request(name, *args, **kwargs)
   File "/home/xxx/.local/lib/python3.10/site-packages/pynvim/msgpack_rpc/session.py", line 102, in request
     raise self.error_wrapper(err)
 pynvim.api.common.NvimError: Keyboard interrupt       
```

# Solution
Just check the args field in the exception object according to [BaseException](https://docs.python.org/ko/3/library/exceptions.html#BaseException )

# After the update
The error message never appears on pressing <C-c>