### PR TITLE
Enable spell checking in snipmate snippet comments

### DIFF
--- a/syntax/snippets_snipmate.vim
+++ b/syntax/snippets_snipmate.vim
@@ -18,7 +18,7 @@ syn cluster snipTabStopTokens contains=snipVisual,snipMirror,snipEscape,snipmate
 
 " Syntax definitions {{{1
 
-syn match snipmateComment "^#.*"
+syn match snipmateComment "^#.*" contains=snipTODO,@Spell
 
 syn match snipmateExtends "^extends\%(\s.*\|$\)" contains=snipExtendsKeyword display
 


### PR DESCRIPTION
The UltiSnips syntax file (snippets.vim) already includes @Spell on snipComment, but the snipmate variant (snippets_snipmate.vim) was missing it. This adds contains=snipTODO,@Spell to snipmateComment so
misspelled words are highlighted when :set spell is active.

Fixes #1086