### PR TITLE
Don't drop snippet when quickfix or location-list opens (#1527)

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -167,14 +167,54 @@ function! UltiSnips#CursorMoved() abort
     py3 UltiSnips_Manager._cursor_moved()
 endf
 
-function! UltiSnips#LeavingBuffer() abort
-    let from_preview = getwinvar(winnr('#'), '&previewwindow')
-    let to_preview = getwinvar(winnr(), '&previewwindow')
-    let from_floating = s:is_floating(win_getid('#'))
-    let to_floating = s:is_floating(win_getid())
+function! s:is_aux_window(winnr) abort
+    " Auxiliary windows that should not tear down an active snippet:
+    "   - the preview window
+    "   - neovim floating windows
+    "   - quickfix and location-list windows
+    " These are typically opened transiently by other plugins
+    " (nvim-cmp docs popup, vimtex quickfix, lsp signature_help, …) and the
+    " user expects to come back to the snippet afterwards.
+    if getwinvar(a:winnr, '&previewwindow')
+        return 1
+    endif
+    if s:is_floating(win_getid(a:winnr))
+        return 1
+    endif
+    if getwinvar(a:winnr, '&buftype') ==# 'quickfix'
+        return 1
+    endif
+    " On `:copen`/`:lopen` Vim sets `&buftype` *after* `BufEnter` fires, so
+    " also recognise the window via `getwininfo()`'s `quickfix` / `loclist`
+    " flags (populated synchronously when the qf window is created).
+    let l:winid = win_getid(a:winnr)
+    if l:winid <= 0
+        return 0
+    endif
+    let l:info = getwininfo(l:winid)
+    if empty(l:info)
+        return 0
+    endif
+    return l:info[0].quickfix || l:info[0].loclist
+endfunction
 
-    if !(from_preview || to_preview || from_floating || to_floating)
+function! s:leaving_buffer_impl() abort
+    if !(s:is_aux_window(winnr('#')) || s:is_aux_window(winnr()))
         py3 UltiSnips_Manager._leaving_buffer()
+    endif
+endfunction
+
+function! UltiSnips#LeavingBuffer() abort
+    " The check is deferred to the next event-loop tick because some auxiliary
+    " windows (notably quickfix / location-list opened via `:copen` / `:lopen`)
+    " set their `&buftype` *after* BufEnter fires. Running the check
+    " synchronously from the BufEnter autocmd would see an unmarked window and
+    " incorrectly tear the snippet down. By the time the timer callback runs,
+    " the window/buffer is fully initialised.
+    if exists('*timer_start')
+        call timer_start(0, {-> s:leaving_buffer_impl()})
+    else
+        call s:leaving_buffer_impl()
     endif
 endf
 

--- a/test/test_Window.py
+++ b/test/test_Window.py
@@ -1,0 +1,58 @@
+from test.constant import EX, JF
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+# https://github.com/SirVer/ultisnips/issues/1527
+#
+# Reporter scenario: vimtex compiles a `.tex` file in the background and pops
+# the quickfix open via `:copen` whenever the in-progress snippet body produces
+# a parse error (`\begin{ite}` is invalid until the env name is finished).
+# `copen` momentarily steals focus, firing BufEnter for the quickfix buffer,
+# which used to call `UltiSnips#LeavingBuffer()` and tear down the snippet —
+# the buffer-local `<buffer>` mappings on the original buffer were left
+# orphaned because the unmap commands run while focus is still in the qf, so
+# the next jump silently no-ops.
+#
+# Fix: classify quickfix and location-list windows alongside preview/floating
+# in the LeavingBuffer guard, AND defer the check via `timer_start(0, ...)`
+# because Vim sets the qf window's `&buftype` *after* BufEnter fires.
+class QuickfixOpenedDuringSnippet_DoesNotClearSnippet_Issue1527(_VimTest):
+    snippets = ("env", "\\begin{$1}\n\t$2\n\\end{$1}", "", "i")
+    # `<c-l>` (chr 12) has no insert-mode default; we map it below to populate
+    # the quickfix list, open it (which steals focus), and switch back — the
+    # same focus dance vimtex does on each background compile.
+    keys = "env" + EX + "itemize" + "\x0c" + JF + "stuff"
+    wanted = "\\begin{itemize}\n\tstuff\n\\end{itemize}"
+
+    def _extra_vim_config(self, vim_config):
+        vim_config.extend(
+            [
+                "function! UltiSnipsTest_OpenQuickfix() abort",
+                "  call setqflist([{'text': 'simulated error'}])",
+                "  copen",
+                "  wincmd p",
+                "endfunction",
+                "inoremap <c-l> <cmd>call UltiSnipsTest_OpenQuickfix()<cr>",
+            ]
+        )
+
+
+# Same scenario as above but with a location-list (`:lopen`) instead of
+# `:copen`. Both share `&buftype == 'quickfix'`, so the single guard covers
+# both — this test pins that contract.
+class LocationListOpenedDuringSnippet_DoesNotClearSnippet_Issue1527(_VimTest):
+    snippets = ("env", "\\begin{$1}\n\t$2\n\\end{$1}", "", "i")
+    keys = "env" + EX + "itemize" + "\x0c" + JF + "stuff"
+    wanted = "\\begin{itemize}\n\tstuff\n\\end{itemize}"
+
+    def _extra_vim_config(self, vim_config):
+        vim_config.extend(
+            [
+                "function! UltiSnipsTest_OpenLocList() abort",
+                "  call setloclist(0, [{'text': 'simulated error'}])",
+                "  lopen",
+                "  wincmd p",
+                "endfunction",
+                "inoremap <c-l> <cmd>call UltiSnipsTest_OpenLocList()<cr>",
+            ]
+        )


### PR DESCRIPTION
Fixes #1527.

When vimtex's continuous compilation drops an error into the quickfix list and `:copen` displays it (or any other plugin opens a quickfix / location-list mid-snippet), focus briefly moves to the qf window. Its BufEnter used to fire `UltiSnips#LeavingBuffer()`, which tore the active snippet down. Worse, the buffer-local `<buffer>` mappings on
the original buffer were left orphaned because the unmap commands fail silently when run while focus is in the qf. Subsequent jumps then no-op'd against an already-empty snippet stack.

Two-part fix in `autoload/UltiSnips.vim`:

- Classify quickfix and location-list windows as auxiliary alongside preview and floating windows, in a new `s:is_aux_window` helper. The helper consults `&buftype`, `&previewwindow`, the existing
`s:is_floating` test, and falls back to `getwininfo()`'s `quickfix` / `loclist` flags.
- Defer the check via `timer_start(0, ...)`. Vim sets the qf window's `&buftype` *after* BufEnter fires, so a synchronous check sees an unmarked window and tears the snippet down anyway. Deferring to the
next event-loop tick lets the qf finish initialising before we evaluate. Verified event order: `BufEnter` →
`OptionSet buftype=quickfix` → `FileType qf` → `BufWinEnter`.


