### PR TITLE
Dedupe snippet matches when the same file is parsed twice

### DIFF
--- a/pythonx/UltiSnips/snippet/source/file/base.py
+++ b/pythonx/UltiSnips/snippet/source/file/base.py
@@ -25,6 +25,27 @@ class SnippetFileSource(SnippetSource):
             if self._needs_update(ft):
                 self._load_snippets_for(ft)
 
+    def get_snippets(
+        self, filetypes, before, possible, autotrigger_only, visual_content
+    ):
+        # The same file can legitimately be loaded under multiple filetype
+        # buckets — for example `<ft>_<sub>.snippets` is picked up for filetype
+        # `<ft>` via the `<ft>_*.snippets` glob and again for filetype
+        # `<ft>_<sub>` when something explicitly extends it. Dedupe by
+        # `(trigger, location)` so the user sees one match instead of a
+        # spurious "multiple matches" prompt.
+        seen = set()
+        result = []
+        for snippet in super().get_snippets(
+            filetypes, before, possible, autotrigger_only, visual_content
+        ):
+            key = (snippet.trigger, snippet.location)
+            if key in seen:
+                continue
+            seen.add(key)
+            result.append(snippet)
+        return result
+
     def refresh(self):
         self.__init__()
 

--- a/pythonx/UltiSnips/snippet/source/file/common.py
+++ b/pythonx/UltiSnips/snippet/source/file/common.py
@@ -13,7 +13,15 @@ def normalize_file_path(path: str) -> str:
 def handle_extends(tail, line_index):
     """Handles an extends line in a snippet."""
     if tail:
-        return "extends", ([p.strip() for p in tail.split(",")],)
+        filetypes = []
+        for p in tail.split(","):
+            p = p.strip()
+            # `extends` takes filetype names, not file names. Tolerate the
+            # common mistake of including the .snippets extension.
+            if p.endswith(".snippets"):
+                p = p[: -len(".snippets")]
+            filetypes.append(p)
+        return "extends", (filetypes,)
     return "error", ("'extends' without file types", line_index)
 
 

--- a/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
+++ b/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
@@ -73,7 +73,9 @@ def find_all_snippet_files(ft) -> set[str]:
             continue
         for pattern in patterns:
             for fn in Path(directory).glob(pattern % ft):
-                ret.add(str(fn))
+                # Canonicalize so symlinked or duplicated runtimepath entries
+                # don't make the same file appear twice.
+                ret.add(normalize_file_path(str(fn)))
     return ret
 
 

--- a/test/test_DuplicateSnippets.py
+++ b/test/test_DuplicateSnippets.py
@@ -1,0 +1,92 @@
+"""Regression tests for the "Multiple matches" dialog appearing on a single
+snippet (issues #1341, #1519, #1559).
+
+The same snippet file can end up being parsed twice — either because the
+runtimepath contains a symlinked copy of the same directory, or because the
+file is picked up via the `<ft>_*.snippets` glob for one filetype and again as
+the canonical file for another filetype that is referenced from `extends`.
+Both cases used to surface as the inputlist() prompt showing the same snippet
+twice, even when the choices were indistinguishable.
+"""
+
+import contextlib
+
+from test.constant import ESC, EX
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class DuplicateSnippets_ExtendsSubFile(_VimTest):
+    # `foo.snippets` extends a filetype whose name (`foo_bar`) collides with
+    # the `foo_*.snippets` sub-file convention. The same file used to be
+    # parsed under both filetypes and `foo_bar` showed up twice.
+    files = {
+        "us/foo.snippets": r"""
+        extends foo_bar
+        """,
+        "us/foo_bar.snippets": r"""
+        snippet hi "Greeting"
+        hello
+        endsnippet
+        """,
+    }
+    keys = ESC + ":set ft=foo\n" + "ihi" + EX
+    wanted = "hello"
+
+
+class DuplicateSnippets_ExtendsWithSnippetsSuffix(_VimTest):
+    # `extends` takes a filetype name; including the `.snippets` extension is
+    # a common user mistake. Be lenient and strip it.
+    files = {
+        "us/foo.snippets": r"""
+        extends foo_bar.snippets
+        """,
+        "us/foo_bar.snippets": r"""
+        snippet hi "Greeting"
+        hello
+        endsnippet
+        """,
+    }
+    keys = ESC + ":set ft=foo\n" + "ihi" + EX
+    wanted = "hello"
+
+
+class DuplicateSnippets_SymlinkedRuntimepath(_VimTest):
+    # A symlink that exposes the temp dir under a second path means the same
+    # snippet file is reached via two distinct string paths. Path
+    # canonicalization in `find_all_snippet_files` collapses them.
+    files = {
+        "us/foo.snippets": r"""
+        snippet hi "Greeting"
+        hello
+        endsnippet
+        """,
+    }
+    keys = ESC + ":set ft=foo\n" + "ihi" + EX
+    wanted = "hello"
+
+    def _extra_vim_config(self, vim_config):
+        sym = self._temp_dir.parent / (self._temp_dir.name + "_sym")
+        with contextlib.suppress(FileExistsError):
+            sym.symlink_to(self._temp_dir, target_is_directory=True)
+        vim_config.append(f"set runtimepath+={sym}")
+
+
+class DuplicateSnippets_DoesNotMergeDistinctTriggers(_VimTest):
+    # Two genuinely different snippets sharing a trigger from different
+    # filetypes must still produce the inputlist() prompt — the dedupe must
+    # only suppress copies of the *same* snippet definition.
+    files = {
+        "us/a.snippets": r"""
+        snippet hi "Greeting from a"
+        from_a
+        endsnippet
+        """,
+        "us/b.snippets": r"""
+        extends a
+        snippet hi "Greeting from b"
+        from_b
+        endsnippet
+        """,
+    }
+    keys = ESC + ":set ft=b\n" + "ihi" + EX + "2\n"
+    wanted = "from_b"


### PR DESCRIPTION
The "Multiple matches" `inputlist()` prompt would appear showing two identical entries in two related setups:

- A runtimepath entry was reachable via both a real path and a symlink, so `find_all_snippet_files` returned two distinct strings pointing at the same file.
- The `<ft>_*.snippets` glob picked up a file whose stem (e.g. `tex_math`) was also referenced from an `extends` directive, so the same file was parsed once for the parent filetype and again for the extended filetype.

Canonicalize paths in `find_all_snippet_files` (matching the existing behavior of `find_snippet_files` and `_snipmate_files_for`) so symlinked duplicates collapse to a single entry, and dedupe snippets by `(trigger, location)` in `SnippetFileSource.get_snippets` so cross-filetype duplicates of the same definition are suppressed.

Also strip a `.snippets` suffix from `extends` arguments so the common `extends foo.snippets` mistake is treated as `extends foo`.

Fixes #1341.
Fixes #1519.
Fixes #1559.