### PR TITLE
Add regression tests for issues #1405 and #1407

### DIFF
--- a/test/test_Interpolation.py
+++ b/test/test_Interpolation.py
@@ -539,6 +539,49 @@ snip.rv = "placeholder: " + snip.p.current_text`)""",
 first second (placeholder: )"""
 
 
+# Issue #1405: same pattern as PythonVisual_HasAccessToSelectedPlaceholders, but
+# with the !p block placed before the tabstops. The reporter claimed this
+# variant exposed a cursor / selection sync bug.
+class PythonVisual_ReversedHasAccessToSelectedPlaceholders(_VimTest):
+    snippets = (
+        "test",
+        """(`!p
+snip.rv = "placeholder: " + snip.p.current_text`) ${1:first} ${2:second}""",
+    )
+    keys = "test" + EX + ESC + "otest" + EX + JF + ESC
+    wanted = """(placeholder: first) first second
+(placeholder: second) first second"""
+
+
+# Issue #1405: zero-length tabstop preceded by a `!p` that evaluates to "" on
+# first expansion exposes the cursor-sync bug the reporter pinpointed in
+# vim_helper.select() (`i` vs `a` choice for zero-length tabstops).
+class Issue1405_EmptyPythonBeforeZeroLengthTabstop(_VimTest):
+    snippets = ("test", "`!p snip.rv = ''`abc$1def")
+    keys = "test" + EX + "X"
+    wanted = "abcXdef"
+
+
+class Issue1405_EmptyPythonAtStartZeroLengthTabstopMid(_VimTest):
+    snippets = ("test", "`!p snip.rv = ''`$1abc")
+    keys = "test" + EX + "X"
+    wanted = "Xabc"
+
+
+class Issue1405_EmptyPythonZeroLengthTabstopEnd(_VimTest):
+    snippets = ("test", "abc$1`!p snip.rv = ''`")
+    keys = "test" + EX + "X"
+    wanted = "abcX"
+
+
+# First tabstop is zero-length and sits right after an empty !p block —
+# the closest reconstruction of the issue's "ZeroLength_Trivial" repro.
+class Issue1405_ZeroLengthTabstopAfterEmptyPython(_VimTest):
+    snippets = ("test", "(`!p snip.rv = ''`)$1 ${2:second}")
+    keys = "test" + EX + "X" + JF + "Y"
+    wanted = "()X Y"
+
+
 class Python_SnipRvCanBeNonText(_VimTest):
     # Test for https://github.com/SirVer/ultisnips/issues/1132
     snippets = ("test", "`!p snip.rv = 5`")

--- a/test/test_TabStop.py
+++ b/test/test_TabStop.py
@@ -483,3 +483,38 @@ class TabStop_KeepCorrectJumpListOnOverwriteOfPartOfSnippetRE(_VimTest):
     }
     keys = "i" + EX + EX + "1" + JF + "2" + JF + " after" + JF + "3"
     wanted = "ia(1, 2) after: 3"
+
+
+# Issue #1407: deeply nested tabstops where the navigation order is non-obvious.
+# Expansion order in the snippet text is 1, 4, 2, 3, but jumping must still
+# walk them in numeric order: 1 -> 2 -> 3 -> 4 -> 0.
+class TabStop_Issue1407_Expand(_VimTest):
+    snippets = ("test", "${1:foo${4:${2:zzz}bar$3fo}}")
+    keys = "test" + EX
+    wanted = "foozzzbarfo"
+
+
+class TabStop_Issue1407_OverwriteFirst(_VimTest):
+    snippets = ("test", "${1:foo${4:${2:zzz}bar$3fo}}")
+    keys = "test" + EX + "X"
+    wanted = "X"
+
+
+class TabStop_Issue1407_JumpAll_NoEdits(_VimTest):
+    snippets = ("test", "${1:foo${4:${2:zzz}bar$3fo}}")
+    keys = "test" + EX + JF + JF + JF + JF
+    wanted = "foozzzbarfo"
+
+
+class TabStop_Issue1407_OverwriteEach(_VimTest):
+    snippets = ("test", "${1:foo${4:${2:zzz}bar$3fo}}")
+    # Jump 1 (default selected) -> 2 (overwrite zzz with A) ->
+    # 3 (zero length, type B) -> 4 (now contains "AbarBfo", overwrite with C) -> 0.
+    keys = "test" + EX + JF + "A" + JF + "B" + JF + "C"
+    wanted = "fooC"
+
+
+class TabStop_Issue1407_OverwriteOnly2And3(_VimTest):
+    snippets = ("test", "${1:foo${4:${2:zzz}bar$3fo}}")
+    keys = "test" + EX + JF + "A" + JF + "B" + JF + JF
+    wanted = "fooAbarBfo"


### PR DESCRIPTION
Both #1405 (cursor / select out-of-sync after expansion) and #1407 (tab-navigation discussion with a 7-point algorithm proposal) are open issues opened in November 2021 by the same author. The author's implementation
attempt (PR #1408) was closed without merge.

The concrete repros from each issue now pass on master, presumably from the intervening fixes for buffer-edit tracking (#1613), popup edit drain (#1620), and TextObject sort order (#1623). This locks that in as regression coverage so the next behavioral change does not silently regress the cases the original reporter cared about.
