### PR TITLE
Preserve unnamed register when expanding from visual mode

### DIFF
--- a/autoload/UltiSnips/map_keys.vim
+++ b/autoload/UltiSnips/map_keys.vim
@@ -67,7 +67,7 @@ function! UltiSnips#map_keys#MapKeys() abort
         exec "inoremap <silent> " . g:UltiSnipsExpandTrigger . " <C-R>=UltiSnips#ExpandSnippet()<cr>"
         exec "snoremap <silent> " . g:UltiSnipsExpandTrigger . " <Esc>:call UltiSnips#ExpandSnippet()<cr>"
     endif
-    exec "xnoremap <silent> " . g:UltiSnipsExpandTrigger. " :call UltiSnips#SaveLastVisualSelection()<cr>gvs"
+    exec "xnoremap <silent> " . g:UltiSnipsExpandTrigger. " :call UltiSnips#SaveLastVisualSelection()<cr>gv\"_s"
     if len(g:UltiSnipsListSnippets) > 0
        exec "inoremap <silent> " . g:UltiSnipsListSnippets . " <C-R>=UltiSnips#ListSnippets()<cr>"
        exec "snoremap <silent> " . g:UltiSnipsListSnippets . " <Esc>:call UltiSnips#ListSnippets()<cr>"

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -48,6 +48,33 @@ class RetainsTheUnnamedRegister_ButOnlyOnce(_VimTest):
     wanted = "\nblah\nhello world "
 
 
+# Test for https://github.com/SirVer/ultisnips/issues/1297 —
+# Triggering a snippet directly from visual mode (the xnoremap path)
+# must not clobber the unnamed register with the visually-selected text.
+
+
+class RetainsTheUnnamedRegister_FromVisualMode(_VimTest):
+    snippets = ("test", "${1:hello} ${2:world} ${0}")
+    keys = (
+        "yank "
+        + ESC
+        + "0y4l"
+        + "$a"
+        + "VICTIM"
+        + ESC
+        + "v5h"
+        + EX
+        + "test"
+        + EX
+        + "HELLO"
+        + JF
+        + JF
+        + ESC
+        + "p"
+    )
+    wanted = "yank HELLO world yank"
+
+
 # End: Github Pull Request # 134
 
 # Test to ensure that shiftwidth follows tabstop when it's set to zero post


### PR DESCRIPTION
Triggering a snippet from visual mode used to clobber `@"` with the visually-selected text.

Route the deletion through the black-hole register (`gv"_s`) so the substitute never touches `@"`.

Fixes #1297.