### PR TITLE
Switch from ftp.vim to ftp.nluug

### DIFF
--- a/docker/download_vim.sh
+++ b/docker/download_vim.sh
@@ -8,7 +8,7 @@ mkdir -p /src && cd /src
 if [[ $VIM_VERSION == "git" ]]; then
    git clone https://github.com/vim/vim
 else
-   curl http://ftp.vim.org/pub/vim/unix/vim-${VIM_VERSION}.tar.bz2 -o vim.tar.bz2
+   curl https://ftp.nluug.nl/pub/vim/unix/vim-${VIM_VERSION}.tar.bz2 -o vim.tar.bz2
    tar xjf vim.tar.bz2
    mv -v vim?? vim
 fi


### PR DESCRIPTION
Fix "curl: (6) Could not resolve host: ftp.vim.org" when running tests.

This is the link on https://www.vim.org/download.php#unix on this line:
> There is one big file to download that contains almost everything. It
> is found in the unix directory

Looks like that change happened years ago to use https instead of ftp: https://github.com/vim/vim/issues/3580

# Test
Ran this script under Ubuntu on WSL:
```bash
VIM_VERSION=8.1
curl https://ftp.nluug.nl/pub/vim/unix/vim-${VIM_VERSION}.tar.bz2 -o vim.tar.bz2
tar xjf vim.tar.bz2
mv -v vim?? vim
ls vim/src/ | wc -l # outputs 255
```

I'm not **certain** it's the correct package, but it has source which seems comparable to cloning from git.
