### PR TITLE
Mark failing CI tests as failed

### DIFF
--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -e -o pipefail
 
 PYTHON_CMD="$(which python)"
 VIM="/usr/local/bin/vim"


### PR DESCRIPTION
With `pipefail`, the exit code for a pipeline will be taken from the first failing command in the pipeline, rather than the last command.