### PR TITLE
Reframe expand_anon docs around when escaping is needed

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -1801,14 +1801,20 @@ Next variables and methods will be also defined in the action code scope:
 * 'snip.snippet_end' - (line, column) of end of the expanded snippet;
 * 'snip.expand_anon()' - alias for 'UltiSnips_Manager.expand_anon()';
 
-The argument to 'snip.expand_anon()' is parsed as a snippet body, not as
-literal text.  If it is built from arbitrary buffer content, the characters
-'`', '$' and '\' will be interpreted as shell/Python code, tabstops, or
-escape sequences -- usually not what you want.  Escape them first, e.g.: >
+The argument to 'snip.expand_anon()' is parsed as a snippet body, so the full
+snippet DSL is available: backticks run shell code, '$N' creates tabstops, and
+'\X' is an escape sequence.  When the argument is built from arbitrary buffer
+content rather than authored as a snippet, escape those three characters so
+they survive as literal text, e.g.: >
 
-    safe = text.replace('\\', '\\\\').replace('`', '\\`').replace('$', '\\$')
+    safe = (text.replace('\\', '\\\\')
+                .replace('`',  '\\`')
+                .replace('$',  '\\$'))
     snip.expand_anon('> ' + safe)
 <
+The backslash replacement must come first; otherwise the backslashes
+introduced for '`' and '$' get escaped on a second pass.
+
 Tabstop object has several useful properties:
 * 'start' - (line, column) of the starting position of the tabstop (also
   accessible as 'tabstop.line' and 'tabstop.col').

--- a/test/test_SnippetActions.py
+++ b/test/test_SnippetActions.py
@@ -528,8 +528,9 @@ class SnippetActions_ExpandAnonLeadingTextBeforeTabstop_AsInGH1115(_VimTest):
 
 # GH #1281: `snip.expand_anon()` parses its argument as a snippet body, so
 # backticks/`$`/`\` from the buffer get interpreted as shell code / tabstops
-# / escape sequences.  This pins down the "unescaped" footgun behavior --
-# a pair of backticks becomes empty shell-code and gets swallowed.
+# / escape sequences -- the full DSL is intentionally available.  This pins
+# down what happens when arbitrary text is passed through unescaped: a pair
+# of backticks is read as an empty shell-code block and disappears.
 class SnippetActions_ExpandAnonReparsesBackticks_GH1281(_VimTest):
     files = {
         "us/all.snippets": """
@@ -545,12 +546,13 @@ class SnippetActions_ExpandAnonReparsesBackticks_GH1281(_VimTest):
         """
     }
     keys = "test with ``quotes'' bug" + EX
-    # The `` pair becomes empty shell-code and disappears.
+    # The `` pair is read as an empty shell-code block and disappears.
     wanted = "test with ``quotes'' > test with quotes'' "
 
 
-# GH #1281: The documented workaround is to escape backticks/`$`/`\` before
-# passing arbitrary text in; this test pins the workaround down.
+# GH #1281: When arbitrary buffer text is spliced into an `expand_anon`
+# argument, the DSL characters must be escaped first so they survive as
+# literal text; this test pins down the documented escape recipe.
 class SnippetActions_ExpandAnonEscapeBufferText_GH1281(_VimTest):
     files = {
         "us/all.snippets": """


### PR DESCRIPTION
The wording added in #1644 framed the DSL behavior (`` ` ``, `$`, `\`) as
"usually not what you want" — which understates that snippet authors
deliberately rely on it.  Reframe the note so the full DSL is presented as
the intended behavior of `expand_anon`, with escaping called out only for
the case where arbitrary buffer content is spliced into the argument.

Also note the backslash-first ordering requirement that was missing from
the earlier example.  Test comments are adjusted to match the new framing.

Follow-up to #1644 / #1281.