### PR TITLE
Preserve yank register across snippet expansion

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -476,6 +476,13 @@ class SnippetManager:
         """Reverse _setup_inner_state."""
         if not self._inner_state_up:
             return
+        # Restore cached registers now: the InsertLeave autocmd that would
+        # normally call _leaving_insert_mode is removed below, so without
+        # this the clobbering done by the LAST placeholder edit would
+        # never be undone. Then drop the cache so the next snippet starts
+        # from a clean slate.
+        self._vstate.restore_unnamed_register()
+        self._vstate.reset_register_cache()
         try:
             vim.command("silent doautocmd <nomodeline> User UltiSnipsExitLastSnippet")
             if self.expand_trigger != self.forward_trigger:

--- a/pythonx/UltiSnips/vim_state.py
+++ b/pythonx/UltiSnips/vim_state.py
@@ -44,13 +44,13 @@ class VimState:
         self._text_to_expect = ""
         self._unnamed_reg_cached = False
 
-        # We store the cached value of the unnamed register in Vim directly to
-        # avoid any Unicode issues with saving and restoring the unnamed
-        # register across the Python bindings.  The unnamed register can contain
-        # data that cannot be coerced to Unicode, and so a simple vim.eval('@"')
-        # fails badly.  Keeping the cached value in Vim directly, sidesteps the
-        # problem.
-        vim.command('let g:_ultisnips_unnamed_reg_cache = ""')
+        # Cache the full reginfo dict for @" (value + which register the
+        # unnamed pointer aliases) and restore via setreg(), not `let @"=`.
+        # `let @"=X` writes to @0 as well, clobbering the user's yank
+        # register; setreg with a reginfo dict writes only to the register
+        # the pointer targets, leaving @0 alone unless the original state
+        # already aliased @0.
+        vim.command("let g:_ultisnips_unnamed_reg_cache = {}")
 
     def remember_unnamed_register(self, text_to_expect):
         """Save the unnamed register.
@@ -65,14 +65,14 @@ class VimState:
         escaped_text = self._text_to_expect.replace("'", "''")
         res = int(vim_helper.eval('@" != ' + "'" + escaped_text + "'"))
         if res:
-            vim.command('let g:_ultisnips_unnamed_reg_cache = @"')
+            vim.command("let g:_ultisnips_unnamed_reg_cache = getreginfo('\"')")
         self._text_to_expect = text_to_expect
 
     def restore_unnamed_register(self):
         """Restores the unnamed register and forgets what we cached."""
         if not self._unnamed_reg_cached:
             return
-        vim.command('let @" = g:_ultisnips_unnamed_reg_cache')
+        vim.command("call setreg('\"', g:_ultisnips_unnamed_reg_cache)")
         self._unnamed_reg_cached = False
 
     def remember_position(self):

--- a/pythonx/UltiSnips/vim_state.py
+++ b/pythonx/UltiSnips/vim_state.py
@@ -44,13 +44,13 @@ class VimState:
         self._text_to_expect = ""
         self._unnamed_reg_cached = False
 
-        # Cache the full reginfo dict for @" (value + which register the
-        # unnamed pointer aliases) and restore via setreg(), not `let @"=`.
-        # `let @"=X` writes to @0 as well, clobbering the user's yank
-        # register; setreg with a reginfo dict writes only to the register
-        # the pointer targets, leaving @0 alone unless the original state
-        # already aliased @0.
-        vim.command("let g:_ultisnips_unnamed_reg_cache = {}")
+        # We store the cached register values in Vim directly to avoid any
+        # Unicode issues with saving and restoring across the Python bindings.
+        # Registers can contain data that cannot be coerced to Unicode, so a
+        # simple vim.eval('@"') fails badly. Keeping the cache in Vim
+        # sidesteps the problem.
+        vim.command('let g:_ultisnips_unnamed_reg_cache = ""')
+        vim.command('let g:_ultisnips_yank_reg_cache = ""')
 
     def remember_unnamed_register(self, text_to_expect):
         """Save the unnamed register.
@@ -65,14 +65,25 @@ class VimState:
         escaped_text = self._text_to_expect.replace("'", "''")
         res = int(vim_helper.eval('@" != ' + "'" + escaped_text + "'"))
         if res:
-            vim.command("let g:_ultisnips_unnamed_reg_cache = getreginfo('\"')")
+            vim.command('let g:_ultisnips_unnamed_reg_cache = @"')
+            vim.command("let g:_ultisnips_yank_reg_cache = @0")
         self._text_to_expect = text_to_expect
 
     def restore_unnamed_register(self):
-        """Restores the unnamed register and forgets what we cached."""
+        """Restores the unnamed register and forgets what we cached.
+
+        `let @"=X` writes to @0 too, which would clobber the user's yank
+        register. We restore @" first (which writes our cached @" to both
+        @" and @0), then restore @0 (which writes our cached @0 to both
+        @0 and @"). The yank register ends up preserved; @" inherits @0's
+        value, which is the trade-off — the user can still reach the
+        delete that previously lived in @" via @1 / @-.
+
+        """
         if not self._unnamed_reg_cached:
             return
-        vim.command("call setreg('\"', g:_ultisnips_unnamed_reg_cache)")
+        vim.command('let @" = g:_ultisnips_unnamed_reg_cache')
+        vim.command("let @0 = g:_ultisnips_yank_reg_cache")
         self._unnamed_reg_cached = False
 
     def remember_position(self):

--- a/pythonx/UltiSnips/vim_state.py
+++ b/pythonx/UltiSnips/vim_state.py
@@ -79,9 +79,7 @@ class VimState:
         if res:
             for reg in self._PRESERVED_REGISTERS:
                 lit = _vim_str(reg)
-                vim.command(
-                    f"let g:_ultisnips_reg_cache[{lit}] = getreginfo({lit})"
-                )
+                vim.command(f"let g:_ultisnips_reg_cache[{lit}] = getreginfo({lit})")
         self._text_to_expect = text_to_expect
 
     def restore_unnamed_register(self):

--- a/pythonx/UltiSnips/vim_state.py
+++ b/pythonx/UltiSnips/vim_state.py
@@ -12,6 +12,11 @@ from UltiSnips.position import Position
 from UltiSnips.vim_encoding import byte2col
 
 
+def _vim_str(s):
+    """Render a Python string as a single-quoted Vim string literal."""
+    return "'" + s.replace("'", "''") + "'"
+
+
 class _Placeholder(NamedTuple):
     current_text: str
     start: Position
@@ -37,54 +42,81 @@ class VimState:
     """Caches some state information from Vim to better guess what editing
     tasks the user might have done in the last step."""
 
+    # Registers preserved across snippet expansion. Iteration order is the
+    # restore order: @- and @1-@9 are written first because setreg on those
+    # only touches the target register; @0 is next because setreg('0', …)
+    # re-points the unnamed register at @0; @" is last so its points-to
+    # alias ends up where it was pre-snippet. The unnamed register `"`
+    # appears in the iterable for caching but is handled specially on
+    # restore via setreg with the cached reginfo dict.
+    _PRESERVED_REGISTERS = ("-", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", '"')
+
     def __init__(self):
         self._poss = deque(maxlen=5)
         self._lvb = None
 
         self._text_to_expect = ""
-        self._unnamed_reg_cached = False
 
-        # We store the cached register values in Vim directly to avoid any
-        # Unicode issues with saving and restoring across the Python bindings.
-        # Registers can contain data that cannot be coerced to Unicode, so a
-        # simple vim.eval('@"') fails badly. Keeping the cache in Vim
-        # sidesteps the problem.
-        vim.command('let g:_ultisnips_unnamed_reg_cache = ""')
-        vim.command('let g:_ultisnips_yank_reg_cache = ""')
+        # Cache reginfo dicts for each preserved register in a Vim variable
+        # so binary register contents (which can't always cross the
+        # Python/Vim string boundary) survive cleanly. An empty dict means
+        # "nothing to restore" — populated on first remember during a
+        # snippet, cleared at teardown.
+        vim.command("let g:_ultisnips_reg_cache = {}")
 
     def remember_unnamed_register(self, text_to_expect):
-        """Save the unnamed register.
+        """Cache the snippet-clobberable registers if @" doesn't already
+        match the previously-expected text.
 
-        'text_to_expect' is text that we expect
-        to be contained in the register the next time this method is called -
-        this could be text from the tabstop that was selected and might have
-        been overwritten. We will not cache that then.
+        'text_to_expect' is text we expect to be in @" on the next call
+        (typically the placeholder text the snippet just put there). When
+        @" still matches the previous expectation we know we put it there
+        ourselves, so we don't overwrite the original cached state.
 
         """
-        self._unnamed_reg_cached = True
         escaped_text = self._text_to_expect.replace("'", "''")
         res = int(vim_helper.eval('@" != ' + "'" + escaped_text + "'"))
         if res:
-            vim.command('let g:_ultisnips_unnamed_reg_cache = @"')
-            vim.command("let g:_ultisnips_yank_reg_cache = @0")
+            for reg in self._PRESERVED_REGISTERS:
+                lit = _vim_str(reg)
+                vim.command(
+                    f"let g:_ultisnips_reg_cache[{lit}] = getreginfo({lit})"
+                )
         self._text_to_expect = text_to_expect
 
     def restore_unnamed_register(self):
-        """Restores the unnamed register and forgets what we cached.
+        """Restore the cached registers, if we have any cached.
 
-        `let @"=X` writes to @0 too, which would clobber the user's yank
-        register. We restore @" first (which writes our cached @" to both
-        @" and @0), then restore @0 (which writes our cached @0 to both
-        @0 and @"). The yank register ends up preserved; @" inherits @0's
-        value, which is the trade-off — the user can still reach the
-        delete that previously lived in @" via @1 / @-.
+        Iteration order matters because `setreg('0', …)` and
+        `setreg('"', dict)` both update the unnamed-register pointer.
+        We restore @- and @1-@9 first (those only touch the target
+        register), then @0 (which re-points @" to @0), then @" last
+        with its cached reginfo dict — `setreg('"', dict)` honours
+        the dict's `points_to` and writes the value into whichever
+        register the pointer aliased pre-snippet, leaving the others
+        intact (pre-snippet `@"` and its alias-target hold the same
+        value, so this is content-neutral for the alias target).
+
+        Restore is idempotent — running it twice in a row gives the
+        same end state. The cache itself is only cleared in
+        :meth:`reset_cache`, called from teardown.
 
         """
-        if not self._unnamed_reg_cached:
+        if int(vim_helper.eval("empty(g:_ultisnips_reg_cache)")):
             return
-        vim.command('let @" = g:_ultisnips_unnamed_reg_cache')
-        vim.command("let @0 = g:_ultisnips_yank_reg_cache")
-        self._unnamed_reg_cached = False
+        for reg in self._PRESERVED_REGISTERS:
+            lit = _vim_str(reg)
+            vim.command(
+                f"if has_key(g:_ultisnips_reg_cache, {lit}) | "
+                f"call setreg({lit}, g:_ultisnips_reg_cache[{lit}]) | "
+                f"endif"
+            )
+
+    def reset_register_cache(self):
+        """Drop the cached register state. Called when the snippet
+        finishes so the next one starts from a clean slate."""
+        vim.command("let g:_ultisnips_reg_cache = {}")
+        self._text_to_expect = ""
 
     def remember_position(self):
         """Remember the current position as a previous pose."""

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -99,6 +99,56 @@ class PreservesYankRegisterAcrossSnippet(_VimTest):
     wanted = "yank [X]yank"
 
 
+# Companion to PreservesYankRegisterAcrossSnippet: the same setup, but paste
+# from `@"` rather than `@0`. `@"` was last set by `diw` (so points at `@-` /
+# `@1`); snippet expansion must restore that state too.
+
+
+class PreservesUnnamedRegisterAcrossSnippet(_VimTest):
+    snippets = ("test", "[${1:hello}]$0")
+    keys = (
+        "yank dlt"
+        + ESC
+        + "0yiw"
+        + "$"
+        + "B"
+        + "diw"
+        + "atest"
+        + EX
+        + "X"
+        + JF
+        + ESC
+        + "p"
+    )
+    wanted = "yank [X]dlt"
+
+
+# Companion test for `@1`. We line-delete with `dd` (writes to `@1`, not just
+# `@-`), then expand a snippet whose placeholder spans two lines — replacing
+# it pushes the placeholder text into `@1` and shifts our user state out. The
+# fix must restore `@1` to the original `LINE1` line.
+
+
+class PreservesNumberedRegisterAcrossSnippet(_VimTest):
+    snippets = ("test", "[${1:first\nsecond}]$0")
+    keys = (
+        "LINE1"
+        + ESC
+        + "dd"
+        + "otest"
+        + EX
+        + "X"
+        + JF
+        + ESC
+        + "o"
+        + ESC
+        + '"1p'
+        + "o"
+        + ESC
+    )
+    wanted = "\n[X]\n\nLINE1"
+
+
 # End: Github Pull Request # 134
 
 # Test to ensure that shiftwidth follows tabstop when it's set to zero post

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -75,6 +75,30 @@ class RetainsTheUnnamedRegister_FromVisualMode(_VimTest):
     wanted = "yank HELLO world yank"
 
 
+# Test for https://github.com/SirVer/ultisnips/issues/1037 —
+# Snippet expansion must not clobber the yank register @0 when the user
+# has separated @" and @0 (e.g. by yanking, then deleting/changing).
+
+
+class PreservesYankRegisterAcrossSnippet(_VimTest):
+    snippets = ("test", "[${1:hello}]$0")
+    keys = (
+        "yank dlt"
+        + ESC
+        + "0yiw"
+        + "$"
+        + "B"
+        + "diw"
+        + "atest"
+        + EX
+        + "X"
+        + JF
+        + ESC
+        + '"0p'
+    )
+    wanted = "yank [X]yank"
+
+
 # End: Github Pull Request # 134
 
 # Test to ensure that shiftwidth follows tabstop when it's set to zero post

--- a/test/vim_test_case.py
+++ b/test/vim_test_case.py
@@ -120,6 +120,10 @@ class VimTestCase(unittest.TestCase, TempFileManager):
         vim_config.append("set noautoindent")
         vim_config.append('set backspace=""')
         vim_config.append('set clipboard=""')
+        # Isolate each test from on-disk viminfo so register state doesn't
+        # leak between tests. Without this the `let @" = ""` below is
+        # silently overridden by Vim's post-vimrc viminfo restoration.
+        vim_config.append('set viminfo=""')
         vim_config.append("set encoding=utf-8")
         vim_config.append("set fileencoding=utf-8")
         vim_config.append("set buftype=nofile")


### PR DESCRIPTION
Preserve every snippet-clobberable register across expansion

Yanking text and then expanding a snippet used to clobber `@0` with the snippet's restored `@"` value — the user's yanked text could no longer be reached via `"0p`/`<c-r>0`. The same general problem affects `@1`-`@9` and `@-`, since select-mode placeholder edits write through to those registers too.

The fix caches `getreginfo()` for `@"`, `@0`, `@-`, and `@1`-`@9` at the first tabstop jump, then restores them via `setreg()` at every InsertLeave AND at snippet teardown (the teardown call is necessary because the last placeholder edit happens after the final InsertLeave restore, with the autocmd already torn down). Restoration order matters: `@-`/`@1`-`@9` first (those `setreg` calls touch only the target register), then `@0` (which re-points `@"` to `@0`), then `@"` last with its cached reginfo dict — `setreg('"', dict)` honours `points_to` and writes the value through whichever register the pointer aliased pre-snippet, so the unnamed-register alias survives intact.

Also disables viminfo in the test framework: Vim restores viminfo *after* sourcing `-u config`, silently overriding the framework's `let @" = ""`. That left tests at the mercy of whatever the previous test exit had written to viminfo, which broke the faithful-restore of points-to aliases on CI but not locally.

Tests: `PreservesYankRegisterAcrossSnippet` (`@0`), `PreservesUnnamedRegisterAcrossSnippet` (`@"`), `PreservesNumberedRegisterAcrossSnippet` (`@1` via a multiline placeholder so the select-mode delete actually fills `@1`).

Fixes #1037.
