### PR TITLE
Make `make lint` catch formatting drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,4 @@ format:
 
 lint:
 	uv run ruff check .
+	uv run ruff format --check .

--- a/test/test_SnippetActions.py
+++ b/test/test_SnippetActions.py
@@ -454,6 +454,8 @@ class SnippetActions_DoNotBreakCursorOnSingleLikeChange(_VimTest):
     }
     keys = "a" + EX + "123"
     wanted = "def123"
+
+
 # GH #1115: expand_anon called from post_jump must place the cursor at the
 # first tabstop *after* any leading literal text, not one column to its left.
 class SnippetActions_ExpandAnonLeadingTextBeforeTabstop(_VimTest):


### PR DESCRIPTION
`make lint` ran `ruff check` but not `ruff format --check`, so PRs whose
files were formatted-different-but-otherwise-clean passed locally and
only blew up in CI -- which is what happened to #1643/#1644.  Add the
format check to the lint target and reformat the one file that was
already out of compliance on master.