### PR TITLE
Add JumpOrExpand support

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -87,6 +87,12 @@ function! UltiSnips#ExpandSnippetOrJump() abort
     return ""
 endfunction
 
+function! UltiSnips#JumpOrExpandSnippet() abort
+    call s:compensate_for_pum()
+    py3 UltiSnips_Manager.jump_or_expand()
+    return ""
+endfunction
+
 function! UltiSnips#ListSnippets() abort
     py3 UltiSnips_Manager.list_snippets()
     return ""

--- a/autoload/UltiSnips/map_keys.vim
+++ b/autoload/UltiSnips/map_keys.vim
@@ -54,7 +54,13 @@ if !exists("g:UltiSnipsEnableSnipMate")
 endif
 
 function! UltiSnips#map_keys#MapKeys() abort
-    if g:UltiSnipsExpandTrigger == g:UltiSnipsJumpForwardTrigger
+    if exists("g:UltiSnipsExpandOrJumpTrigger")
+        exec "inoremap <silent> " . g:UltiSnipsExpandOrJumpTrigger . " <C-R>=UltiSnips#ExpandSnippetOrJump()<cr>"
+        exec "snoremap <silent> " . g:UltiSnipsExpandOrJumpTrigger . " <Esc>:call UltiSnips#ExpandSnippetOrJump()<cr>"
+    elseif exists("g:UltiSnipsJumpOrExpandTrigger")
+        exec "inoremap <silent> " . g:UltiSnipsJumpOrExpandTrigger . " <C-R>=UltiSnips#JumpOrExpandSnippet()<cr>"
+        exec "snoremap <silent> " . g:UltiSnipsJumpOrExpandTrigger . " <Esc>:call UltiSnips#JumpOrExpandSnippet()<cr>"
+    elseif g:UltiSnipsExpandTrigger == g:UltiSnipsJumpForwardTrigger
         exec "inoremap <silent> " . g:UltiSnipsExpandTrigger . " <C-R>=UltiSnips#ExpandSnippetOrJump()<cr>"
         exec "snoremap <silent> " . g:UltiSnipsExpandTrigger . " <Esc>:call UltiSnips#ExpandSnippetOrJump()<cr>"
     else

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -284,7 +284,7 @@ is set, g:UltiSnipsExpandOrJumpTrigger variable will take effects.
 
 3.2.2 Using your own trigger functions           *UltiSnips-trigger-functions*
 
-For advanced users there are four functions that you can map directly to a
+For advanced users there are functions that you can map directly to a
 key and that correspond to some of the triggers previously defined:
    g:UltiSnipsExpandTrigger        <--> UltiSnips#ExpandSnippet
    g:UltiSnipsJumpForwardTrigger   <--> UltiSnips#JumpForwards

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -246,6 +246,7 @@ The priority will then be rails -> ruby -> programming -> all.
 
                            *g:UltiSnipsExpandTrigger* *g:UltiSnipsListSnippets*
                *g:UltiSnipsJumpForwardTrigger* *g:UltiSnipsJumpBackwardTrigger*
+              *g:UltiSnipsExpandOrJumpTrigger* *g:UltiSnipsJumpOrExpandTrigger*
 
 You can define the keys used to trigger UltiSnips actions by setting global
 variables. Variables define the keys used to expand a snippet, jump forward
@@ -267,6 +268,20 @@ following to your vimrc file or switching to a plugin like Supertab or
 YouCompleteMe. >
    inoremap <c-x><c-k> <c-x><c-k>
 
+If you prefer to use the same trigger for expanding snippets and jumping
+forward, g:UltiSnipsExpandOrJumpTrigger and g:UltiSnipsJumpOrExpandTrigger
+variables are what you want. Try to set g:UltiSnipsExpandOrJumpTrigger if
+you give priority to expanding snippets. It'll expand snippets first when
+you are in a position where you can both expand snippets and jump forward. >
+   let g:UltiSnipsExpandOrJumpTrigger = "<tab>"
+
+Or else, if you have a preference for jumping forward first, set
+g:UltiSnipsJumpOrExpandTrigger instead. >
+   let g:UltiSnipsJumpOrExpandTrigger = "<tab>"
+
+If both g:UltiSnipsExpandOrJumpTrigger and g:UltiSnipsJumpOrExpandTrigger
+is set, g:UltiSnipsExpandOrJumpTrigger variable will take effects.
+
 3.2.2 Using your own trigger functions           *UltiSnips-trigger-functions*
 
 For advanced users there are four functions that you can map directly to a
@@ -274,19 +289,23 @@ key and that correspond to some of the triggers previously defined:
    g:UltiSnipsExpandTrigger        <--> UltiSnips#ExpandSnippet
    g:UltiSnipsJumpForwardTrigger   <--> UltiSnips#JumpForwards
    g:UltiSnipsJumpBackwardTrigger  <--> UltiSnips#JumpBackwards
+   g:UltiSnipsExpandOrJumpTrigger  <--> UltiSnips#ExpandSnippetOrJump
+   g:UltiSnipsJumpOrExpandTrigger  <--> UltiSnips#JumpOrExpandSnippet
 
 If you have g:UltiSnipsExpandTrigger and g:UltiSnipsJumpForwardTrigger set
 to the same value then the function you are actually going to use is
 UltiSnips#ExpandSnippetOrJump.
 
 Each time any of the functions UltiSnips#ExpandSnippet,
-UltiSnips#ExpandSnippetOrJump, UltiSnips#JumpForwards or
-UltiSnips#JumpBackwards is called a global variable is set that contains the
-return value of the corresponding function.
+UltiSnips#ExpandSnippetOrJump, UltiSnips#JumpOrExpandSnippet,
+UltiSnips#JumpForwards or UltiSnips#JumpBackwards is called a global variable
+is set that contains the return value of the corresponding function.
 
 The corresponding variables and functions are:
 UltiSnips#ExpandSnippet       --> g:ulti_expand_res (0: fail, 1: success)
 UltiSnips#ExpandSnippetOrJump --> g:ulti_expand_or_jump_res (0: fail,
+                                                    1: expand, 2: jump)
+UltiSnips#JumpOrExpandSnippet --> g:ulti_expand_or_jump_res (0: fail,
                                                     1: expand, 2: jump)
 UltiSnips#JumpForwards        --> g:ulti_jump_forwards_res (0: fail, 1: success)
 UltiSnips#JumpBackwards       --> g:ulti_jump_backwards_res (0: fail, 1: success)

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -181,7 +181,7 @@ class SnippetManager:
 
     @err_to_scratch_buffer.wrap
     def expand_or_jump(self):
-        """This function is used for people who wants to have the same trigger
+        """This function is used for people who want to have the same trigger
         for expansion and forward jumping.
 
         It first tries to expand a snippet, if this fails, it tries to
@@ -199,7 +199,7 @@ class SnippetManager:
 
     @err_to_scratch_buffer.wrap
     def jump_or_expand(self):
-        """This function is used for people who wants to have the same trigger
+        """This function is used for people who want to have the same trigger
         for expansion and forward jumping.
 
         It first tries to jump forward, if this fails, it tries to

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -198,6 +198,24 @@ class SnippetManager:
             self._handle_failure(self.expand_trigger, True)
 
     @err_to_scratch_buffer.wrap
+    def jump_or_expand(self):
+        """This function is used for people who wants to have the same trigger
+        for expansion and forward jumping.
+
+        It first tries to jump forward, if this fails, it tries to
+        expand a snippet.
+
+        """
+        vim_helper.command("let g:ulti_expand_or_jump_res = 2")
+        rv = self._jump(JumpDirection.FORWARD)
+        if not rv:
+            vim_helper.command("let g:ulti_expand_or_jump_res = 1")
+            rv = self._try_expand()
+        if not rv:
+            vim_helper.command("let g:ulti_expand_or_jump_res = 0")
+            self._handle_failure(self.expand_trigger, True)
+
+    @err_to_scratch_buffer.wrap
     def snippets_in_current_scope(self, search_all):
         """Returns the snippets that could be expanded to Vim as a global
         variable."""

--- a/test/test_Expand.py
+++ b/test/test_Expand.py
@@ -81,3 +81,35 @@ class SimpleExpand_Issue1343(_VimTest):
     snippets = ("test", r"${1:\Safe\\}")
     keys = "test" + EX + JF + "foo"
     wanted = r"\Safe\foo"
+
+class SimpleExpandJumpOrExpand_Expand(_VimTest):
+    snippets = ("hallo", "Hallo Welt!")
+    keys = "hallo" + EX
+    wanted = "Hallo Welt!"
+    
+    def _extra_vim_config(self, vim_config):
+        vim_config.append('let g:UltiSnipsJumpOrExpandTrigger="<tab>"')
+
+class SimpleExpandJumpOrExpand_Ambiguity(_VimTest):
+    snippets = ("test", r"test$1 foo$0")
+    keys = "test" + EX + EX + "foo"
+    wanted = "test foofoo"
+    
+    def _extra_vim_config(self, vim_config):
+        vim_config.append('let g:UltiSnipsJumpOrExpandTrigger="<tab>"')
+
+class SimpleExpandExpandOrJump_Expand(_VimTest):
+    snippets = ("hallo", "Hallo Welt!")
+    keys = "hallo" + EX
+    wanted = "Hallo Welt!"
+    
+    def _extra_vim_config(self, vim_config):
+        vim_config.append('let g:UltiSnipsExpandOrJumpTrigger="<tab>"')
+
+class SimpleExpandExpandOrJump_Ambiguity(_VimTest):
+    snippets = ("test", r"test$1 foo$0")
+    keys = "test" + EX + EX + "foo"
+    wanted = "testfoo foo foo"
+    
+    def _extra_vim_config(self, vim_config):
+        vim_config.append('let g:UltiSnipsExpandOrJumpTrigger="<tab>"')


### PR DESCRIPTION
This is a very small improvement. As far as I know, we can not consider to jump forward instead of expanding snippets first if the expand trigger is as same as the jump forward trigger. So I introduce two new options `g:UltiSnipsExpandOrJumpTrigger` & `g:UltiSnipsJumpOrExpandTrigger` to achieve this goal. If none of them is set, it'll still expand snippets first if two triggers remain same, or it'll map separately(that is, same as before, nothing broken).

Besides, I'm wondering how to write the document. I'll appreciate if some one could help me improve the document with adding the introduction of these two new options.

I'm not familiar with this project that I may misunderstand something or make some mistakes. If so, please let me know! Any advice is welcome. Hopefully my PR could be accepted.