### PR TITLE
Document that jump trigger mappings are only live while a snippet is active

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -263,7 +263,10 @@ their default values are: >
    g:UltiSnipsJumpBackwardTrigger         <c-k>
 
 UltiSnips will only map the jump triggers while a snippet is active to
-interfere as little as possible with other mappings.
+interfere as little as possible with other mappings. Because of this,
+inspecting the mappings with |:map| (for example `:verbose imap <c-k>`)
+reports no mapping until a snippet is actually being expanded — expand
+a snippet first, then inspect the mappings while still inside it.
 
 The default value for g:UltiSnipsJumpBackwardTrigger interferes with the
 built-in complete function: |i_CTRL-X_CTRL-K|. A workaround is to add the


### PR DESCRIPTION
Extend the existing note in `doc/UltiSnips.txt` so it explicitly covers
the common `:verbose map <c-k>` confusion reported in #1497: the jump
triggers are mapped lazily as buffer-local mappings only while a snippet
is currently being expanded, so inspecting them with `:map` reports
nothing until a snippet is active.

No code change — current behavior is intentional (documented since the
note was introduced) so that UltiSnips doesn't clobber the user's own
`<c-j>` / `<c-k>` mappings outside of snippet expansion.

Fixes #1497.