### PR TITLE
Fix cursor placement after `!p` block that takes a few iterations to converge (#1402)

### DIFF
--- a/pythonx/UltiSnips/snippet/definition/base.py
+++ b/pythonx/UltiSnips/snippet/definition/base.py
@@ -517,5 +517,26 @@ class SnippetDefinition:
         )
         self.instantiate(snippet_instance, initial_text, indent)
         snippet_instance.replace_initial_text(vim_helper.buf)
-        snippet_instance.update_textobjects(vim_helper.buf)
+
+        # Iterate update_textobjects until the snippet's text reaches a fixed
+        # point. A `!p` block whose rv depends on its own side effect
+        # (sys.modules state, locals[] cache, ...) only produces its final
+        # value on a later evaluation; the inner convergence loop alone
+        # exits as soon as one evaluation produces ct == rv, leaving
+        # snippet.end stale before _jump synthesizes the implicit $0 and
+        # parks the cursor. Repeat until current_text stabilizes; cap at the
+        # same depth the inner loop uses. See issue #1402.
+        prev_text = None
+        for _ in range(10):
+            snippet_instance.update_textobjects(vim_helper.buf)
+            cur_text = snippet_instance.current_text
+            if cur_text == prev_text:
+                break
+            prev_text = cur_text
+        else:
+            raise PebkacError(
+                "The snippets content did not converge: text kept changing "
+                "across 10 update_textobjects passes. Check `!p` blocks for "
+                "non-idempotent rv that never settles."
+            )
         return snippet_instance

--- a/pythonx/UltiSnips/text_objects/python_code.py
+++ b/pythonx/UltiSnips/text_objects/python_code.py
@@ -260,10 +260,6 @@ class PythonCode(NoneditableTextObject):
             ),
         )
 
-        # Tracks whether this block has produced an apparently-stable rv at
-        # least once. See _update for why this matters (issue #1402).
-        self._has_stabilized_once = False
-
         super().__init__(parent, token.start, token.end, token.initial_text)
 
     def _update(self, done, buf):
@@ -292,19 +288,5 @@ class PythonCode(NoneditableTextObject):
 
         if ct != rv:
             self.overwrite(buf, rv)
-            return False
-
-        # ct == rv, so the buffer matches what we just produced. But the
-        # block may have side effects (e.g. sys.modules state, locals[]
-        # mutation) that only manifest on the *next* execution and would
-        # produce a different rv. Force one extra evaluation before
-        # declaring this block done so the convergence loop does not exit
-        # while the snippet end position is still stale. Without this,
-        # _jump runs select_next_tab against the stale end, plants the
-        # cursor there, and the second update_textobjects (called from
-        # _jump itself) fixes the text but cannot move the already-placed
-        # cursor. See issue #1402.
-        if not self._has_stabilized_once:
-            self._has_stabilized_once = True
             return False
         return True

--- a/pythonx/UltiSnips/text_objects/python_code.py
+++ b/pythonx/UltiSnips/text_objects/python_code.py
@@ -260,6 +260,10 @@ class PythonCode(NoneditableTextObject):
             ),
         )
 
+        # Tracks whether this block has produced an apparently-stable rv at
+        # least once. See _update for why this matters (issue #1402).
+        self._has_stabilized_once = False
+
         super().__init__(parent, token.start, token.end, token.initial_text)
 
     def _update(self, done, buf):
@@ -288,5 +292,19 @@ class PythonCode(NoneditableTextObject):
 
         if ct != rv:
             self.overwrite(buf, rv)
+            return False
+
+        # ct == rv, so the buffer matches what we just produced. But the
+        # block may have side effects (e.g. sys.modules state, locals[]
+        # mutation) that only manifest on the *next* execution and would
+        # produce a different rv. Force one extra evaluation before
+        # declaring this block done so the convergence loop does not exit
+        # while the snippet end position is still stale. Without this,
+        # _jump runs select_next_tab against the stale end, plants the
+        # cursor there, and the second update_textobjects (called from
+        # _jump itself) fixes the text but cannot move the already-placed
+        # cursor. See issue #1402.
+        if not self._has_stabilized_once:
+            self._has_stabilized_once = True
             return False
         return True

--- a/test/test_Interpolation.py
+++ b/test/test_Interpolation.py
@@ -603,3 +603,43 @@ class PythonCode_SameStartCol_OrderedBySource_Issue1403(_VimTest):
     )
     keys = "test" + EX
     wanted = "tt"
+
+
+# https://github.com/SirVer/ultisnips/issues/1402 — a `!p` block that
+# converges in two evaluations (because rv depends on side-effect state
+# set by the first call). Before the fix in PythonCode._update, the
+# convergence loop exited after the first call (ct == rv == ""), the
+# snippet end was still at column 0, _jump placed the cursor there, and
+# the *second* update_textobjects (driven by _jump) wrote "tt" to the
+# buffer but could no longer move the cursor — the user's first keystroke
+# landed at the wrong end ("Xtt" instead of "ttX").
+class PythonCode_TwoStepConverge_RvExplicitlyEmpty_Issue1402(_VimTest):
+    snippets = (
+        "test1402a",
+        """`!p
+import sys
+if 'ut_1402_a' not in sys.modules:
+    sys.modules['ut_1402_a'] = 'tt'
+    snip.rv = ''
+else:
+    snip.rv = 'tt'
+`""",
+    )
+    keys = "test1402a" + EX + "X"
+    wanted = "ttX"
+
+
+class PythonCode_TwoStepConverge_RvNotMutated_Issue1402(_VimTest):
+    snippets = (
+        "test1402b",
+        """`!p
+import sys
+if 'ut_1402_b' not in sys.modules:
+    sys.modules['ut_1402_b'] = 'tt'
+    # snip.rv is intentionally not mutated on first execution
+else:
+    snip.rv = 'tt'
+`""",
+    )
+    keys = "test1402b" + EX + "X"
+    wanted = "ttX"


### PR DESCRIPTION
If a snippet on initial expand gives a different text than after a second round of evaluation could confuse UltiSnips. 
This change adds a fixed point iteration on initial expand - only accept the initial expansion if it is stable, even after a 2nd iteration. 

This has the tradeoff that every snippet is evaluated twice on initial expand, but enhances correctness, so worth to me.

Closes #1402.