### PR TITLE
Stabilize get_deep_extends iteration order

### DIFF
--- a/pythonx/UltiSnips/snippet/source/base.py
+++ b/pythonx/UltiSnips/snippet/source/base.py
@@ -12,7 +12,10 @@ class SnippetSource:
 
     def __init__(self):
         self._snippets = defaultdict(SnippetDictionary)
-        self._extends = defaultdict(set)
+        # dict-with-None-values gives us a set that preserves insertion order,
+        # which keeps `get_deep_extends` deterministic — see issue surfaced in
+        # `DuplicateSnippets_DoesNotMergeDistinctTriggers`.
+        self._extends = defaultdict(dict)
 
     def ensure(self, filetypes):
         """Ensures that snippets are loaded."""
@@ -76,20 +79,27 @@ class SnippetSource:
     def update_extends(self, child_ft, parent_fts):
         """Update the extending relation by given child filetype and its parent
         filetypes."""
-        self._extends[child_ft].update(parent_fts)
+        for ft in parent_fts:
+            self._extends[child_ft][ft] = None
 
     def get_deep_extends(self, base_filetypes):
-        """Get a list of filetypes that is either directed or indirected
-        extended by given base filetypes.
+        """Return the list of filetypes that is directly or transitively
+        extended by `base_filetypes`, including the base filetypes themselves.
 
-        Note that the returned list include the root filetype itself.
-
+        Iteration is BFS so base filetypes appear before their parents, and
+        among siblings the order is the insertion order of the `extends`
+        directives. A stable order matters: the "Multiple matches" prompt
+        and per-trigger priority resolution both walk this list, so two
+        Vim sessions must agree on which snippet is "first".
         """
-        seen = set(base_filetypes)
-        todo_fts = list(set(base_filetypes))
+        seen = {}  # dict gives us an order-preserving set
+        for ft in base_filetypes:
+            seen.setdefault(ft, None)
+        todo_fts = list(seen)
         while todo_fts:
-            todo_ft = todo_fts.pop()
-            unseen_extends = {ft for ft in self._extends[todo_ft] if ft not in seen}
-            seen.update(unseen_extends)
-            todo_fts.extend(unseen_extends)
-        return seen
+            todo_ft = todo_fts.pop(0)
+            for parent_ft in self._extends[todo_ft]:
+                if parent_ft not in seen:
+                    seen[parent_ft] = None
+                    todo_fts.append(parent_ft)
+        return list(seen)

--- a/test/test_DuplicateSnippets.py
+++ b/test/test_DuplicateSnippets.py
@@ -88,5 +88,7 @@ class DuplicateSnippets_DoesNotMergeDistinctTriggers(_VimTest):
         endsnippet
         """,
     }
+    # Buffer filetype `b` is listed first by `get_deep_extends`, so b's
+    # snippet appears as option 1 in the prompt and a's as option 2.
     keys = ESC + ":set ft=b\n" + "ihi" + EX + "2\n"
-    wanted = "from_b"
+    wanted = "from_a"


### PR DESCRIPTION
`SnippetSource.get_deep_extends` returned a `set`, whose iteration order depends on Python's hash randomization. That made the "Multiple matches" prompt show the same set of snippets in different orders across runs, which surfaced as a flaky `DuplicateSnippets_DoesNotMergeDistinctTriggers` in CI even though it passed locally.

Switch the deep-extends bookkeeping to a dict-as-ordered-set: BFS from the base filetypes outwards, with parents recorded in the order their `extends` directives mention them. Base filetypes come first, then their parents in declaration order. The Multiple matches prompt and per-trigger priority resolution are now deterministic.

Update the regression test's expected answer accordingly — option 2 now maps to the parent's snippet.