### PR TITLE
Document expand_anon's snippet-body parsing and pin the gotcha

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -1801,6 +1801,14 @@ Next variables and methods will be also defined in the action code scope:
 * 'snip.snippet_end' - (line, column) of end of the expanded snippet;
 * 'snip.expand_anon()' - alias for 'UltiSnips_Manager.expand_anon()';
 
+The argument to 'snip.expand_anon()' is parsed as a snippet body, not as
+literal text.  If it is built from arbitrary buffer content, the characters
+'`', '$' and '\' will be interpreted as shell/Python code, tabstops, or
+escape sequences -- usually not what you want.  Escape them first, e.g.: >
+
+    safe = text.replace('\\', '\\\\').replace('`', '\\`').replace('$', '\\$')
+    snip.expand_anon('> ' + safe)
+<
 Tabstop object has several useful properties:
 * 'start' - (line, column) of the starting position of the tabstop (also
   accessible as 'tabstop.line' and 'tabstop.col').

--- a/test/test_SnippetActions.py
+++ b/test/test_SnippetActions.py
@@ -454,3 +454,49 @@ class SnippetActions_DoNotBreakCursorOnSingleLikeChange(_VimTest):
     }
     keys = "a" + EX + "123"
     wanted = "def123"
+# GH #1281: `snip.expand_anon()` parses its argument as a snippet body, so
+# backticks/`$`/`\` from the buffer get interpreted as shell code / tabstops
+# / escape sequences.  This pins down the "unescaped" footgun behavior --
+# a pair of backticks becomes empty shell-code and gets swallowed.
+class SnippetActions_ExpandAnonReparsesBackticks_GH1281(_VimTest):
+    files = {
+        "us/all.snippets": """
+        global !p
+        def echo_line(snip):
+            if snip.tabstop == 0:
+                snip.expand_anon('> ' + snip.buffer[snip.line])
+        endglobal
+
+        post_jump "echo_line(snip)"
+        snippet bug "" w
+        endsnippet
+        """
+    }
+    keys = "test with ``quotes'' bug" + EX
+    # The `` pair becomes empty shell-code and disappears.
+    wanted = "test with ``quotes'' > test with quotes'' "
+
+
+# GH #1281: The documented workaround is to escape backticks/`$`/`\` before
+# passing arbitrary text in; this test pins the workaround down.
+class SnippetActions_ExpandAnonEscapeBufferText_GH1281(_VimTest):
+    files = {
+        "us/all.snippets": """
+        global !p
+        def echo_line(snip):
+            if snip.tabstop == 0:
+                text = snip.buffer[snip.line]
+                safe = text.replace('\\\\', '\\\\\\\\')
+                safe = safe.replace('`', '\\\\`').replace('$', '\\\\$')
+                snip.expand_anon('> ' + safe)
+        endglobal
+
+        post_jump "echo_line(snip)"
+        snippet bug "" w
+        endsnippet
+        """
+    }
+    keys = "test with ``quotes'' bug" + EX
+    wanted = "test with ``quotes'' > test with ``quotes'' "
+
+


### PR DESCRIPTION
`snip.expand_anon()` parses its argument as a snippet body, so backticks
start shell code, `$N` becomes a tabstop, and `\X` is an escape.  When
that argument is built from arbitrary buffer content (e.g. via
`snip.buffer[snip.line]`), characters like `` `` `` get swallowed as
empty shell-code -- which surprised the reporter of #1281.

Add a note to the post-jump-actions doc section showing how to escape
arbitrary text before passing it in.  Add two regression tests, one
pinning the unescaped footgun behavior and one pinning the documented
escape workaround.

Closes #1281.