### PR TITLE
Add variable to control AutoTrigger

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -123,6 +123,11 @@ function! UltiSnips#CanJumpBackwards() abort
 	return can_jump_backwards
 endfunction
 
+function! UltiSnips#ToggleAutoTrigger() abort
+    py3 vim.command("let autotrigger = %d" % UltiSnips_Manager._toggle_autotrigger())
+    return autotrigger
+endfunction
+
 function! UltiSnips#SaveLastVisualSelection() range abort
     py3 UltiSnips_Manager._save_last_visual_selection()
     return ""

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -511,6 +511,21 @@ situation. This is useful in conditional mappings.
 This function returns 1 if UltiSnips can jump backwards in the current
 situation. This is useful in conditional mappings.
 
+ 3.4.7 UltiSnips#ToggleAutoTrigger              *UltiSnips#ToggleAutoTrigger*
+
+This function toggles the `autotrigger` functionality. Its return value
+corresponds to the new state of the `autotrigger` (0: disabled, 1: enabled).
+
+For example, the following mapping can be used to toggle the `autotrigger`
+in the Insert mode: >
+    inoremap <silent> <C-t> <CMD>call UltiSnips#ToggleAutoTrigger()<CR>
+<
+                                                    *g:UltiSnipsAutoTrigger*
+By default, `autotrigger` is enabled (relevant for snippets with the option 'A').
+If you want to disable it by default, add the following line to your vimrc: >
+    let g:UltiSnipsAutoTrigger = 0
+
+
 3.5 Warning about missing python support           *UltiSnips-python-warning*
 ----------------------------------------
 
@@ -1832,6 +1847,10 @@ will be triggered.
 
 *Warning:* using of this feature might lead to significant vim slowdown. If
 you discovered that, please report an issue.
+
+If you want to temporarily disable autotriggering, the `autotrigger` behavior
+can be toggled via |UltiSnips#ToggleAutoTrigger|. By default it is enabled,
+but it is possible to customize it with |g:UltiSnipsAutoTrigger|.
 
 Consider following useful Go snippets:
 ------------------- SNIP -------------------

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -146,6 +146,10 @@ class SnippetManager:
         if enable_snipmate == "1":
             self.register_snippet_source("snipmate_files", SnipMateFileSource())
 
+        self._autotrigger = True
+        if vim_helper.eval("exists('g:UltiSnipsAutoTrigger')") == "1":
+            self._autotrigger = vim_helper.eval("g:UltiSnipsAutoTrigger") == "1"
+
         self._should_update_textobjects = False
         self._should_reset_visual = False
 
@@ -852,6 +856,10 @@ class SnippetManager:
     def can_jump_backwards(self):
         return self.can_jump(JumpDirection.BACKWARD)
 
+    def _toggle_autotrigger(self):
+        self._autotrigger = not self._autotrigger
+        return self._autotrigger
+
     @property
     def _current_snippet(self):
         """The current snippet or None."""
@@ -956,7 +964,8 @@ class SnippetManager:
                 before = vim_helper.buf.line_till_cursor
 
                 if (
-                    before
+                    self._autotrigger
+                    and before
                     and self._last_change[0] != ""
                     and before[-1] == self._last_change[0]
                 ):

--- a/test/test_Autotrigger.py
+++ b/test/test_Autotrigger.py
@@ -52,3 +52,50 @@ class Autotrigger_CanMatchPreviouslySelectedPlaceholder(_VimTest):
     }
     keys = "if" + EX + "=" + ESC + "o="
     wanted = "if var == nil: pass\n="
+
+class Autotrigger_GlobalDisable(_VimTest):
+    def _extra_vim_config(self, vim_config):
+        vim_config.append("let g:UltiSnipsAutoTrigger=0")
+    files = {
+        "us/all.snippets": r"""
+        snippet a "desc" A
+        autotriggered
+        endsnippet
+        """
+    }
+    keys = "a"
+    wanted = "a"
+
+class Autotrigger_CanToggle(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        snippet a "desc" A
+        autotriggered
+        endsnippet
+        """
+    }
+    keys = (
+        "a"
+        + ESC + ":call UltiSnips#ToggleAutoTrigger()\n"
+        + "o" + "a"
+        + ESC + ":call UltiSnips#ToggleAutoTrigger()\n"
+        + "o" + "a"
+    )
+    wanted = "autotriggered\na\nautotriggered"
+
+class Autotrigger_GlobalDisableThenToggle(_VimTest):
+    def _extra_vim_config(self, vim_config):
+        vim_config.append("let g:UltiSnipsAutoTrigger=0")
+    files = {
+        "us/all.snippets": r"""
+        snippet a "desc" A
+        autotriggered
+        endsnippet
+        """
+    }
+    keys = (
+        "a"
+        + ESC + ":call UltiSnips#ToggleAutoTrigger()\n"
+        + "o" + "a"
+    )
+    wanted = "a\nautotriggered"


### PR DESCRIPTION
~Now it is possible to disable AutoTrigger in the current buffer by setting the buffer variable `b:UltiSnipsAutoTrigger = 0`.~

Now it is possible to disable AutoTrigger via global variable `g:UltiSnipsAutoTrigger`, and to dynamically toggle AutoTrigger on/off with `Ultisnips#ToggleAutoTrigger()`.

This is just a first crude shot at implementing this "toggling feature" (documentation and so on TODO).
What do you think, is this alright, or is there perhaps some better way in your opinion?