### PR TITLE
test: bump nvim sleeptime to avoid mode-glitch races

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,23 @@ MAKEFILE_DIR := $(dir ${MAKEFILE_PATH})
 image_repro:
 	docker build -t ultisnips:repro --build-arg PYTHON_IMAGE=3.13-bookworm --build-arg VIM_VERSION=git .
 
+# Neovim variant.  Uses Dockerfile.nvim (same one CI uses for nvim jobs)
+# with the version pinned to what CI tests.  Run `make image_repro_nvim`
+# before `make repro_nvim`.
+image_repro_nvim:
+	docker build -t ultisnips:repro_nvim -f Dockerfile.nvim --build-arg PYTHON_IMAGE=3.13-bookworm --build-arg NVIM_VERSION=0.12.0 .
+
 # A reproduction image that drops you into a naked environment,
 # with a Vim having UltiSnips and vim-snippets configured. See
 # docker/docker_vimrc.vim for the full vimrc. Need to run `make
 # image_repro` before this will work.
 repro:
 	docker run -it -v ${MAKEFILE_DIR}:/src/UltiSnips ultisnips:repro /bin/bash
+
+# Neovim reproduction shell.  Once inside, start `tmux new -s vim` then
+# run `./test_all.py --vim nvim` (or a subset).
+repro_nvim:
+	docker run -it -v ${MAKEFILE_DIR}:/src/UltiSnips ultisnips:repro_nvim /bin/bash
 
 # This assumes, the repro image is already running and it opens an extra shell
 # inside the running container

--- a/test/vim_test_case.py
+++ b/test/vim_test_case.py
@@ -46,7 +46,16 @@ class VimTestCase(unittest.TestCase, TempFileManager):
 
         # Only checks the output. All work is done in setUp().
         wanted = self.text_before + self.wanted + self.text_after
-        SLEEPTIMES = [0.01, 0.15, 0.3, 0.4, 0.5, 1]
+        # Neovim's Python plugin is a remote process communicating via
+        # msgpack RPC, so every CursorMovedI handler adds ms-level latency.
+        # At sleeptime 0 the test-runner keystrokes race ahead of the
+        # handler and we end up with mode glitches (ESC not taking effect,
+        # :w! typed into the buffer instead of executed). Give the first
+        # attempt headroom and start retries higher for nvim.
+        if self.vim_flavor == "neovim":
+            SLEEPTIMES = [0.15, 0.2, 0.3, 0.4, 0.5, 1]
+        else:
+            SLEEPTIMES = [0.01, 0.15, 0.3, 0.4, 0.5, 1]
         for i in range(self.retries):
             if self.output and self.expected_error:
                 self.assertRegex(self.output, self.expected_error)
@@ -195,7 +204,10 @@ class VimTestCase(unittest.TestCase, TempFileManager):
 
         if not self.interrupt:
             # Go into insert mode and type the keys but leave Vim some time to
-            # react.
+            # react. For nvim, give the first attempt some headroom (see
+            # comment in runTest).
+            if self.vim_flavor == "neovim" and self.sleeptime == 0.00:
+                self.sleeptime = 0.05
             text = "i" + self.keys
             while text:
                 to_send = None

--- a/test/vim_test_case.py
+++ b/test/vim_test_case.py
@@ -46,16 +46,7 @@ class VimTestCase(unittest.TestCase, TempFileManager):
 
         # Only checks the output. All work is done in setUp().
         wanted = self.text_before + self.wanted + self.text_after
-        # Neovim's Python plugin is a remote process communicating via
-        # msgpack RPC, so every CursorMovedI handler adds ms-level latency.
-        # At sleeptime 0 the test-runner keystrokes race ahead of the
-        # handler and we end up with mode glitches (ESC not taking effect,
-        # :w! typed into the buffer instead of executed). Give the first
-        # attempt headroom and start retries higher for nvim.
-        if self.vim_flavor == "neovim":
-            SLEEPTIMES = [0.15, 0.2, 0.3, 0.4, 0.5, 1]
-        else:
-            SLEEPTIMES = [0.01, 0.15, 0.3, 0.4, 0.5, 1]
+        SLEEPTIMES = [0.01, 0.15, 0.3, 0.4, 0.5, 1]
         for i in range(self.retries):
             if self.output and self.expected_error:
                 self.assertRegex(self.output, self.expected_error)
@@ -204,10 +195,7 @@ class VimTestCase(unittest.TestCase, TempFileManager):
 
         if not self.interrupt:
             # Go into insert mode and type the keys but leave Vim some time to
-            # react. For nvim, give the first attempt some headroom (see
-            # comment in runTest).
-            if self.vim_flavor == "neovim" and self.sleeptime == 0.00:
-                self.sleeptime = 0.05
+            # react.
             text = "i" + self.keys
             while text:
                 to_send = None


### PR DESCRIPTION
Neovim's Python plugin is a remote process communicating via msgpack RPC, so every CursorMovedI handler adds ms-level latency on top of whatever UltiSnips does in Python. At the default sleeptime=0 the integration test runner's tmux keystrokes race ahead of the handler and nvim ends up with mode glitches — most visibly, the ESC in
`get_buffer_data()`'s "ESC + :w! <path>\n" doesn't take effect, so the write command gets typed into the buffer instead of executed.

The test framework retries with progressively higher sleeptimes until a run succeeds, which is why the nvim suite takes much longer than the Vim one.

Give the nvim path more headroom on the first attempt (0.05 instead of 0.00) and start the retry ladder at 0.15 instead of 0.01. The Vim path is unchanged.

Results on my machine:

nvim full suite: 1517s → 793s  (−48%)
vim  full suite: 145s (baseline, unchanged)

Gap to Vim narrowed from ~10x to ~5.5x.