### PR TITLE
fix #1165: insert mode lag

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -3,6 +3,9 @@ if exists("b:did_autoload_ultisnips")
 endif
 let b:did_autoload_ultisnips = 1
 
+" Ensure snippets are loaded for current buffer
+au UltiSnips_AutoTrigger FileType,BufEnter * call UltiSnips#CheckFiletype()
+
 " Also import vim as we expect it to be imported in many places.
 py3 import vim
 py3 from UltiSnips import UltiSnips_Manager

--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -183,6 +183,10 @@ function! UltiSnips#TrackChange() abort
     py3 UltiSnips_Manager._track_change()
 endfunction
 
+function! UltiSnips#CheckFiletype() abort
+    py3 UltiSnips_Manager._check_filetype(vim.eval('&ft'))
+endfunction
+
 function! UltiSnips#RefreshSnippets() abort
     py3 UltiSnips_Manager._refresh_snippets()
 endfunction

--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -41,7 +41,6 @@ augroup UltiSnips_AutoTrigger
     if exists('##TextChangedP')
         au TextChangedP * call UltiSnips#TrackChange()
     endif
-    au FileType * call UltiSnips#CheckFiletype()
 augroup END
 
 call UltiSnips#map_keys#MapKeys()

--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -41,6 +41,7 @@ augroup UltiSnips_AutoTrigger
     if exists('##TextChangedP')
         au TextChangedP * call UltiSnips#TrackChange()
     endif
+    au FileType * call UltiSnips#CheckFiletype()
 augroup END
 
 call UltiSnips#map_keys#MapKeys()

--- a/pythonx/UltiSnips/snippet/source/base.py
+++ b/pythonx/UltiSnips/snippet/source/base.py
@@ -15,6 +15,7 @@ class SnippetSource:
     def __init__(self):
         self._snippets = defaultdict(SnippetDictionary)
         self._extends = defaultdict(set)
+        self._must_refresh = True
 
     def ensure(self, filetypes):
         """Ensures that snippets are loaded."""

--- a/pythonx/UltiSnips/snippet/source/base.py
+++ b/pythonx/UltiSnips/snippet/source/base.py
@@ -15,7 +15,7 @@ class SnippetSource:
     def __init__(self):
         self._snippets = defaultdict(SnippetDictionary)
         self._extends = defaultdict(set)
-        self._must_refresh = True
+        self.must_ensure = True
 
     def ensure(self, filetypes):
         """Ensures that snippets are loaded."""

--- a/pythonx/UltiSnips/snippet/source/file/base.py
+++ b/pythonx/UltiSnips/snippet/source/file/base.py
@@ -27,9 +27,11 @@ class SnippetFileSource(SnippetSource):
         SnippetSource.__init__(self)
 
     def ensure(self, filetypes):
-        for ft in self.get_deep_extends(filetypes):
-            if self._needs_update(ft):
-                self._load_snippets_for(ft)
+        if self._must_refresh:
+            for ft in self.get_deep_extends(filetypes):
+                if self._needs_update(ft):
+                    self._load_snippets_for(ft)
+            self._must_refresh = False
 
     def refresh(self):
         self.__init__()

--- a/pythonx/UltiSnips/snippet/source/file/base.py
+++ b/pythonx/UltiSnips/snippet/source/file/base.py
@@ -27,11 +27,11 @@ class SnippetFileSource(SnippetSource):
         SnippetSource.__init__(self)
 
     def ensure(self, filetypes):
-        if self._must_refresh:
+        if self.must_ensure:
             for ft in self.get_deep_extends(filetypes):
                 if self._needs_update(ft):
                     self._load_snippets_for(ft)
-            self._must_refresh = False
+            self.must_ensure = False
 
     def refresh(self):
         self.__init__()

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -130,6 +130,7 @@ class SnippetManager:
         self._visual_content = VisualContentPreserver()
 
         self._snippet_sources = []
+        self._filetypes = []
 
         self._snip_expanded_in_action = False
         self._inside_action = False
@@ -973,6 +974,15 @@ class SnippetManager:
     def _refresh_snippets(self):
         for _, source in self._snippet_sources:
             source.refresh()
+
+
+    @err_to_scratch_buffer.wrap
+    def _check_filetype(self, ft):
+        """Ensure snippets are loaded for the current filetype."""
+        if ft not in self._filetypes:
+            self._filetypes.append(ft)
+            for _, source in self._snippet_sources:
+                source.refresh()
 
 
 UltiSnips_Manager = SnippetManager(  # pylint:disable=invalid-name

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -982,7 +982,7 @@ class SnippetManager:
         if ft not in self._filetypes:
             self._filetypes.append(ft)
             for _, source in self._snippet_sources:
-                source._must_refresh = True
+                source.must_ensure = True
 
 
 UltiSnips_Manager = SnippetManager(  # pylint:disable=invalid-name

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -982,7 +982,7 @@ class SnippetManager:
         if ft not in self._filetypes:
             self._filetypes.append(ft)
             for _, source in self._snippet_sources:
-                source.refresh()
+                source._must_refresh = True
 
 
 UltiSnips_Manager = SnippetManager(  # pylint:disable=invalid-name


### PR DESCRIPTION
Ultisnips was traversing the whole runtimepath every time an expansion was attempted, something that happens for every key press since there is autotrigger.

Even without autotrigger, traversal was done at every snippet expansion, which caused slowdowns in that case.

With this change, traversal happens only the first time, or after a source must be refreshed (because a snippets file has been updated).

Note: I cannot run tests (Windows).