### PR TITLE
Drain queued buffer edits before expand when popup is visible (#1380)

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -77,6 +77,7 @@ function! UltiSnips#FileTypeComplete(arglead, cmdline, cursorpos) abort
 endfunction
 
 function! UltiSnips#ExpandSnippet() abort
+    call s:compensate_for_pum()
     py3 UltiSnips_Manager.expand()
     return ""
 endfunction
@@ -94,6 +95,7 @@ function! UltiSnips#JumpOrExpandSnippet() abort
 endfunction
 
 function! UltiSnips#ListSnippets() abort
+    call s:compensate_for_pum()
     py3 UltiSnips_Manager.list_snippets()
     return ""
 endfunction

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -798,6 +798,12 @@ class SnippetManager:
 
     def _try_expand(self, autotrigger_only=False):
         """Try to expand a snippet in the current place."""
+        # Drain buffer edits queued while CursorMovedI could not fire —
+        # notably while the completion popup was visible. Without this the
+        # text-object tree is stale and _do_snippet's replay crosses
+        # placeholder boundaries, deleting sibling tabstops. See #1380/#1327.
+        if self._active_snippets:
+            self._cursor_moved()
         before, snippets = self._can_expand(autotrigger_only)
         if snippets:
             # prefer snippets with context if any

--- a/test/test_Completion.py
+++ b/test/test_Completion.py
@@ -37,3 +37,92 @@ class Completion_BackwardsJumpWithoutCOMPL_ACCEPT(_VimTest):
     snippets = ("test", "$1 $2")
     keys = COMPLETION_OPTIONS + "test" + EX + "foo" + JF + "com" + COMPL_KW + JB + "foo"
     wanted = COMPLETION_OPTIONS + "foo completion1"
+
+
+# https://github.com/SirVer/ultisnips/issues/1380 (and #1327) — when the
+# completion popup is visible at the moment an iA autosnippet fires, nested
+# expansions and the subsequent forward-jumps get confused and end up in
+# select mode over a previous placeholder. 'k' then replaces that content.
+#
+# Reporter's exact repro: nest `frac` three times with the popup open, then
+# three forward-jumps + 'k'. Buggy output is ``\frac{\frac{k}{}}{}`` —
+# 'k' replaced the already-filled inner ``\frac{}{}`` instead of landing at
+# the outermost second-slot or past it.
+
+
+class Popup_NestedAutosnippet_DoesNotJumpBackward(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        snippet frac "Fraction" iA
+        \frac{${1:${VISUAL}}}{$2}$0
+        endsnippet
+        """
+    }
+    # Pre-fill the buffer with words starting with 'frac' so COMPL_KW has
+    # something to offer. These must live in text_before, NOT in `keys`,
+    # because typing "fraction" / "fracture" / "fractal" would trigger the
+    # iA snippet on each 'frac' substring.
+    text_before = "fraction fracture fractal --- some text before --- \n\n"
+    # First `frac` is typed without the popup — InsertCharPre does not fire
+    # for the very first characters typed inside a fresh popup session, so
+    # iA would never see the trigger if the popup were open from the start.
+    # Real users hit the bug after already being inside a snippet when the
+    # popup pops up (as coc.nvim or deoplete would cause on typing).
+    keys = "frac" + COMPL_KW + "frac" + COMPL_KW + "frac" + JF + JF + JF + "k"
+    # Expected (non-buggy) behaviour: three forward-jumps from the innermost
+    # first-slot should walk through innermost $2, middle $2, outer $2 (or
+    # past $0), and 'k' lands at the outermost slot — never replacing the
+    # filled inner ``\frac{}{}``.
+    # `wanted` is the content between text_before / text_after — the
+    # framework wraps it. Three JFs from innermost T1 walk:
+    #   inner T1 → inner T2 → (T0 & pop) → middle T2
+    # where 'k' is typed. Hitting $0 exits that nesting level but doesn't
+    # auto-advance through the parent, so 3 JFs = middle T2, not outer T2.
+    wanted = r"\frac{\frac{\frac{}{}}{k}}{}"
+
+    def _extra_vim_config(self, vim_config):
+        # Without `noinsert`, Vim auto-inserts the first popup match as you
+        # type (that's why 'some' was leaking into the buffer earlier).
+        # `noselect` keeps the popup visible without committing a choice,
+        # which is exactly the scenario the bug needs.
+        vim_config.append("set completeopt=menu,menuone,noinsert,noselect")
+
+
+# Same as above, but without auto trigger.
+class Popup_NestedNonAutosnippet_DoesNotJumpBackward(_VimTest):
+    snippets = ("frac", r"\frac{${1:${VISUAL}}}{$2}$0", "", "i")
+    text_before = "fraction fracture fractal --- some text before --- \n\n"
+    keys = (
+        COMPL_KW
+        + "frac"
+        + EX
+        + COMPL_KW
+        + "frac"
+        + EX
+        + COMPL_KW
+        + "frac"
+        + EX
+        + JF
+        + JF
+        + JF
+        + "k"
+    )
+    # `wanted` is the content between text_before / text_after — the
+    # framework wraps it. Three JFs from innermost T1 walk:
+    #   inner T1 → inner T2 → (T0 & pop) → middle T2
+    # where 'k' is typed. Hitting $0 exits that nesting level but doesn't
+    # auto-advance through the parent, so 3 JFs = middle T2, not outer T2.
+    wanted = r"\frac{\frac{\frac{}{}}{k}}{}"
+
+    def _extra_vim_config(self, vim_config):
+        vim_config.append("set completeopt=menu,menuone,noinsert,noselect")
+
+
+# Control: identical expansion/jump sequence but without opening the
+# completion popup. Should pass — establishes that the nesting + jump logic
+# itself is fine, and it's the popup interaction that breaks it.
+class NoPopup_NestedNonAutosnippet_DoesNotJumpBackward(_VimTest):
+    snippets = ("frac", r"\frac{${1:${VISUAL}}}{$2}$0", "", "i")
+    text_before = "fraction fracture fractal --- some text before --- \n\n"
+    keys = "frac" + EX + "frac" + EX + "frac" + EX + JF + JF + JF + "k"
+    wanted = r"\frac{\frac{\frac{}{}}{k}}{}"


### PR DESCRIPTION
## Summary

Closes #1380 and #1327. The completion popup (Vim's built-in pum, coc.nvim, deoplete, nvim-compe — any of them) suppresses `CursorMovedI`. That's the only autocmd that drives `_cursor_moved`, and through it the `listener_add` / `on_bytes` queue drain. So when a user types a nested snippet trigger inside a placeholder while a popup is visible, the chars reach the buffer but never make it into the text-object tree. The next expand then runs `_do_snippet` against stale placeholder spans; the resulting "delete trigger / insert body" replay crosses placeholder boundaries and `EditableTextObject._do_edit` kills the parent's T1 and T2 via `_del_child`. A subsequent jump finds only T0 (carrying T1's old span) and select-mode-selects the inner snippet, which the next keystroke then replaces.

- `pythonx/UltiSnips/snippet_manager.py` — `_try_expand` calls `self._cursor_moved()` up front when a snippet is active, so the textobject tree is in sync before any expansion edits land. `_cursor_moved` is idempotent — empty queue is a no-op.
- `autoload/UltiSnips.vim` — `UltiSnips#ExpandSnippet` and `UltiSnips#ListSnippets` now call `s:compensate_for_pum()` to match the four other vim entry points (`ExpandSnippetOrJump`, `JumpOrExpandSnippet`, `JumpForwards`, `JumpBackwards`). The Python guard makes this redundant but keeps the vimscript pattern consistent.
