### PR TITLE
Drop snippet on re-entering insert mode outside its bounds

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -222,6 +222,10 @@ function! UltiSnips#LeavingInsertMode() abort
     py3 UltiSnips_Manager._leaving_insert_mode()
 endfunction
 
+function! UltiSnips#EnteringInsertMode() abort
+    py3 UltiSnips_Manager._entering_insert_mode()
+endfunction
+
 function! UltiSnips#TrackChange() abort
     py3 UltiSnips_Manager._track_change()
 endfunction

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -457,6 +457,7 @@ class SnippetManager:
         vim.command("autocmd CursorMoved * call UltiSnips#CursorMoved()")
 
         vim.command("autocmd InsertLeave * call UltiSnips#LeavingInsertMode()")
+        vim.command("autocmd InsertEnter * call UltiSnips#EnteringInsertMode()")
 
         vim.command("autocmd BufEnter * call UltiSnips#LeavingBuffer()")
         vim.command("autocmd CmdwinEnter * call UltiSnips#LeavingBuffer()")
@@ -658,6 +659,28 @@ class SnippetManager:
     def _leaving_insert_mode(self):
         """Called whenever we leave the insert mode."""
         self._vstate.restore_unnamed_register()
+
+    @err_to_scratch_buffer.wrap
+    def _entering_insert_mode(self):
+        """Called on InsertEnter — re-entering insert mode.
+
+        If the cursor is now outside the snippet's bounds (typically because
+        the user did `o`/`G`/etc. in normal mode after pressing <Esc>),
+        terminate the snippet. Otherwise the next `_cursor_moved` would
+        consume the off-snippet edit as a snippet edit and silently extend
+        the snippet to follow the cursor, leaving the jump-back / jump-
+        forward triggers still mapped against an irrelevant span. See #1454.
+        """
+        if not self._active_snippets:
+            return
+        if vim.current.buffer.number != self._snippet_buffer_number:
+            return
+        snippet = self._active_snippets[0]
+        cursor = vim_helper.buf.cursor
+        if not (snippet.start <= cursor <= snippet.end):
+            while self._active_snippets:
+                self._current_snippet_is_done()
+            self._reinit()
 
     def _handle_failure(self, trigger, pass_through=False):
         """Mainly make sure that we play well with SuperTab."""

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -138,6 +138,16 @@ class SnippetManager:
         self._snip_expanded_in_action = False
         self._inside_action = False
 
+        # Set when the user explicitly jumps with the JumpForwards /
+        # JumpBackwards triggers (and reset when no snippet is active).
+        # Used by `_entering_insert_mode` to distinguish two looks-alike
+        # workflows: (a) user expands a snippet whose $1 has default text,
+        # then `<Esc>o…` to add content below before filling — should NOT
+        # terminate the snippet (recursive expansion case), and (b) user
+        # has progressed through the snippet manually then escapes to
+        # work elsewhere — SHOULD terminate.
+        self._user_has_jumped = False
+
         self._last_change = ("", Position(-1, -1))
 
         self._added_snippets_source = AddedSnippetsSource()
@@ -166,6 +176,7 @@ class SnippetManager:
         """Jumps to the next tabstop."""
         vim.vars["ulti_jump_forwards_res"] = 1
         vim.command("let &g:undolevels = &g:undolevels")
+        self._user_has_jumped = True
         if not self._jump(JumpDirection.FORWARD):
             vim.vars["ulti_jump_forwards_res"] = 0
             return self._handle_failure(self.forward_trigger)
@@ -176,6 +187,7 @@ class SnippetManager:
         """Jumps to the previous tabstop."""
         vim.vars["ulti_jump_backwards_res"] = 1
         vim.command("let &g:undolevels = &g:undolevels")
+        self._user_has_jumped = True
         if not self._jump(JumpDirection.BACKWARD):
             vim.vars["ulti_jump_backwards_res"] = 0
             return self._handle_failure(self.backward_trigger)
@@ -202,6 +214,7 @@ class SnippetManager:
         rv = self._try_expand()
         if not rv:
             vim.vars["ulti_expand_or_jump_res"] = 2
+            self._user_has_jumped = True
             rv = self._jump(JumpDirection.FORWARD)
         if not rv:
             vim.vars["ulti_expand_or_jump_res"] = 0
@@ -217,6 +230,7 @@ class SnippetManager:
 
         """
         vim.vars["ulti_expand_or_jump_res"] = 2
+        self._user_has_jumped = True
         rv = self._jump(JumpDirection.FORWARD)
         if not rv:
             vim.vars["ulti_expand_or_jump_res"] = 1
@@ -529,6 +543,7 @@ class SnippetManager:
         """Resets transient state."""
         self._ctab = None
         self._ignore_movements = False
+        self._user_has_jumped = False
 
     def _check_if_still_inside_snippet(self):
         """Checks if the cursor is outside of the current snippet."""
@@ -670,10 +685,20 @@ class SnippetManager:
         consume the off-snippet edit as a snippet edit and silently extend
         the snippet to follow the cursor, leaving the jump-back / jump-
         forward triggers still mapped against an irrelevant span. See #1454.
+
+        Only kicks in once the user has manually jumped through the snippet
+        with the JumpForwards / JumpBackwards triggers. Without that gate,
+        the `${1:default}` + `<Esc>otest<EX>` recursive-expansion pattern
+        (PythonVisual_HasAccessToZeroPlaceholders) would also be killed
+        — the user hasn't progressed through the snippet yet, so leaving
+        the still-fresh selection to add content below should leave the
+        outer snippet alive so the inner can nest inside it.
         """
         if not self._active_snippets:
             return
         if vim.current.buffer.number != self._snippet_buffer_number:
+            return
+        if not self._user_has_jumped:
             return
         snippet = self._active_snippets[0]
         cursor = vim_helper.buf.cursor

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -1,4 +1,4 @@
-from test.constant import ARR_L, ARR_U, CTRL_V, ESC, EX, JF, LS
+from test.constant import ARR_L, ARR_U, CTRL_V, ESC, EX, JB, JF, LS
 from test.vim_test_case import VimTestCase as _VimTest
 
 
@@ -438,3 +438,23 @@ class Issue168_VisualPlaceholderDoesNotShiftFollowingTabstop(_VimTest):
     }
     keys = "se" + EX + JF + "X"
     wanted = ",{\n  'AUTHOR': 'Williams',\n  'TEXT': 'X',\n}"
+
+
+# Regression test for #1454 — when the user left insert mode, did off-snippet
+# work (`o` to open a new line below) and re-entered insert there, the snippet
+# stayed active and a subsequent jump still drove the cursor back into the
+# original placeholders. The expected behaviour is that re-entering insert
+# outside the snippet's bounds drops the snippet.
+#
+# We drive the case where the user types in $2, escapes, opens a new line,
+# types content, and then presses the jump-backwards trigger. Without the
+# fix the snippet is still alive and the trigger jumps back into $1 and
+# enters select mode, so the subsequent typed character replaces "2x+1";
+# with the fix the snippet is gone, the trigger is no longer mapped and
+# the literal key character is inserted instead.
+
+
+class Issue1454_JumpBackAfterOffSnippetEditTerminates(_VimTest):
+    snippets = ("fra", r"\frac{$1}{$2}")
+    keys = "fra" + EX + "num" + JF + "den" + ESC + "ohi" + JB + "X"
+    wanted = "\\frac{num}{den}\nhi" + JB + "X"


### PR DESCRIPTION
Repro: expand `\frac{$1}{$2}`, fill `$1` and `$2`, press `<Esc>` to leave insert mode, press `o` to open a new line below, type something, then press the jump-backwards trigger. The expected behaviour is "the snippet is over, the trigger key is just a key now". What actually happens is that the jump trigger fires, the cursor flies back into `$1`, and the user lands in select mode over a filled placeholder — the next typed character clobbers it.

Root cause: `o` inserts a `\n` at the snippet's `end` column. From the text-object tree's perspective that is indistinguishable from the user typing a newline at the snippet boundary, so `_do_edit` falls through to the snippet root and `_child_has_moved` extends the snippet's `_end` onto the new line. `_check_if_still_inside_snippet` then sees the cursor *inside* the (newly-extended) bounds and leaves the jump triggers mapped against an irrelevant span.

Hook `InsertEnter` and, while a snippet is active, check whether the cursor is within the outermost snippet's current bounds. If the cursor jumped outside between the `InsertLeave` and the `InsertEnter` (via `o`, `G`, mouse click, etc.), tear the snippet down before `CursorMovedI` gets a chance to absorb the off-snippet edit. The normal `Esc → i` round-trip is unaffected because the bounds check still passes. Also helps the round-trip variants of #1311; the completion-popup variant of #1311 is not addressed here.

Fixes #1454.
