### PR TITLE
Refuse to extend snippet past _end on fall-through insertions

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -222,10 +222,6 @@ function! UltiSnips#LeavingInsertMode() abort
     py3 UltiSnips_Manager._leaving_insert_mode()
 endfunction
 
-function! UltiSnips#EnteringInsertMode() abort
-    py3 UltiSnips_Manager._entering_insert_mode()
-endfunction
-
 function! UltiSnips#TrackChange() abort
     py3 UltiSnips_Manager._track_change()
 endfunction

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -722,10 +722,18 @@ class SnippetManager:
 
         def walk(obj):
             if isinstance(obj, TabStop):
+                # The tabstop's tracked end position can be ahead of the
+                # buffer when called from `InsertEnter` — the text-object
+                # tree only resyncs inside `_cursor_moved`. A select-mode
+                # `<BS>` (delete-selection + enter insert) fires
+                # InsertEnter before the deletion edit has been replayed,
+                # so reading `current_text` raises IndexError on Vim and
+                # `vim.error` (`NvimError`) on Neovim. Treat that as
+                # "not modified" — we'll re-evaluate on the next entry.
                 try:
                     if obj.current_text != obj._initial_text:
                         return True
-                except IndexError:
+                except (IndexError, vim_helper.error):
                     pass
             children = getattr(obj, "_children", None)
             if children is not None:

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -138,16 +138,6 @@ class SnippetManager:
         self._snip_expanded_in_action = False
         self._inside_action = False
 
-        # Set when the user explicitly jumps with the JumpForwards /
-        # JumpBackwards triggers (and reset when no snippet is active).
-        # Used by `_entering_insert_mode` to distinguish two looks-alike
-        # workflows: (a) user expands a snippet whose $1 has default text,
-        # then `<Esc>o…` to add content below before filling — should NOT
-        # terminate the snippet (recursive expansion case), and (b) user
-        # has progressed through the snippet manually then escapes to
-        # work elsewhere — SHOULD terminate.
-        self._user_has_jumped = False
-
         self._last_change = ("", Position(-1, -1))
 
         self._added_snippets_source = AddedSnippetsSource()
@@ -176,7 +166,6 @@ class SnippetManager:
         """Jumps to the next tabstop."""
         vim.vars["ulti_jump_forwards_res"] = 1
         vim.command("let &g:undolevels = &g:undolevels")
-        self._user_has_jumped = True
         if not self._jump(JumpDirection.FORWARD):
             vim.vars["ulti_jump_forwards_res"] = 0
             return self._handle_failure(self.forward_trigger)
@@ -187,7 +176,6 @@ class SnippetManager:
         """Jumps to the previous tabstop."""
         vim.vars["ulti_jump_backwards_res"] = 1
         vim.command("let &g:undolevels = &g:undolevels")
-        self._user_has_jumped = True
         if not self._jump(JumpDirection.BACKWARD):
             vim.vars["ulti_jump_backwards_res"] = 0
             return self._handle_failure(self.backward_trigger)
@@ -214,7 +202,6 @@ class SnippetManager:
         rv = self._try_expand()
         if not rv:
             vim.vars["ulti_expand_or_jump_res"] = 2
-            self._user_has_jumped = True
             rv = self._jump(JumpDirection.FORWARD)
         if not rv:
             vim.vars["ulti_expand_or_jump_res"] = 0
@@ -230,7 +217,6 @@ class SnippetManager:
 
         """
         vim.vars["ulti_expand_or_jump_res"] = 2
-        self._user_has_jumped = True
         rv = self._jump(JumpDirection.FORWARD)
         if not rv:
             vim.vars["ulti_expand_or_jump_res"] = 1
@@ -471,7 +457,6 @@ class SnippetManager:
         vim.command("autocmd CursorMoved * call UltiSnips#CursorMoved()")
 
         vim.command("autocmd InsertLeave * call UltiSnips#LeavingInsertMode()")
-        vim.command("autocmd InsertEnter * call UltiSnips#EnteringInsertMode()")
 
         vim.command("autocmd BufEnter * call UltiSnips#LeavingBuffer()")
         vim.command("autocmd CmdwinEnter * call UltiSnips#LeavingBuffer()")
@@ -543,7 +528,6 @@ class SnippetManager:
         """Resets transient state."""
         self._ctab = None
         self._ignore_movements = False
-        self._user_has_jumped = False
 
     def _check_if_still_inside_snippet(self):
         """Checks if the cursor is outside of the current snippet."""
@@ -676,73 +660,6 @@ class SnippetManager:
     def _leaving_insert_mode(self):
         """Called whenever we leave the insert mode."""
         self._vstate.restore_unnamed_register()
-
-    @err_to_scratch_buffer.wrap
-    def _entering_insert_mode(self):
-        """Called on InsertEnter — re-entering insert mode.
-
-        If the cursor is now outside the snippet's bounds (typically because
-        the user did `o`/`G`/etc. in normal mode after pressing <Esc>),
-        terminate the snippet. Otherwise the next `_cursor_moved` would
-        consume the off-snippet edit as a snippet edit and silently extend
-        the snippet to follow the cursor, leaving the jump-back / jump-
-        forward triggers still mapped against an irrelevant span. See #1454.
-
-        Only kicks in once the user has actually progressed through the
-        snippet — either by pressing a jump trigger (`_user_has_jumped`)
-        or by typing content into a tabstop (`_user_has_modified_snippet`).
-        The fresh-just-expanded-default-still-selected state is preserved
-        so the `${1:default}` + `<Esc>otest<EX>` recursive-expansion
-        pattern (PythonVisual_HasAccessToZeroPlaceholders) keeps working.
-        See #1311 (ei14 variant) for the typed-but-not-jumped case.
-        """
-        if not self._active_snippets:
-            return
-        if vim.current.buffer.number != self._snippet_buffer_number:
-            return
-        if not (self._user_has_jumped or self._user_has_modified_snippet()):
-            return
-        snippet = self._active_snippets[0]
-        cursor = vim_helper.buf.cursor
-        if not (snippet.start <= cursor <= snippet.end):
-            while self._active_snippets:
-                self._current_snippet_is_done()
-            self._reinit()
-
-    def _user_has_modified_snippet(self):
-        """Returns True when any tabstop's `current_text` differs from the
-        default it was instantiated with. Used by `_entering_insert_mode`
-        as a "user has actually edited the snippet" gate alongside
-        `_user_has_jumped`.
-        """
-        from UltiSnips.text_objects.tabstop import TabStop
-
-        if not self._active_snippets:
-            return False
-
-        def walk(obj):
-            if isinstance(obj, TabStop):
-                # The tabstop's tracked end position can be ahead of the
-                # buffer when called from `InsertEnter` — the text-object
-                # tree only resyncs inside `_cursor_moved`. A select-mode
-                # `<BS>` (delete-selection + enter insert) fires
-                # InsertEnter before the deletion edit has been replayed,
-                # so reading `current_text` raises IndexError on Vim and
-                # `vim.error` (`NvimError`) on Neovim. Treat that as
-                # "not modified" — we'll re-evaluate on the next entry.
-                try:
-                    if obj.current_text != obj._initial_text:
-                        return True
-                except (IndexError, vim_helper.error):
-                    pass
-            children = getattr(obj, "_children", None)
-            if children is not None:
-                for child in children:
-                    if walk(child):
-                        return True
-            return False
-
-        return walk(self._active_snippets[0])
 
     def _handle_failure(self, trigger, pass_through=False):
         """Mainly make sure that we play well with SuperTab."""

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -688,19 +688,19 @@ class SnippetManager:
         the snippet to follow the cursor, leaving the jump-back / jump-
         forward triggers still mapped against an irrelevant span. See #1454.
 
-        Only kicks in once the user has manually jumped through the snippet
-        with the JumpForwards / JumpBackwards triggers. Without that gate,
-        the `${1:default}` + `<Esc>otest<EX>` recursive-expansion pattern
-        (PythonVisual_HasAccessToZeroPlaceholders) would also be killed
-        — the user hasn't progressed through the snippet yet, so leaving
-        the still-fresh selection to add content below should leave the
-        outer snippet alive so the inner can nest inside it.
+        Only kicks in once the user has actually progressed through the
+        snippet — either by pressing a jump trigger (`_user_has_jumped`)
+        or by typing content into a tabstop (`_user_has_modified_snippet`).
+        The fresh-just-expanded-default-still-selected state is preserved
+        so the `${1:default}` + `<Esc>otest<EX>` recursive-expansion
+        pattern (PythonVisual_HasAccessToZeroPlaceholders) keeps working.
+        See #1311 (ei14 variant) for the typed-but-not-jumped case.
         """
         if not self._active_snippets:
             return
         if vim.current.buffer.number != self._snippet_buffer_number:
             return
-        if not self._user_has_jumped:
+        if not (self._user_has_jumped or self._user_has_modified_snippet()):
             return
         snippet = self._active_snippets[0]
         cursor = vim_helper.buf.cursor
@@ -708,6 +708,33 @@ class SnippetManager:
             while self._active_snippets:
                 self._current_snippet_is_done()
             self._reinit()
+
+    def _user_has_modified_snippet(self):
+        """Returns True when any tabstop's `current_text` differs from the
+        default it was instantiated with. Used by `_entering_insert_mode`
+        as a "user has actually edited the snippet" gate alongside
+        `_user_has_jumped`.
+        """
+        from UltiSnips.text_objects.tabstop import TabStop
+
+        if not self._active_snippets:
+            return False
+
+        def walk(obj):
+            if isinstance(obj, TabStop):
+                try:
+                    if obj.current_text != obj._initial_text:
+                        return True
+                except IndexError:
+                    pass
+            children = getattr(obj, "_children", None)
+            if children is not None:
+                for child in children:
+                    if walk(child):
+                        return True
+            return False
+
+        return walk(self._active_snippets[0])
 
     def _handle_failure(self, trigger, pass_through=False):
         """Mainly make sure that we play well with SuperTab."""

--- a/pythonx/UltiSnips/text_objects/base.py
+++ b/pythonx/UltiSnips/text_objects/base.py
@@ -280,6 +280,16 @@ class EditableTextObject(TextObject):
         for cidx, child in enumerate(self._children):
             if child._start < pivot <= child._end:
                 idx = cidx
+        # An insertion that landed at our `_end` and that no child took is
+        # the user typing past the snippet (typically `o` from normal
+        # mode, which queues an "I" of `\n` at end-of-line). Don't drag
+        # `_end` along; leave the snippet's bounds where they were so
+        # `_check_if_still_inside_snippet` observes the cursor outside
+        # them and terminates the snippet. We only do this at the
+        # outermost level (no parent EditableTextObject above us) — nested
+        # tabstop / snippet edits still need to propagate.
+        if ctype == "I" and idx == -1 and self._parent is None and pivot >= self._end:
+            return
         self._child_has_moved(idx, pivot, delta)
 
     def _move(self, pivot, diff):

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -442,16 +442,11 @@ class Issue168_VisualPlaceholderDoesNotShiftFollowingTabstop(_VimTest):
 
 # Regression test for #1454 — when the user left insert mode, did off-snippet
 # work (`o` to open a new line below) and re-entered insert there, the snippet
-# stayed active and a subsequent jump still drove the cursor back into the
-# original placeholders. The expected behaviour is that re-entering insert
-# outside the snippet's bounds drops the snippet.
-#
-# We drive the case where the user types in $2, escapes, opens a new line,
-# types content, and then presses the jump-backwards trigger. Without the
-# fix the snippet is still alive and the trigger jumps back into $1 and
-# enters select mode, so the subsequent typed character replaces "2x+1";
-# with the fix the snippet is gone, the trigger is no longer mapped and
-# the literal key character is inserted instead.
+# used to stay active. The `\n` queued by `o` lands at the snippet's `_end`,
+# and the fall-through path in `_do_edit` previously dragged `_end` onto the
+# new line — so `_check_if_still_inside_snippet` never noticed the cursor was
+# now outside. Refusing to extend `_end` on past-end fall-through restores
+# the natural "cursor outside ⇒ drop snippet" path.
 
 
 class Issue1454_JumpBackAfterOffSnippetEditTerminates(_VimTest):
@@ -497,11 +492,11 @@ class Issue503_MOptionStripsEmptyVisualLines(_VimTest):
 # type into $1, `<Esc>`, `o` to drop a new line below, then press the expand
 # trigger. With `g:UltiSnipsExpandTrigger == g:UltiSnipsJumpForwardTrigger`
 # (Tab mapped via `ExpandSnippetOrJump`), no snippet matches at the new-line
-# cursor, so the trigger falls through to `_jump` and yanks the cursor back
-# into the dead snippet — even though the user has moved to a different
-# line. #1648 only fired this termination once the user had pressed a jump
-# trigger; here the user only typed inside $1, which leaves the heuristic
-# blind. Extend it to count "user has typed into a tabstop" as progress.
+# cursor, so the trigger falls through to `_jump`. Same mechanism as #1454:
+# `o` queued a `\n` at end-of-snippet, fall-through used to drag the
+# snippet's `_end` onto the new line, the cursor-bounds check then saw the
+# cursor inside the (extended) snippet and `_jump` happily jumped back in.
+# Refusing to extend on past-end fall-through closes both.
 
 
 class Issue1311_PairTabAfterModeRoundTrip(_VimTest):

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -491,3 +491,27 @@ class Issue503_MOptionStripsEmptyVisualLines(_VimTest):
     snippets = ("test", "${VISUAL}", "", "m")
     keys = "empty line in visual\n\nshould be empty" + ESC + "V2k" + EX + "\ttest" + EX
     wanted = "\tempty line in visual\n\n\tshould be empty"
+
+
+# Regression test for the ei14 variant of #1311 — `pair` snippet `($1, $2)`,
+# type into $1, `<Esc>`, `o` to drop a new line below, then press the expand
+# trigger. With `g:UltiSnipsExpandTrigger == g:UltiSnipsJumpForwardTrigger`
+# (Tab mapped via `ExpandSnippetOrJump`), no snippet matches at the new-line
+# cursor, so the trigger falls through to `_jump` and yanks the cursor back
+# into the dead snippet — even though the user has moved to a different
+# line. #1648 only fired this termination once the user had pressed a jump
+# trigger; here the user only typed inside $1, which leaves the heuristic
+# blind. Extend it to count "user has typed into a tabstop" as progress.
+
+
+class Issue1311_PairTabAfterModeRoundTrip(_VimTest):
+    snippets = ("pair", "($1, $2)")
+    # Mirror the ei14 repro by mapping Tab to both expand and jump (the
+    # default when the two triggers are identical).
+    keys = "pair" + EX + "1" + ESC + "o" + EX
+    wanted = "(1, )\n" + EX
+
+    def _extra_vim_config(self, vim_config):
+        vim_config.append('let g:UltiSnipsExpandTrigger="<tab>"')
+        vim_config.append('let g:UltiSnipsJumpForwardTrigger="<tab>"')
+        vim_config.append('let g:UltiSnipsJumpBackwardTrigger="<s-tab>"')

--- a/test/test_Interpolation.py
+++ b/test/test_Interpolation.py
@@ -528,17 +528,6 @@ snip.rv = "placeholder: " + snip.p.current_text`)""",
 first second (placeholder: second)"""
 
 
-class PythonVisual_HasAccessToZeroPlaceholders(_VimTest):
-    snippets = (
-        "test",
-        """${1:first} ${2:second} (`!p
-snip.rv = "placeholder: " + snip.p.current_text`)""",
-    )
-    keys = "test" + EX + ESC + "otest" + EX + JF + JF + JF + JF
-    wanted = """first second (placeholder: first second (placeholder: ))
-first second (placeholder: )"""
-
-
 # Issue #1405: same pattern as PythonVisual_HasAccessToSelectedPlaceholders, but
 # with the !p block placed before the tabstops. The reporter claimed this
 # variant exposed a cursor / selection sync bug.


### PR DESCRIPTION
This changes behaviour: a `o` to add a new line after a snippet is now terminating the snippet; not extending it to the new line. We originally had this behaviour codified, so this changes this and hence is a breaking change in some way of looking at it. 

It reframes #1454's fix to address the underlying defect rather than working around it. #1648 hooked `InsertEnter` and terminated the snippet when the cursor had crossed its bounds on jump; the prior version of this PR layered a "user has typed in a tabstop" walk on top to catch ei14's #1311 variant. Both were compensating for the same root cause: when an insertion falls through `EditableTextObject._do_edit` (no child tabstop takes it) at the snippet's `_end`, the fall-through path calls `_child_has_moved` which unconditionally drags `_end` along with the edit — even though no semantic claim was being made on the new line.

That auto-extension is what hides `o` from `_check_if_still_inside_snippet`: the cursor ends up "inside" the freshly-extended bounds and the snippet stays alive, leaving the expand/jump triggers mapped against a span the user has already abandoned.

Fix at the source: in the fall-through path, when an insertion lands at or past `_end` with no child claiming it, leave `_end` where it was. The cursor sits outside the snippet's bounds, the existing `_check_if_still_inside_snippet` terminates the snippet on the next cursor-moved pass, and every "user moved out of the snippet" case takes the same path regardless of mode or how they got there. Restricted to the outermost level (`self._parent is None`) so nested tabstop/snippet propagation still works, which is the expected behaviour.

Removes `PythonVisual_HasAccessToZeroPlaceholders`. That test exercised an `ESC + o + nested expand` workflow that depended on the old auto-extension to land the inner snippet inside the outer's footprint, then asserted a specific cross-snippet `!p` re-evaluation shape that has no analogue in the new model. 

Regression tests for #1454 and the ei14 variant of #1311 keep their bodies but get rewritten docstrings describing the new mechanism.

Fixes #1311.