### PR TITLE
Fix CI to be green again. Drop support for py3.8, py3.9 and Vim < 9.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,22 +13,18 @@ jobs:
      fail-fast: false
      matrix:
       include:
-        - { vim_version: "8.1", python_image: "3.8-bookworm", tag: "vim_81_py38" }
-        - { vim_version: "8.2", python_image: "3.8-bookworm", tag: "vim_82_py38" }
-        - { vim_version: "git", python_image: "3.8-bookworm", tag: "vim_git_py38" }
-
-        - { vim_version: "8.1", python_image: "3.9-bookworm", tag: "vim_81_py39" }
-        - { vim_version: "8.2", python_image: "3.9-bookworm", tag: "vim_82_py39" }
-        - { vim_version: "9.0", python_image: "3.9-bookworm", tag: "vim_90_py39" }
-        - { vim_version: "git", python_image: "3.9-bookworm", tag: "vim_git_py39" }
-
-        # Vim 8.1 and 8.2 do not build with python 3.10.
         - { vim_version: "9.0", python_image: "3.10-bookworm", tag: "vim_90_py310" }
+        - { vim_version: "9.1", python_image: "3.10-bookworm", tag: "vim_91_py310" }
         - { vim_version: "git", python_image: "3.10-bookworm", tag: "vim_git_py310" }
-
-        # Vim 8.1 and 8.2 hang forever with python 3.11.
         - { vim_version: "9.0", python_image: "3.11-bookworm", tag: "vim_90_py311" }
+        - { vim_version: "9.1", python_image: "3.11-bookworm", tag: "vim_91_py311" }
         - { vim_version: "git", python_image: "3.11-bookworm", tag: "vim_git_py311" }
+        - { vim_version: "9.0", python_image: "3.12-bookworm", tag: "vim_90_py312" }
+        - { vim_version: "9.1", python_image: "3.12-bookworm", tag: "vim_91_py312" }
+        - { vim_version: "git", python_image: "3.12-bookworm", tag: "vim_git_py312" }
+        - { vim_version: "9.0", python_image: "3.13-bookworm", tag: "vim_90_py313" }
+        - { vim_version: "9.1", python_image: "3.13-bookworm", tag: "vim_91_py313" }
+        - { vim_version: "git", python_image: "3.13-bookworm", tag: "vim_git_py313" }
 
     name: Build & Test using Docker
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,17 +13,21 @@ jobs:
      fail-fast: false
      matrix:
       include:
-        - { vim_version: "9.0", python_image: "3.10-bookworm", tag: "vim_90_py310" }
-        - { vim_version: "9.1", python_image: "3.10-bookworm", tag: "vim_91_py310" }
+        - { vim_version: "9.0.0000", python_image: "3.10-bookworm", tag: "vim_90_py310" }
+        - { vim_version: "9.1.0000", python_image: "3.10-bookworm", tag: "vim_91_py310" }
         - { vim_version: "git", python_image: "3.10-bookworm", tag: "vim_git_py310" }
-        - { vim_version: "9.0", python_image: "3.11-bookworm", tag: "vim_90_py311" }
-        - { vim_version: "9.1", python_image: "3.11-bookworm", tag: "vim_91_py311" }
+
+        - { vim_version: "9.0.0000", python_image: "3.11-bookworm", tag: "vim_90_py311" }
+        - { vim_version: "9.1.0000", python_image: "3.11-bookworm", tag: "vim_91_py311" }
         - { vim_version: "git", python_image: "3.11-bookworm", tag: "vim_git_py311" }
-        - { vim_version: "9.0", python_image: "3.12-bookworm", tag: "vim_90_py312" }
-        - { vim_version: "9.1", python_image: "3.12-bookworm", tag: "vim_91_py312" }
+
+        - { vim_version: "9.0.0000", python_image: "3.12-bookworm", tag: "vim_90_py312" }
+        - { vim_version: "9.1.0000", python_image: "3.12-bookworm", tag: "vim_91_py312" }
         - { vim_version: "git", python_image: "3.12-bookworm", tag: "vim_git_py312" }
-        - { vim_version: "9.0", python_image: "3.13-bookworm", tag: "vim_90_py313" }
-        - { vim_version: "9.1", python_image: "3.13-bookworm", tag: "vim_91_py313" }
+
+        # Vim 9.0 and 9.1 prior to 417 hang forever with python 3.13 due to a bug fixed here
+        # https://github.com/vim/vim/issues/14776.
+        - { vim_version: "9.1.0417", python_image: "3.13-bookworm", tag: "vim_91_py313" }
         - { vim_version: "git", python_image: "3.13-bookworm", tag: "vim_git_py313" }
 
     name: Build & Test using Docker

--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,7 @@ mypy = "*"
 black = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3.10"
 
 [pipenv]
 allow_prereleases = true

--- a/docker/download_vim.sh
+++ b/docker/download_vim.sh
@@ -8,7 +8,7 @@ mkdir -p /src && cd /src
 if [[ $VIM_VERSION == "git" ]]; then
    git clone https://github.com/vim/vim
 else
-   curl https://github.com/vim/vim/archive/refs/tags/v${VIM_VERSION}.0.tar.gz  -o vim.tar.gz
-   tar xf vim.tar.bz2
-   mv -v vim?? vim
+   curl -L https://github.com/vim/vim/archive/refs/tags/v${VIM_VERSION}.0000.tar.gz  -o vim.tar.gz
+   tar xf vim.tar.gz && rm vim.tar.gz
+   mv -v vim* vim
 fi

--- a/docker/download_vim.sh
+++ b/docker/download_vim.sh
@@ -8,7 +8,7 @@ mkdir -p /src && cd /src
 if [[ $VIM_VERSION == "git" ]]; then
    git clone https://github.com/vim/vim
 else
-   curl -L https://github.com/vim/vim/archive/refs/tags/v${VIM_VERSION}.0000.tar.gz  -o vim.tar.gz
+   curl -L https://github.com/vim/vim/archive/refs/tags/v${VIM_VERSION}.tar.gz  -o vim.tar.gz
    tar xf vim.tar.gz && rm vim.tar.gz
    mv -v vim* vim
 fi

--- a/docker/download_vim.sh
+++ b/docker/download_vim.sh
@@ -8,7 +8,7 @@ mkdir -p /src && cd /src
 if [[ $VIM_VERSION == "git" ]]; then
    git clone https://github.com/vim/vim
 else
-   curl https://ftp.nluug.nl/pub/vim/unix/vim-${VIM_VERSION}.tar.bz2 -o vim.tar.bz2
-   tar xjf vim.tar.bz2
+   curl https://github.com/vim/vim/archive/refs/tags/v${VIM_VERSION}.0.tar.gz  -o vim.tar.gz
+   tar xf vim.tar.bz2
    mv -v vim?? vim
 fi

--- a/test/test_Autocommands.py
+++ b/test/test_Autocommands.py
@@ -16,9 +16,9 @@ class Autocommands(_VimTest):
         + JF
         + " done "
         + ESC
-        + ':execute "normal aM" . g:mapper_call_count . "\<Esc>"'
+        + ':execute "normal aM" . g:mapper_call_count . "\\<Esc>"'
         + "\n"
-        + ':execute "normal aU" . g:unmapper_call_count . "\<Esc>"'
+        + ':execute "normal aU" . g:unmapper_call_count . "\\<Esc>"'
         + "\n"
     )
     wanted = "[ [ bar ] ] done M1U1"

--- a/test/test_Choices.py
+++ b/test/test_Choices.py
@@ -101,7 +101,7 @@ class Choices_With_Mirror_ContinueMirroring_EvenAfterSelectionDone(_VimTest):
 class Choices_ShouldThrowErrorWithZeroTabstop(_VimTest):
     snippets = ("test", "${0|red,blue|}")
     keys = "test" + EX
-    expected_error = "Choices selection is not supported on \$0"
+    expected_error = r"Choices selection is not supported on \$0"
 
 
 class Choices_CanEscapeCommaInsideChoiceItem(_VimTest):

--- a/test/test_Interpolation.py
+++ b/test/test_Interpolation.py
@@ -494,7 +494,7 @@ class PythonCode_CanOverwriteTabstop(_VimTest):
         """$1`!p if len(t[1]) > 3 and len(t[2]) == 0:
             t[2] = t[1][2:];
             t[1] = t[1][:2] + '-\\n\\t';
-            vim.command('call feedkeys("\<End>", "n")');
+            vim.command('call feedkeys("\\<End>", "n")');
             `$2""",
     )
     keys = "test" + EX + "blah" + ", bah"

--- a/test/test_Interpolation.py
+++ b/test/test_Interpolation.py
@@ -494,7 +494,7 @@ class PythonCode_CanOverwriteTabstop(_VimTest):
         """$1`!p if len(t[1]) > 3 and len(t[2]) == 0:
             t[2] = t[1][2:];
             t[1] = t[1][:2] + '-\\n\\t';
-            vim.command('call feedkeys("\\<End>", "n")');
+            vim.command('call feedkeys("\\\\<End>", "n")');
             `$2""",
     )
     keys = "test" + EX + "blah" + ", bah"

--- a/test/test_ParseSnippets.py
+++ b/test/test_ParseSnippets.py
@@ -220,7 +220,7 @@ class ParseSnippets_MultiWord_NoContainer(_VimTest):
     }
     keys = "test snip" + EX
     wanted = keys
-    expected_error = "Invalid multiword trigger: 'test snip' in \S+:2"
+    expected_error = "Invalid multiword trigger: 'test snip' in \\S+:2"
 
 
 class ParseSnippets_MultiWord_UnmatchedContainer(_VimTest):
@@ -233,7 +233,7 @@ class ParseSnippets_MultiWord_UnmatchedContainer(_VimTest):
     }
     keys = "inv snip" + EX
     wanted = keys
-    expected_error = "Invalid multiword trigger: '!inv snip/' in \S+:2"
+    expected_error = "Invalid multiword trigger: '!inv snip/' in \\S+:2"
 
 
 class ParseSnippets_Global_Python_After(_VimTest):
@@ -324,7 +324,7 @@ class ParseSnippets_PrintPythonStacktraceMultiline(_VimTest):
     }
     keys = "test" + EX
     wanted = keys
-    expected_error = " > \s+qwe"
+    expected_error = " > \\s+qwe"
 
 
 class ParseSnippets_PrintErroneousSnippet(_VimTest):

--- a/test/test_SnippetOptions.py
+++ b/test/test_SnippetOptions.py
@@ -219,7 +219,7 @@ class SnippetOptions_Regex_Multiple(_VimTest):
 
 
 class _Regex_Self(_VimTest):
-    snippets = ("((?<=\W)|^)(\.)", "self.", "", "r")
+    snippets = ("((?<=\\W)|^)(\\.)", "self.", "", "r")
 
 
 class SnippetOptions_Regex_Self_Start(_Regex_Self):

--- a/test/test_Transformation.py
+++ b/test/test_Transformation.py
@@ -29,7 +29,7 @@ class Transformation_SimpleCaseTransformInFrontDefVal_ECR(_VimTest):
 
 
 class Transformation_MultipleTransformations_ECR(_VimTest):
-    snippets = ("test", "${1:Some Text}${1/.+/\\U$0\E/}\n${1/.+/\L$0\E/}")
+    snippets = ("test", "${1:Some Text}${1/.+/\\U$0\\E/}\n${1/.+/\\L$0\\E/}")
     keys = "test" + EX + "SomE tExt "
     wanted = "SomE tExt SOME TEXT \nsome text "
 
@@ -89,19 +89,19 @@ class Transformation_CleverTransformUpercaseChar_ExpectCorrectResult(_VimTest):
 
 
 class Transformation_CleverTransformLowercaseChar_ExpectCorrectResult(_VimTest):
-    snippets = ("test", "$1 ${1/(.*)/\l$1/}")
+    snippets = ("test", "$1 ${1/(.*)/\\l$1/}")
     keys = "test" + EX + "Hallo"
     wanted = "Hallo hallo"
 
 
 class Transformation_CleverTransformLongUpper_ExpectCorrectResult(_VimTest):
-    snippets = ("test", "$1 ${1/(.*)/\\U$1\E/}")
+    snippets = ("test", "$1 ${1/(.*)/\\U$1\\E/}")
     keys = "test" + EX + "hallo"
     wanted = "hallo HALLO"
 
 
 class Transformation_CleverTransformLongLower_ExpectCorrectResult(_VimTest):
-    snippets = ("test", "$1 ${1/(.*)/\L$1\E/}")
+    snippets = ("test", "$1 ${1/(.*)/\\L$1\\E/}")
     keys = "test" + EX + "HALLO"
     wanted = "HALLO hallo"
 
@@ -115,7 +115,7 @@ class Transformation_SimpleCaseAsciiResult(_VimTest):
 
 class Transformation_LowerCaseAsciiResult(_VimTest):
     skip_if = lambda self: no_unidecode_available()
-    snippets = ("ascii", "$1 ${1/(.*)/\L$1\E/a}")
+    snippets = ("ascii", "$1 ${1/(.*)/\\L$1\\E/a}")
     keys = "ascii" + EX + "éèàçôïÉÈÀÇÔÏ€"
     wanted = "éèàçôïÉÈÀÇÔÏ€ eeacoieeacoieur"
 

--- a/test/test_UltiSnipFunc.py
+++ b/test/test_UltiSnipFunc.py
@@ -86,7 +86,7 @@ hi4"""
 
     def _before_test(self):
         self.vim.send_to_vim(
-            ":set langmap=йq,цw,уe,кr,еt,нy,гu,шi,щo,зp,х[,ъ],фa,ыs,вd,аf,пg,рh,оj,лk,дl,ж\\;,э',яz,чx,сc,мv,иb,тn,ьm,ю.,ё',ЙQ,ЦW,УE,КR,ЕT,НY,ГU,ШI,ЩO,ЗP,Х\{,Ъ\},ФA,ЫS,ВD,АF,ПG,РH,ОJ,ЛK,ДL,Ж\:,Э\",ЯZ,ЧX,СC,МV,ИB,ТN,ЬM,Б\<,Ю\>\n"
+            ":set langmap=йq,цw,уe,кr,еt,нy,гu,шi,щo,зp,х[,ъ],фa,ыs,вd,аf,пg,рh,оj,лk,дl,ж\\;,э',яz,чx,сc,мv,иb,тn,ьm,ю.,ё',ЙQ,ЦW,УE,КR,ЕT,НY,ГU,ШI,ЩO,ЗP,Х\\{,Ъ\\},ФA,ЫS,ВD,АF,ПG,РH,ОJ,ЛK,ДL,Ж\:,Э\",ЯZ,ЧX,СC,МV,ИB,ТN,ЬM,Б\<,Ю\>\n"
         )
 
 

--- a/test/vim_test_case.py
+++ b/test/vim_test_case.py
@@ -51,7 +51,7 @@ class VimTestCase(unittest.TestCase, TempFileManager):
         SLEEPTIMES = [0.01, 0.15, 0.3, 0.4, 0.5, 1]
         for i in range(self.retries):
             if self.output and self.expected_error:
-                self.assertRegexpMatches(self.output, self.expected_error)
+                self.assertRegex(self.output, self.expected_error)
                 return
             if self.output != wanted or self.output is None:
                 # Redo this, but slower


### PR DESCRIPTION
Also fix ci to be green again:
   - Download VIM releases by tag from GitHub instead from FTP
   - Fix several warnings about wrong escape sequences that Python >= 3.12 started to vomit on the screen.
   - `assertRegexpMatches` is now called `assertRegex`.