### PR TITLE
Strip empty ${VISUAL} lines when the snippet has the m option

### DIFF
--- a/pythonx/UltiSnips/text_objects/visual.py
+++ b/pythonx/UltiSnips/text_objects/visual.py
@@ -59,7 +59,25 @@ class Visual(NoneditableTextObject, TextObjectTransformation):
             text = text[:-1]  # Strip final '\n'
 
         text = self._transform(text)
+        if self._snippet_has_m_option():
+            # The `m` option strips trailing whitespace from every line at
+            # launch, but ${VISUAL} content is materialized later in
+            # _update; the indent we just prepended to empty visual lines
+            # would survive as a bare-whitespace line. Match the `m`
+            # contract by rstripping each line of the substituted content.
+            # See #503.
+            text = "\n".join(line.rstrip() for line in text.split("\n"))
         self.overwrite(buf, text)
         self._parent._del_child(self)
 
         return True
+
+    def _snippet_has_m_option(self):
+        """Walk up to the containing SnippetInstance and check the `m` option."""
+        obj = self._parent
+        while obj is not None:
+            snippet = getattr(obj, "snippet", None)
+            if snippet is not None:
+                return snippet.has_option("m")
+            obj = obj._parent
+        return False

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -438,3 +438,24 @@ class Issue168_VisualPlaceholderDoesNotShiftFollowingTabstop(_VimTest):
     }
     keys = "se" + EX + JF + "X"
     wanted = ",{\n  'AUTHOR': 'Williams',\n  'TEXT': 'X',\n}"
+
+
+# Regression test for #503 — the `m` option strips trailing whitespace from
+# each line of the snippet at launch time, but ${VISUAL} replaces a single-
+# line placeholder with multi-line content during update_textobjects, so
+# the line-mode indent prepended to each new line was never stripped.
+# Empty visual lines came out as a bare indent string instead of an empty
+# line.
+
+
+class Issue503_MOptionStripsEmptyVisualLines(_VimTest):
+    snippets = ("test", "${VISUAL}", "", "m")
+    keys = (
+        "empty line in visual\n\nshould be empty"
+        + ESC
+        + "V2k"
+        + EX
+        + "\ttest"
+        + EX
+    )
+    wanted = "\tempty line in visual\n\n\tshould be empty"

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -450,12 +450,5 @@ class Issue168_VisualPlaceholderDoesNotShiftFollowingTabstop(_VimTest):
 
 class Issue503_MOptionStripsEmptyVisualLines(_VimTest):
     snippets = ("test", "${VISUAL}", "", "m")
-    keys = (
-        "empty line in visual\n\nshould be empty"
-        + ESC
-        + "V2k"
-        + EX
-        + "\ttest"
-        + EX
-    )
+    keys = "empty line in visual\n\nshould be empty" + ESC + "V2k" + EX + "\ttest" + EX
     wanted = "\tempty line in visual\n\n\tshould be empty"


### PR DESCRIPTION
The `m` option's documented behaviour is "remove all whitespace at the end of the lines of the snippet". The rstrip runs at snippet launch time in `SnippetDefinition.launch`, but `${VISUAL}` is only a placeholder at launch — its real content is rendered later inside `Visual._update`. For line-mode visual selections that renderer prepends the snippet's indent to every non-first line, so an empty visual line comes out as a bare-indent line and the launch-time rstrip never sees it.

In `Visual._update`, walk up the text-object chain to the containing `SnippetInstance`; if the snippet carries the `m` option, rstrip each line of the substituted text.

**Scope: why only `${VISUAL}`?** There is a structural difference between Visual and the other interpolations (mirrors, `!p`, `` ` ` ``, `!v`, transformations). For `${VISUAL}` in line mode the trailing whitespace on empty lines is *UltiSnips-generated* — the renderer prepends an indent that the user did not author. For `!p` / `` ` ` `` / `!v` / mirrors / transforms the trailing whitespace, if any, is *user-authored* in the snippet's `!p` code or in the upstream tabstop's text. Stripping the former is uncontroversial (it is a rendering artefact); stripping the latter is a behaviour change that would surprise users whose `!p` blocks intentionally emit trailing spaces. A strict reading of the docs argues for stripping every interpolation's output and is worth discussing in a follow-up issue, but it does not belong in the fix for the concrete `${VISUAL}` bug reported here.

Fixes #503.
