### PR TITLE
Add regression tests for issues #1115 and #1510

### DIFF
--- a/test/test_Format.py
+++ b/test/test_Format.py
@@ -149,3 +149,23 @@ should wrap properlyafter
 startThis is a
 longersnippet that
 should wrap properlyend"""
+
+
+# GH #1510: auto-triggered snippet expands across a textwidth-induced wrap.
+# Trigger `mm` near column tw forces Vim to insert a newline mid-expansion;
+# the body `\( $1 \) $0` must come out intact, not corrupted into `\|)`.
+class _Tw79Base(_VimTest):
+    def _extra_vim_config(self, vim_config):
+        vim_config.append("set tw=79")
+        vim_config.append("set fo+=t")
+
+
+class FOAutoTriggerNearWrap_GH1510(_Tw79Base):
+    # Snippet body matches the user's `\\( $1 \\) $0` literally.  The parser
+    # turns each `\\` into a literal backslash, leaving the body `\( $1 \) $0`.
+    snippets = ("mm", r"\\( $1 \\) $0", "Inline Math", "wA")
+    # 78 chars of "x " padding plus "mm" → trigger fires at col 80, beyond tw.
+    # After expansion, "Y" goes into $1 and "Z" into $0; both must land in
+    # the snippet body, not get smeared into the surrounding `\(...\)`.
+    keys = "x " * 39 + "mm" + "Y" + JF + "Z"
+    wanted = ("x " * 39).rstrip() + "\n\\( Y \\) Z"

--- a/test/test_SnippetActions.py
+++ b/test/test_SnippetActions.py
@@ -454,3 +454,71 @@ class SnippetActions_DoNotBreakCursorOnSingleLikeChange(_VimTest):
     }
     keys = "a" + EX + "123"
     wanted = "def123"
+# GH #1115: expand_anon called from post_jump must place the cursor at the
+# first tabstop *after* any leading literal text, not one column to its left.
+class SnippetActions_ExpandAnonLeadingTextBeforeTabstop(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        global !p
+        def add_bullet(snip):
+            if snip.tabstop == 0:
+                snip.buffer[snip.line] = ''
+                snip.expand_anon('- $1')
+        endglobal
+
+        post_jump "add_bullet(snip)"
+        snippet bullet "" b
+        endsnippet
+        """
+    }
+    keys = "bullet" + EX + "X"
+    wanted = "- X"
+
+
+class SnippetActions_ExpandAnonLeadingTextBeforeTabstop_Multi(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        global !p
+        def add_bullets(snip):
+            if snip.tabstop == 0:
+                snip.buffer[snip.line] = ''
+                snip.expand_anon('- $1\n- $2\n- $3')
+        endglobal
+
+        post_jump "add_bullets(snip)"
+        snippet bullets "" b
+        endsnippet
+        """
+    }
+    keys = "bullets" + EX + "X" + JF + "Y" + JF + "Z"
+    wanted = "- X\n- Y\n- Z"
+
+
+# Mirror of the user's repro in GH #1115: regex trigger captures a digit,
+# the snippet body returns it via `!p snip.rv = match.group(1)` (so the
+# captured digit goes onto the current line), and post_jump expands an
+# anonymous snippet that builds N bullet points with leading `- ` text.
+class SnippetActions_ExpandAnonLeadingTextBeforeTabstop_AsInGH1115(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        global !p
+        def create_dotpoints(snip):
+            try:
+                amount = int(snip.buffer[snip.line].strip())
+            except:
+                amount = 1
+            snip.buffer[snip.line] = ''
+            body = ''
+            for i in range(amount):
+                body += '- $' + str(i+1) + '\n'
+            snip.expand_anon(body)
+        endglobal
+
+        post_jump "create_dotpoints(snip)"
+        snippet "stnd\.(\d?)" "Adds dot-points" br
+        `!p snip.rv = match.group(1)`
+        endsnippet
+        """
+    }
+    keys = "stnd.3" + EX + "A" + JF + "B" + JF + "C"
+    wanted = "- A\n- B\n- C\n"


### PR DESCRIPTION
Both bugs reproduce on the versions where they were reported but are no
longer reproducible on master -- they got swept up by the recent cursor
and expansion fixes.  Lock the working behavior down so it doesn't
regress.

#1115 — `expand_anon` cursor placement with leading literal text before
the first tabstop.  Three tests in `test/test_SnippetActions.py` cover
the simple, multi-tabstop, and exact-user-repro setups.

#1510 — auto-triggered LaTeX-style snippet `\\( $1 \\) $0` expanding
across a textwidth-induced line break at `tw=79`.  One test in
`test/test_Format.py` types `Y` into `$1` and `Z` into `$0` to assert
that the wrap happens but $1 and $0 still land at the right positions.

Closes #1115.
Closes #1510.