### PR TITLE
Drop snippet on pathological buffer changes instead of hanging in diff()

### DIFF
--- a/pythonx/UltiSnips/change_provider.py
+++ b/pythonx/UltiSnips/change_provider.py
@@ -15,6 +15,39 @@ from contextlib import contextmanager
 
 import vim
 
+# Returned by consume_edits when the buffer change cannot plausibly be
+# reconciled against the snippet's tracked state (pre-snippet content
+# restored by undo, huge single-event paste dumped outside any tabstop,
+# etc.). The caller terminates the snippet rather than hanging in diff()
+# or producing a corrupted text-object tree.
+DROP_SNIPPET = object()
+
+# diff() is an O(|a|·|b|) shortest-edit-path search. For total char counts
+# up to a few hundred it is imperceptible; beyond ~2000 the latency becomes
+# a freeze. Rather than feed such inputs to diff(), we treat them as a
+# signal that the snippet has lost its grip on the buffer.
+_PATHOLOGICAL_CHAR_DELTA = 2000
+
+
+def _joined_len(lines):
+    """Length of '\\n'.join(lines) without materializing the string."""
+    if not lines:
+        return 0
+    return sum(len(l) for l in lines) + len(lines) - 1
+
+
+def _is_pathological_diff_input(old_lines, new_lines):
+    """Return True when running diff(old, new) would be both slow and
+    structurally suspect — meaning the buffer has diverged from the
+    snippet's tracked state in a way no reasonable replay can recover.
+
+    Heuristic: the character-count delta exceeds what an interactive
+    snippet edit could plausibly produce in a single CursorMoved cycle.
+    """
+    return (
+        abs(_joined_len(new_lines) - _joined_len(old_lines)) > _PATHOLOGICAL_CHAR_DELTA
+    )
+
 
 def diff(a, b, sline=0):
     """
@@ -444,6 +477,44 @@ def detect_edits(old_lines, new_lines, start_line, cursor_line, cursor_col):
                     cmds.append(("I", base_line + 1, 0, new_second_part))
                 return cmds
 
+            # added >= 2: a single line becomes many (multi-line paste into
+            # a tabstop, etc.). Bridge by preserving the common prefix with
+            # rem_new[0] and the common suffix with rem_new[-1]; the
+            # intermediate lines are pure insertions.
+            if old_line:
+                p = 0
+                max_p = min(len(old_line), len(rem_new[0]))
+                while p < max_p and old_line[p] == rem_new[0][p]:
+                    p += 1
+                s = 0
+                max_s = min(len(old_line) - p, len(rem_new[-1]))
+                while (
+                    s < max_s
+                    and old_line[len(old_line) - 1 - s]
+                    == rem_new[-1][len(rem_new[-1]) - 1 - s]
+                ):
+                    s += 1
+                cmds = []
+                deleted_mid = old_line[p : len(old_line) - s if s else None]
+                if deleted_mid:
+                    cmds.append(("D", base_line, p, deleted_mid))
+                extra_on_first = rem_new[0][p:]
+                if extra_on_first:
+                    cmds.append(("I", base_line, p, extra_on_first))
+                cmds.append(("I", base_line, len(rem_new[0]), "\n"))
+                for i in range(1, len(rem_new) - 1):
+                    if rem_new[i]:
+                        cmds.append(("I", base_line + i, 0, rem_new[i]))
+                    cmds.append(("I", base_line + i, len(rem_new[i]), "\n"))
+                last_prefix = rem_new[-1][: len(rem_new[-1]) - s if s else None]
+                if last_prefix:
+                    cmds.append(("I", base_line + len(rem_new) - 1, 0, last_prefix))
+                return cmds
+            # old_line is empty and many new lines arrived: likely the
+            # snippet's remembered state no longer reflects the buffer
+            # (e.g. undo past the expansion). Let the caller's pathological
+            # check decide to drop the snippet.
+
         return None
 
     return None
@@ -563,6 +634,8 @@ class VimChangeProvider(_ChangeProvider):
         es = detect_edits(old_lines, new_lines, snippet_start, pos.line, pos.col)
         if es is not None:
             return es
+        if _is_pathological_diff_input(old_lines, new_lines):
+            return DROP_SNIPPET
         return diff("\n".join(old_lines), "\n".join(new_lines), snippet_start)
 
 
@@ -611,4 +684,6 @@ class NvimChangeProvider(_ChangeProvider):
         es = detect_edits(old_lines, new_lines, snippet_start, pos.line, pos.col)
         if es is not None:
             return es
+        if _is_pathological_diff_input(old_lines, new_lines):
+            return DROP_SNIPPET
         return diff("\n".join(old_lines), "\n".join(new_lines), snippet_start)

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -10,7 +10,11 @@ import vim
 
 from UltiSnips import err_to_scratch_buffer, vim_helper
 from UltiSnips.buffer_proxy import suspend_proxy_edits, use_proxy_buffer
-from UltiSnips.change_provider import NvimChangeProvider, VimChangeProvider
+from UltiSnips.change_provider import (
+    DROP_SNIPPET,
+    NvimChangeProvider,
+    VimChangeProvider,
+)
 from UltiSnips.position import JumpDirection, Position
 from UltiSnips.snippet.definition import UltiSnipsSnippetDefinition
 from UltiSnips.snippet.source import (
@@ -391,6 +395,14 @@ class SnippetManager:
             es = self._change_provider.consume_edits(
                 vim_helper.buf, self._active_snippets[0], self._vstate
             )
+            if es is DROP_SNIPPET:
+                # Buffer has diverged from the snippet's tracked state so
+                # heavily that reconciling would hang diff() or corrupt
+                # the text-object tree. Abandon the snippet cleanly.
+                while self._active_snippets:
+                    self._current_snippet_is_done()
+                self._reinit()
+                return
             if es is not None:
                 self._active_snippets[0].replay_user_edits(es, self._ctab)
 

--- a/pythonx/UltiSnips/test_change_provider.py
+++ b/pythonx/UltiSnips/test_change_provider.py
@@ -9,6 +9,7 @@ module is mocked by pythonx/conftest.py so these run without Vim.
 import unittest
 
 from UltiSnips.change_provider import (
+    _is_pathological_diff_input,
     _listener_to_edits,
     _on_bytes_to_edits,
     detect_edits,
@@ -156,6 +157,76 @@ class TestDetectEdits(unittest.TestCase):
         self.assertIsNotNone(cmds)
         result = _apply(["hello", "world"], cmds, 0)
         self.assertEqual(result, ["helloworld"])
+
+    def test_1_to_n_multi_line_paste(self):
+        # Paste of 3 additional lines into a single line — mimics e.g. a
+        # multi-line clipboard paste inside a tabstop. Previously this
+        # fell through detect_edits to the O(n·m) diff() fallback; it now
+        # resolves deterministically via the general 1→N handler.
+        old = ["hello world"]
+        new = ["hello X", "middle", "another", "Y world"]
+        cmds = self._check(old, new, 0, 0, 0)
+        self.assertIsNotNone(cmds)
+
+    def test_1_to_n_many_lines_large_paste(self):
+        # Regression for the #1074-style large-paste-into-tabstop case:
+        # detect_edits must resolve this without falling back to diff.
+        old = ["AB"]
+        new = ["A" + "x" + str(i) for i in range(100)] + ["end B"]
+        cmds = self._check(old, new, 0, 0, 0)
+        self.assertIsNotNone(cmds)
+
+    def test_1_to_n_empty_old_returns_none(self):
+        # Regression for #1513: when rem_old is a single empty line, the
+        # snippet's remembered state has diverged from the buffer (e.g.
+        # undo past the expansion). detect_edits deliberately gives up
+        # here so that consume_edits' pathological check can drop the
+        # snippet instead of replaying edits into a stale tree.
+        old = [""]
+        new = ["AAAAA"] * 50
+        cmds = detect_edits(old, new, 0, 0, 0)
+        self.assertIsNone(cmds)
+
+
+class TestIsPathologicalDiffInput(unittest.TestCase):
+    """Regression for #1513/#155/#1074 — diff() is O(n·m) and freezes for
+    large inputs. consume_edits uses _is_pathological_diff_input as a
+    guard: when the old→new character delta is too large, we signal the
+    caller to drop the snippet rather than attempting a (slow, and at
+    this point semantically pointless) reconciliation."""
+
+    def test_pure_insert_many_lines_is_pathological(self):
+        # The #1513 shape: [''] → thousands of content lines (undo of big
+        # deletion while snippet still tracked).
+        self.assertTrue(_is_pathological_diff_input([""], ["AAAAA"] * 3000))
+
+    def test_pure_delete_many_lines_is_pathological(self):
+        # The #155 shape: thousands of lines visually selected and fed
+        # into a snippet ${VISUAL} ends up producing a huge delta in the
+        # other direction on subsequent edits.
+        self.assertTrue(_is_pathological_diff_input(["AAAAA"] * 3000, [""]))
+
+    def test_small_edit_is_not_pathological(self):
+        # Normal typing/backspace: diff() would be trivial anyway.
+        self.assertFalse(_is_pathological_diff_input(["hello"], ["hellox"]))
+        self.assertFalse(_is_pathological_diff_input(["hello"], ["helo"]))
+
+    def test_moderate_multi_line_edit_is_not_pathological(self):
+        # ~100-char paste: diff would run in a few ms. Not worth dropping
+        # the snippet over.
+        old = ["hello world"]
+        new = ["hello"] + ["x" * 10] * 5 + ["world"]
+        self.assertFalse(_is_pathological_diff_input(old, new))
+
+    def test_at_threshold_boundary(self):
+        # Delta exactly at the threshold is NOT pathological;
+        # above is. Documents the cutoff.
+        from UltiSnips.change_provider import _PATHOLOGICAL_CHAR_DELTA
+
+        under = ["a" * _PATHOLOGICAL_CHAR_DELTA]
+        self.assertFalse(_is_pathological_diff_input([""], under))
+        over = ["a" * (_PATHOLOGICAL_CHAR_DELTA + 1)]
+        self.assertTrue(_is_pathological_diff_input([""], over))
 
 
 class TestOnBytesToEdits(unittest.TestCase):

--- a/test/test_Editing.py
+++ b/test/test_Editing.py
@@ -48,6 +48,19 @@ class Undo_CompletelyUndoSnippet(_VimTest):
     wanted = ""
 
 
+# Regression for #1513: undoing a big deletion while a snippet is still
+# tracked used to fall into the O(n·m) diff() fallback in _cursor_moved and
+# freeze Vim for tens of seconds. After the fix detect_edits handles the
+# 1 → N line transition deterministically (and _cursor_moved drops the
+# snippet instead of hanging if even that gives up).
+class Undo_RestoreLinesWhileSnippetTracked(_VimTest):
+    snippets = ("(", "($1)")
+    text_before = "AAAAA\n" * 49 + "AAAAA"  # 50 lines
+    text_after = ""
+    keys = ESC + "ggVGd" + "i(" + EX + ESC + "uuu"
+    wanted = ""  # final buffer = text_before + "" + text_after = 50 AAAAA lines
+
+
 class JumpForward_DefSnippet(_VimTest):
     snippets = ("test", "${1}\n`!p snip.rv = '\\n'.join(t[1].split())`\n\n${0:pass}")
     keys = "test" + EX + "a b c" + JF + "shallnot"


### PR DESCRIPTION
A non-trivial buffer change (big undo, large paste, `${VISUAL}` capture of a huge selection) could leave the snippet's text-object tree so out of sync with the buffer that `consume_edits` fell through to the `diff()`
O(n·m) shortest-edit-path search, hanging Vim for tens of seconds to minutes. In extreme cases it exhausted RAM or recursed `_do_edit` to death.

## What changed

1. **`detect_edits` handles the general 1 → N line transition** deterministically. Previously only the `added == 1` "Enter key" case was handled; `added >= 2` fell through to `diff()`. This catches multi-line paste into a tabstop etc.

2. **New `_is_pathological_diff_input` guard.** When `detect_edits` can't produce commands AND the char-count delta exceeds 2000 - an arbitrary number - `consume_edits` returns a new `DROP_SNIPPET` sentinel. In practice this fires when the snippet's remembered state has lost touch with the buffer (undo past the expansion, `['']` vs thousands of restored lines, etc.).

3. **`_cursor_moved` terminates the snippet on `DROP_SNIPPET`** instead of replaying edits into a stale text-object tree.

## Issues likely affected

- Fixes #1513. (undo of big deletion hangs): `diff('', 17999 chars)` took 34 s on the repro. After: `detect_edits` returns None for the `[''] → N` shape, pathological check fires, snippet dropped. Sub‑ms. 
- Files #155. (`${VISUAL}` wrap of big selection stuck): same `diff()` freeze class, acknowledged by the author in 2013. 

- Likely fixes #1074. (Vim OOM on large paste into tabstop): same root cause. Covered by the 1 → N `detect_edits` path or the pathological check, depending on input shape.
- Likely fixes #1532, #361, #1175, #906, #629, #438. (RecursionError / IndexError on expand + undo): all same class of "stale tree walked by a corrupted edit stream." `DROP_SNIPPET` short-circuits the walk.