### PR TITLE
Fix list_snippets not finding in-word snippets with a prefix

### DIFF
--- a/pythonx/UltiSnips/snippet/definition/base.py
+++ b/pythonx/UltiSnips/snippet/definition/base.py
@@ -384,9 +384,15 @@ class SnippetDefinition:
             if words_suffix != words:
                 match = False
         elif "i" in self._opts:
-            # TODO: It is hard to define when a inword snippet could match,
-            # therefore we check only for full-word trigger.
-            match = self._trigger.startswith(words)
+            # In-word snippets can appear after arbitrary non-word
+            # characters, so check if the trigger starts with any
+            # suffix of `words`.  GH #1036.
+            match = False
+            for i in range(len(words)):
+                if self._trigger.startswith(words[i:]):
+                    match = True
+                    self._matched = words[i:]
+                    break
         else:
             match = self._trigger.startswith(words)
 

--- a/test/test_ListSnippets.py
+++ b/test/test_ListSnippets.py
@@ -46,3 +46,11 @@ class ListAllAvailable_Disabled_ExpectCorrectResult(_ListAllSnippets):
 
     def _extra_vim_config(self, vim_config):
         vim_config.append('let g:UltiSnipsListSnippets=""')
+
+
+# GH #1036: In-word snippets should be listed even when preceded by
+# non-word characters.
+class ListAllAvailable_InWordWithPrefix_ExpectCorrectResult(_VimTest):
+    snippets = (("exists", "exists('${1}')", "exists check", "i"),)
+    keys = "!exists" + LS + "1\n"
+    wanted = "!exists('')"


### PR DESCRIPTION
`could_match()` for in-word (`i`) snippets checked whether the trigger
started with the full word under the cursor. But for in-word snippets
the word can include a non-trigger prefix — e.g. `!exists` when the
trigger is `exists`. Since `"exists".startswith("!exists")` is false,
the snippet was never listed.

Fix by checking whether the trigger starts with any suffix of the word,
since in-word snippets can appear at any position within text.

Fixes #1036