### PR TITLE
Fix tabstops drifting out of sync after edits in multi-line snippets

### DIFF
--- a/pythonx/UltiSnips/buffer_proxy.py
+++ b/pythonx/UltiSnips/buffer_proxy.py
@@ -192,7 +192,7 @@ class VimBufferProxy(vim_helper.VimBuffer):
             if len(change) != 5:
                 diff = Position(0, direction * len(change_text))
 
-            snippet._move(Position(line_number, column_number), diff)
+            snippet._move(pos, diff)
         elif pos >= snippet._end:
             return
         else:

--- a/pythonx/UltiSnips/buffer_proxy.py
+++ b/pythonx/UltiSnips/buffer_proxy.py
@@ -176,9 +176,14 @@ class VimBufferProxy(vim_helper.VimBuffer):
 
         change_type, line_number, column_number, change_text = change[0:4]
 
-        line_before = line_number <= self._snippets_stack[0]._start.line
-        column_before = column_number <= self._snippets_stack[0]._start.col
-        if line_before and column_before:
+        # Position comparison must be lexicographic on (line, col); the
+        # historical version compared line and column independently, which
+        # silently dropped any edit whose `column_number` >= `_end.col` —
+        # for a multi-line snippet whose end sits at the start of a line
+        # (`_end.col == 0`) that's *every* edit on an interior line.
+        snippet = self._snippets_stack[0]
+        pos = Position(line_number, column_number)
+        if pos <= snippet._start:
             direction = 1
             if change_type == "D":
                 direction = -1
@@ -187,13 +192,11 @@ class VimBufferProxy(vim_helper.VimBuffer):
             if len(change) != 5:
                 diff = Position(0, direction * len(change_text))
 
-            self._snippets_stack[0]._move(Position(line_number, column_number), diff)
+            snippet._move(Position(line_number, column_number), diff)
+        elif pos >= snippet._end:
+            return
         else:
-            if line_number > self._snippets_stack[0]._end.line:
-                return
-            if column_number >= self._snippets_stack[0]._end.col:
-                return
-            self._snippets_stack[0]._do_edit(change[0:4])
+            snippet._do_edit(change[0:4])
 
     def _disable_edits(self):
         """

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -400,6 +400,7 @@ class Issue193_AnonAddsLineInsideContainer(_VimTest):
     keys = "container" + EX + "x" + JF + JF + "y" + JF + "z"
     wanted = "A:EXTRA_x\n\nB:y\nC:z"
 
+
 # Regression test for #161 — typing `<Esc>O` immediately after expanding a
 # snippet used to race CursorMoved and bleed snippet text into the new line.
 # Fixed in passing by the listener-based edit-detection rewrite (#1613).

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -340,3 +340,62 @@ endsnippet
     }
     keys = "ott" + EX + ESC + ":bd!\n"
     wanted = ""
+
+
+# Regression tests for #1182 and #193 — `VimBufferProxy._apply_change`
+# used to compare line and column independently against the snippet's
+# end, dropping any edit whose column was >= the snippet's end column.
+# For a multi-line snippet whose end sits at the start of a line
+# (`_end.col == 0`, which is the common case) that's *every* edit on
+# an interior line. The downstream symptom: a `snip.buffer` mutation in
+# a `post_jump` action that runs inside an outer snippet leaves the
+# outer's text-object tree pointing at stale (line, col) coordinates,
+# producing garbled output and the appearance of tabstops "multiplying".
+
+
+class Issue1182_NestedDynamicTabstop(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        global !p
+        def create_row_placeholders(snip):
+            placeholders_amount = int(snip.buffer[snip.line].strip())
+            snip.buffer[snip.line] = ''
+            anon = ' & '.join(['$' + str(i + 1) for i in range(placeholders_amount)])
+            snip.expand_anon(anon)
+        endglobal
+
+        post_jump "create_row_placeholders(snip)"
+        snippet "tr(\d+)" "latex table row" r
+        `!p snip.rv = match.group(1)`
+        endsnippet
+
+        snippet "\[\[" "display math" r
+        \\begin{align*}
+            $1
+        \\end{align*}
+        $0
+        endsnippet
+        """
+    }
+    keys = "[[" + EX + "tr2" + EX + "a" + JF + "b"
+    wanted = "\\begin{align*}\na & b\n\\end{align*}\n"
+
+
+class Issue193_AnonAddsLineInsideContainer(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        global !p
+        def insert_extra(snip):
+            snip.expand_anon("EXTRA_$1\n")
+        endglobal
+
+        post_jump "if snip.tabstop == 1: insert_extra(snip)"
+        snippet container "container" b
+        A:${1}
+        B:${2}
+        C:${3}
+        endsnippet
+        """
+    }
+    keys = "container" + EX + "x" + JF + JF + "y" + JF + "z"
+    wanted = "A:EXTRA_x\n\nB:y\nC:z"


### PR DESCRIPTION
`VimBufferProxy._apply_change` decides whether a buffer edit lands before, inside, or after the active outer snippet by comparing the change position against the snippet's `_start` / `_end`. The old version compared the line and column axes independently:

```
if line_number > end.line: return
if column_number >= end.col: return
```

For a multi-line snippet whose end sits at the start of a line (`_end.col == 0` — i.e. any snippet that ends on its own line) the second check fires on *every* edit on an interior line because `column_number >= 0` is always true. The edit gets silently dropped, the outer snippet's text-object tree falls behind the actual buffer, and any subsequent operation writes at stale `(line, col)` coordinates. Downstream this surfaces as "tabstops multiplying" and stray characters bleeding into the buffer.

The same shape of bug existed in the corresponding "before the snippet" check — `line_number <= start.line AND column_number <= start.col` misclassified e.g. line 1 col 100 with start at (2, 0) as not-before.

Compare `(line, col)` as a single lexicographic `Position` instead. `<=` on the start side keeps the previous behaviour for an insertion exactly at the snippet start (it moves the snippet down so the inserted text ends up *before* the snippet).

Regression tests covering both reports added in `test/test_Fixes.py`.

Fixes #1182.
Fixes #193.