### PR TITLE
Fix cursor attribution at zero-width tabstop seams

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -420,9 +420,7 @@ class SnippetManager:
         self._check_if_still_inside_snippet()
         if self._active_snippets:
             with self._change_provider.suppressed():
-                self._active_snippets[0].update_textobjects(
-                    vim_helper.buf, self._ctab
-                )
+                self._active_snippets[0].update_textobjects(vim_helper.buf, self._ctab)
                 self._vstate.remember_buffer(self._active_snippets[0])
 
     def _setup_inner_state(self):

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -420,7 +420,9 @@ class SnippetManager:
         self._check_if_still_inside_snippet()
         if self._active_snippets:
             with self._change_provider.suppressed():
-                self._active_snippets[0].update_textobjects(vim_helper.buf)
+                self._active_snippets[0].update_textobjects(
+                    vim_helper.buf, self._ctab
+                )
                 self._vstate.remember_buffer(self._active_snippets[0])
 
     def _setup_inner_state(self):
@@ -601,7 +603,9 @@ class SnippetManager:
                             self._visual_content.placeholder
                         )
                         self._should_reset_visual = False
-                        self._active_snippets[0].update_textobjects(vim_helper.buf)
+                        self._active_snippets[0].update_textobjects(
+                            vim_helper.buf, self._ctab
+                        )
                         # Open any folds this might have created
                         vim.command("normal! zv")
                         self._vstate.remember_buffer(self._active_snippets[0])

--- a/pythonx/UltiSnips/text_objects/base.py
+++ b/pythonx/UltiSnips/text_objects/base.py
@@ -125,6 +125,20 @@ class TextObject:
             return
         old_end = self._end
         self._end = _replace_text(buf, self._start, self._end, gtext)
+        # The _VimCursor sentinel (tiebreaker (-1, -1)) holds the absolute
+        # (line, col) where the user's cursor should land after this update
+        # cycle. When an interpolation overwrites a tabstop with a
+        # differently-shaped string (e.g. a `!p` block that swaps in a
+        # multi-line replacement), the cursor's old absolute position can
+        # fall outside the rewritten span and the next to_vim() clamps it
+        # to an unrelated cell. Pull cursor sentinels back to the new end
+        # so they sit on a valid coordinate; the test in
+        # PythonCode_CanOverwriteTabstop exercises this exact path.
+        if hasattr(self, "_children"):
+            for child in self._children:
+                if child._tiebreaker == Position(-1, -1):
+                    child._start = Position(self._end.line, self._end.col)
+                    child._end = Position(self._end.line, self._end.col)
         if self._parent:
             self._parent._child_has_moved(
                 self._parent._children.index(self),

--- a/pythonx/UltiSnips/text_objects/snippet_instance.py
+++ b/pythonx/UltiSnips/text_objects/snippet_instance.py
@@ -65,7 +65,7 @@ class SnippetInstance(EditableTextObject):
         for cmd in cmds:
             self._do_edit(cmd, ctab)
 
-    def update_textobjects(self, buf):
+    def update_textobjects(self, buf, ctab=None):
         """Update the text objects that should change automagically after the
         users edits have been replayed.
 
@@ -75,6 +75,17 @@ class SnippetInstance(EditableTextObject):
         done = set()
         not_done = set()
 
+        def _contains_ctab(obj):
+            """True if obj is ctab or one of its ancestors."""
+            if ctab is None:
+                return False
+            cur = ctab
+            while cur is not None:
+                if cur is obj:
+                    return True
+                cur = cur._parent
+            return False
+
         def _find_recursive(obj):
             """Finds all text objects and puts them into 'not_done'."""
             cursorInsideLowest = None
@@ -83,8 +94,26 @@ class SnippetInstance(EditableTextObject):
                     isinstance(obj, TabStop) and obj.number == 0
                 ):
                     cursorInsideLowest = obj
+                # Two siblings can both contain the cursor at a zero-width
+                # seam — e.g. `$1$2` immediately after expansion, or `$1$1$2`
+                # once `$1` has accumulated content and its mirror sits at
+                # the same column as the next tabstop. The last sibling
+                # would win the naive `or cursorInsideLowest` chain, but the
+                # currently-selected tabstop is where the user is editing,
+                # so prefer that branch. Without this, a mirror update
+                # inside the wrong sibling drags the cursor with it and
+                # subsequent typing falls outside any tabstop. See #1359.
+                preferred = None
+                fallback = cursorInsideLowest
                 for child in obj._children:
-                    cursorInsideLowest = _find_recursive(child) or cursorInsideLowest
+                    child_match = _find_recursive(child)
+                    if child_match is None:
+                        continue
+                    if _contains_ctab(child):
+                        preferred = child_match
+                    else:
+                        fallback = child_match
+                cursorInsideLowest = preferred or fallback
             not_done.add(obj)
             return cursorInsideLowest
 

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -438,3 +438,22 @@ class Issue168_VisualPlaceholderDoesNotShiftFollowingTabstop(_VimTest):
     }
     keys = "se" + EX + JF + "X"
     wanted = ",{\n  'AUTHOR': 'Williams',\n  'TEXT': 'X',\n}"
+
+
+# Regression test for #1359 — when adjacent zero-width tabstops/mirrors share
+# a position, typing into the active tabstop misattributed the cursor to the
+# trailing sibling. The mirror update then dragged the cursor with it, so
+# only the first character was mirrored and subsequent characters landed
+# in the wrong place (or outside any tabstop).
+
+
+class Issue1359_AdjacentMirrorTabstop_TypingMirrors(_VimTest):
+    snippets = ("test", "$1$1$2(some other things)$0")
+    keys = "test" + EX + "words"
+    wanted = "wordswords(some other things)"
+
+
+class Issue1359_AdjacentMirrorTabstop_JumpThenType(_VimTest):
+    snippets = ("test", "$1$1$2")
+    keys = "test" + EX + "hi" + JF + "x"
+    wanted = "hihix"


### PR DESCRIPTION
When adjacent zero-width tabstops or mirrors share a column, `_find_recursive` inside `update_textobjects` picked the *last* sibling whose `[start, end]` contains the cursor. For a snippet like `$1$1$2`, after typing the first character into `$1` the cursor sits at the seam between `$1` and its mirror — both spans contain it, and the mirror's later sibling `$2` wins the naive last-match chain. The cursor gets reattached to `$2`; the mirror update then inserts text and drags the cursor with it, so subsequent typing falls outside any tabstop and only the first character is mirrored.

Thread the currently-selected tabstop (`self._ctab`) through `SnippetInstance.update_textobjects`, and when `_find_recursive` finds more than one child containing the cursor, prefer the branch that contains the active tabstop. Single-match paths still pick the deepest container exactly as before.

Fixes #1359.
