### PR TITLE
Fix out of bounds NvimError: Add iter to VimBuffer

### DIFF
--- a/pythonx/UltiSnips/vim_helper.py
+++ b/pythonx/UltiSnips/vim_helper.py
@@ -28,6 +28,9 @@ class VimBuffer:
     def __len__(self):
         return len(vim.current.buffer)
 
+    def __iter__(self):
+        return iter(vim.current.buffer)
+
     @property
     def line_till_cursor(self):  # pylint:disable=no-self-use
         """Returns the text before the cursor."""

--- a/pythonx/UltiSnips/vim_helper.py
+++ b/pythonx/UltiSnips/vim_helper.py
@@ -28,6 +28,8 @@ class VimBuffer:
     def __len__(self):
         return len(vim.current.buffer)
 
+    # This is a workaround for a bug in Neovim's Python layer. See here for
+    # context https://github.com/SirVer/ultisnips/issues/1041
     def __iter__(self):
         return iter(vim.current.buffer)
 


### PR DESCRIPTION
Fix #1041: iterating over snip.buffer fails in neovim.

Use __iter__() to defer iteration of a buffer to the underlying object.

Test
* Run this code in neovim and vim: import vim import UltiSnips.vim_helper as helper
```
    def dump(b):
        for line in b:
            print(line.upper())

    # This works fine in both nvim and vim.
    dump(vim.current.buffer)

    # In nvim, the iteration previously failed with "pynvim.api.common.NvimError: Index out of bounds"
    dump(helper.VimBuffer())
```