### PR TITLE
Drop snippet on buffer switch before BufEnter teardown fires

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -124,6 +124,7 @@ class SnippetManager:
         self.forward_trigger = forward_trigger
         self.backward_trigger = backward_trigger
         self._inner_state_up = False
+        self._snippet_buffer_number = None
         self._supertab_keys = None
 
         self._active_snippets = []
@@ -392,6 +393,16 @@ class SnippetManager:
             return
 
         if self._active_snippets:
+            # `:bd!` (and similar buffer-switch commands) fire CursorMoved on
+            # the new buffer before the BufEnter-scheduled `_leaving_buffer`
+            # timer callback runs. Reconciling the snippet's text objects
+            # against an unrelated buffer corrupts both the buffer and the
+            # snippet state — drop the snippets here so the caller sees a
+            # clean slate.
+            if vim.current.buffer.number != self._snippet_buffer_number:
+                self._leaving_buffer()
+                return
+
             es = self._change_provider.consume_edits(
                 vim_helper.buf, self._active_snippets[0], self._vstate
             )
@@ -458,6 +469,7 @@ class SnippetManager:
 
         vim.command("silent doautocmd <nomodeline> User UltiSnipsEnterFirstSnippet")
         self._change_provider.attach(vim.current.buffer.number)
+        self._snippet_buffer_number = vim.current.buffer.number
         self._inner_state_up = True
 
     def _teardown_inner_state(self):
@@ -481,6 +493,7 @@ class SnippetManager:
             pass
         finally:
             self._change_provider.detach()
+            self._snippet_buffer_number = None
             self._inner_state_up = False
 
     @err_to_scratch_buffer.wrap

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -221,3 +221,21 @@ class NullByte_ExpandAfter(_VimTest):
 
 
 # End: #1386
+
+
+# https://github.com/SirVer/ultisnips/issues/1628 — :bd! while a snippet with
+# a !p block is active used to fire CursorMoved against the new buffer before
+# the deferred BufEnter teardown ran, leaving the snippet trying to reconcile
+# its text-object tree against an unrelated buffer.
+class BufferDelete_DropsActiveSnippet_Issue1628(_VimTest):
+    text_before = ""
+    text_after = ""
+    files = {
+        "us/all.snippets": r"""
+snippet ott
+${1:Video} tube`!p snip.rv = '' if t[1] else 's'`.
+endsnippet
+        """
+    }
+    keys = "ott" + EX + ESC + ":bd!\n"
+    wanted = ""


### PR DESCRIPTION
`:bd!` (and similar buffer-switch commands) fire `CursorMoved` on the new buffer immediately. UltiSnips' `BufEnter`-driven `_leaving_buffer` runs through `timer_start(0, ...)` so its cleanup is one event-loop tick late.
In that gap, `_cursor_moved` reconciles the still-active snippet against an unrelated buffer, which corrupts the new buffer and (for snippets with a `!p` block whose output depends on tabstops) trips the "snippets did not converge" guard.

Track the snippet's home buffer in the manager and bail out of `_cursor_moved` when we wake up somewhere else, dropping snippets synchronously.

Fixes #1628 