### PR TITLE
Sanitize null bytes in eval'ed text

### DIFF
--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -e -o pipefail
 
 PYTHON_CMD="$(which python)"
 VIM="/usr/local/bin/vim"

--- a/pythonx/UltiSnips/vim_helper.py
+++ b/pythonx/UltiSnips/vim_helper.py
@@ -120,6 +120,9 @@ def command(cmd):
 
 def eval(text):
     """Wraps vim.eval."""
+    # Replace null bytes with newlines, as vim raises a ValueError and neovim
+    # treats it as a terminator for the entire command.
+    text = text.replace("\x00", "\n")
     return vim.eval(text)
 
 

--- a/test/constant.py
+++ b/test/constant.py
@@ -18,3 +18,5 @@ EA = "#"  # Expand anonymous
 
 COMPL_KW = chr(24) + chr(14)
 COMPL_ACCEPT = chr(25)
+
+CTRL_V = chr(22)

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -1,3 +1,5 @@
+import unittest
+
 from test.vim_test_case import VimTestCase as _VimTest
 from test.constant import *
 
@@ -125,3 +127,26 @@ class PassThroughNonexecutedTrigger(_VimTest):
 
 
 # End: #1184
+
+
+# Tests for https://github.com/SirVer/ultisnips/issues/1386 (embedded null byte)
+
+
+NULL_BYTE = CTRL_V + "000"
+
+
+@unittest.expectedFailure
+class NullByte_ListSnippets(_VimTest):
+    snippets = ("word", "never expanded", "", "w")
+    keys = "foobar" + NULL_BYTE + LS + "\n"
+    wanted = "foobar\x00\n"
+
+
+@unittest.expectedFailure
+class NullByte_ExpandAfter(_VimTest):
+    snippets = ("test", "Expand me!", "", "w")
+    keys = "foobar " + NULL_BYTE + "test" + EX
+    wanted = "foobar \x00Expand me!"
+
+
+# End: #1386

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -135,14 +135,12 @@ class PassThroughNonexecutedTrigger(_VimTest):
 NULL_BYTE = CTRL_V + "000"
 
 
-@unittest.expectedFailure
 class NullByte_ListSnippets(_VimTest):
     snippets = ("word", "never expanded", "", "w")
     keys = "foobar" + NULL_BYTE + LS + "\n"
     wanted = "foobar\x00\n"
 
 
-@unittest.expectedFailure
 class NullByte_ExpandAfter(_VimTest):
     snippets = ("test", "Expand me!", "", "w")
     keys = "foobar " + NULL_BYTE + "test" + EX


### PR DESCRIPTION
Both vim and neovim error out if we try to evaluate a string with a null byte in it. It appears that they use `<NL>` to represent `<Nul>` in several places, so replace any null bytes in text passed to `vim_helper.eval()` with newlines.

In my testing, I copied text from a file containing a null byte and pasted it into the commands that were giving errors, and found that the null byte does get treated as a word boundary in that case:
https://github.com/SirVer/ultisnips/blob/24a3ebb36687b6d59a19d63173713575b486d739/pythonx/UltiSnips/snippet/definition/base.py#L345-L347
https://github.com/SirVer/ultisnips/blob/24a3ebb36687b6d59a19d63173713575b486d739/pythonx/UltiSnips/snippet/definition/base.py#L388-L392

Fixes #1386.