### PR TITLE
Add test for invalid partial snippet directive

### DIFF
--- a/pythonx/UltiSnips/snippet/source/file/snipmate.py
+++ b/pythonx/UltiSnips/snippet/source/file/snipmate.py
@@ -109,7 +109,7 @@ def _parse_snippets_file(data, filename):
         head, tail = head_tail(line)
         if head == "extends":
             yield handle_extends(tail, lines.line_index)
-        elif head in "snippet":
+        elif head == "snippet":
             snippet = _parse_snippet(line, lines, filename)
             if snippet is not None:
                 yield snippet

--- a/test/test_ParseSnippets.py
+++ b/test/test_ParseSnippets.py
@@ -37,6 +37,17 @@ class ParseSnippets_UnknownDirective(_VimTest):
     expected_error = r"Invalid line 'unknown directive' in \S+:2"
 
 
+class ParseSnippets_InvalidPartialSnippet(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        snip invalid
+        """
+    }
+    keys = "testsnip" + EX
+    wanted = "testsnip" + EX
+    expected_error = r"Invalid line 'snip invalid' in \S+:2"
+
+
 class ParseSnippets_InvalidPriorityLine(_VimTest):
     files = {
         "us/all.snippets": r"""


### PR DESCRIPTION
## Summary
- ensure SnipMate parser checks full keyword
- add regression test that `snip` doesn't parse as `snippet`

## Testing
- `python3 test_all.py ParseSnippets_InvalidPartialSnippet` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'vim')*

------
https://chatgpt.com/codex/tasks/task_e_6841bbc49b7c833294feb24b30177b97