### PR TITLE
Don't reinterpret capture-group backslashes as case-switch escapes

### DIFF
--- a/pythonx/UltiSnips/text_objects/transformation.py
+++ b/pythonx/UltiSnips/text_objects/transformation.py
@@ -81,16 +81,20 @@ class _CleverReplace:
     def replace(self, match):
         """Replaces 'match' through the correct replacement string."""
         transformed = self._expression
-        # Replace all $? with capture groups
-        transformed = _DOLLAR.subn(lambda m: match.group(int(m.group(1))), transformed)[
-            0
-        ]
 
         # Shelter escaped backslashes (\\) so they are not consumed by
         # case-switch regexes (\l, \u, \U, \L) or whitespace escapes
         # (\n, \t, ...).  Restored before the final unescape() which
-        # turns \\ into a literal \.  GH #998, GH #1495.
+        # turns \\ into a literal \.  GH #998, GH #1495.  Capture-group
+        # content is sheltered the same way so backslashes from $1..$9
+        # aren't reinterpreted as escape sequences either.  GH #1444.
         _ESCAPED_BSLASH = "\x00"
+
+        def _expand_dollar(dollar_match):
+            group = match.group(int(dollar_match.group(1))) or ""
+            return group.replace("\\", _ESCAPED_BSLASH)
+
+        transformed = _DOLLAR.subn(_expand_dollar, transformed)[0]
         transformed = transformed.replace("\\\\", _ESCAPED_BSLASH)
 
         # Replace Case switches

--- a/test/test_SnippetActions.py
+++ b/test/test_SnippetActions.py
@@ -454,6 +454,8 @@ class SnippetActions_DoNotBreakCursorOnSingleLikeChange(_VimTest):
     }
     keys = "a" + EX + "123"
     wanted = "def123"
+
+
 # GH #1115: expand_anon called from post_jump must place the cursor at the
 # first tabstop *after* any leading literal text, not one column to its left.
 class SnippetActions_ExpandAnonLeadingTextBeforeTabstop(_VimTest):

--- a/test/test_Transformation.py
+++ b/test/test_Transformation.py
@@ -305,3 +305,17 @@ class Transformation_EscapedBackslashBeforeUppercaseU(_VimTest):
     snippets = ("test", r"$1 ${1/(.+)/\\u$1/}")
     keys = "test" + EX + "world"
     wanted = r"world \uworld"
+
+
+# GH #1444: Backslashes coming from a capture group ($1..$9) must stay
+# literal -- they must not be reinterpreted as case-switch escapes.
+class Transformation_BackslashInCaptureNotCaseSwitch(_VimTest):
+    snippets = ("test", r"$1 ${1/^(\\u)/$1aa/}")
+    keys = "test" + EX + r"\u"
+    wanted = r"\u \uaa"
+
+
+class Transformation_BackslashInCaptureNotLongCaseSwitch(_VimTest):
+    snippets = ("test", r"$1 ${1/^(.+)/$1aa/}")
+    keys = "test" + EX + r"\Uhi"
+    wanted = r"\Uhi \Uhiaa"


### PR DESCRIPTION
In transformation replacement strings, `\u`/`\l`/`\U`...`\E` are
case-switch directives.  Backslashes in `$N` capture-group content were
being passed through verbatim, so a captured `\u` was getting matched by
the case-switch regex after substitution -- e.g. `${1/^(\\u)/$1aa/}`
with $1 = `\u` produced `Aa` instead of `\uaa`.

Shelter capture-group backslashes with the same `\x00` sentinel that
already protects template-level `\\`.  After the case-switch pass, both
forms restore to `\\` and unescape to a literal `\`, so user-typed text
stays literal.

Fixes #1444.