### PR TITLE
Fix escaped backslashes in transformation replacement strings

### DIFF
--- a/pythonx/UltiSnips/text_objects/transformation.py
+++ b/pythonx/UltiSnips/text_objects/transformation.py
@@ -86,6 +86,13 @@ class _CleverReplace:
             0
         ]
 
+        # Shelter escaped backslashes (\\) so they are not consumed by
+        # case-switch regexes (\l, \u, \U, \L) or whitespace escapes
+        # (\n, \t, ...).  Restored before the final unescape() which
+        # turns \\ into a literal \.  GH #998, GH #1495.
+        _ESCAPED_BSLASH = "\x00"
+        transformed = transformed.replace("\\\\", _ESCAPED_BSLASH)
+
         # Replace Case switches
         def _one_char_case_change(match):
             """Replaces one character case changes."""
@@ -103,7 +110,10 @@ class _CleverReplace:
 
         transformed = _LONG_CASEFOLDINGS.subn(_multi_char_case_change, transformed)[0]
         transformed = _replace_conditional(match, transformed)
-        return unescape(fill_in_whitespace(transformed))
+
+        transformed = fill_in_whitespace(transformed)
+        transformed = transformed.replace(_ESCAPED_BSLASH, "\\\\")
+        return unescape(transformed)
 
 
 # flag used to display only one time the lack of unidecode

--- a/test/test_Transformation.py
+++ b/test/test_Transformation.py
@@ -275,3 +275,18 @@ class Transformation_ConditionalWithBackslashBeforeDelimiter1(_VimTest):
     snippets = "test", r"$1 ${1/(aa)|.*/(?1:yes:no\\)/}"
     keys = "test" + EX + "ab"
     wanted = "ab no\\"
+
+
+# GH #998: An escaped backslash before a whitespace escape character
+# (n, t, r, ...) should produce a literal backslash + letter, not the
+# whitespace character.
+class Transformation_LiteralBackslashN(_VimTest):
+    snippets = ("test", r"$1 ${1/.*/\\n/}")
+    keys = "test" + EX + "hi"
+    wanted = "hi \\n"
+
+
+class Transformation_LiteralBackslashT(_VimTest):
+    snippets = ("test", r"$1 ${1/.*/\\t/}")
+    keys = "test" + EX + "hi"
+    wanted = "hi \\t"


### PR DESCRIPTION
Escaped backslashes (`\\`) in replacement strings were consumed by
case-switch regexes (`\l`, `\u`, `\U`, `\L`) and whitespace escapes
(`\n`, `\t`, `\r`, ...) before `unescape()` could turn `\\` into a
literal backslash.

For example, `\\n` produced a newline instead of literal `\n`, and
`\\linewidth` produced `inewidth` instead of `\linewidth`. No amount
of escaping could produce a literal backslash before these characters.

Fix by sheltering `\\` sequences (replacing with a sentinel) before
any processing, and restoring them after `fill_in_whitespace` but
before `unescape`.

Supersedes #1609 which fixed only the case-switch half of the problem.

Fixes #998
Fixes #1495