### PR TITLE
Fix snippet parsing docstrings

### DIFF
--- a/pythonx/UltiSnips/snippet/definition/base.py
+++ b/pythonx/UltiSnips/snippet/definition/base.py
@@ -135,7 +135,7 @@ class SnippetDefinition:
         )
 
     def _re_match(self, trigger):
-        """Test if a the current regex trigger matches `trigger`.
+        """Test if the current regex trigger matches `trigger`.
 
         If so, set _last_re and _matched.
 

--- a/pythonx/UltiSnips/snippet/source/file/snipmate.py
+++ b/pythonx/UltiSnips/snippet/source/file/snipmate.py
@@ -70,7 +70,7 @@ def _parse_snippet_file(content, full_filename):
 
 
 def _parse_snippet(line, lines, filename):
-    """Parse a snippet defintions."""
+    """Parse a snippet definition."""
     start_line_index = lines.line_index
     trigger, description = head_tail(line[len("snippet") :].lstrip())
     content = ""


### PR DESCRIPTION
## Summary
- update docstring of `_parse_snippet` in snipmate source
- refine `_re_match` docstring for clarity

## Testing
- `python -m py_compile pythonx/UltiSnips/snippet/source/file/snipmate.py pythonx/UltiSnips/snippet/definition/base.py`

------
https://chatgpt.com/codex/tasks/task_e_6841bbba75fc8332b9c65f9d4acd8382