### PR TITLE
Pin down the snippets from autotrigger bug reports as regression tests

### DIFF
--- a/test/test_Issue1221.py
+++ b/test/test_Issue1221.py
@@ -23,7 +23,7 @@ class Issue1221_NoPopup_BeginExpands(_VimTest):
     files = {
         "us/all.snippets": "\n".join(
             [
-                "snippet \\begin \"begin{arg}\" bA",
+                'snippet \\begin "begin{arg}" bA',
                 r"\\begin\{${1}}",
                 "${0:${VISUAL}}",
                 r"\\end\{$1}",
@@ -39,7 +39,7 @@ class Issue1450_NoPopup_FracExpands(_VimTest):
     files = {
         "us/all.snippets": "\n".join(
             [
-                "snippet fra \"Frac\" wA",
+                'snippet fra "Frac" wA',
                 r"\frac{$1}{$2} $0",
                 "endsnippet",
             ]
@@ -56,7 +56,7 @@ class Issue1450_KeywordPopup_FracExpands(_VimTest):
     files = {
         "us/all.snippets": "\n".join(
             [
-                "snippet fra \"Frac\" wA",
+                'snippet fra "Frac" wA',
                 r"\frac{$1}{$2} $0",
                 "endsnippet",
             ]
@@ -74,7 +74,7 @@ class Issue1221_KeywordPopup_BeginExpands(_VimTest):
     files = {
         "us/all.snippets": "\n".join(
             [
-                "snippet \\begin \"begin{arg}\" bA",
+                'snippet \\begin "begin{arg}" bA',
                 r"\\begin\{${1}}",
                 "${0:${VISUAL}}",
                 r"\\end\{$1}",

--- a/test/test_Issue1221.py
+++ b/test/test_Issue1221.py
@@ -1,0 +1,90 @@
+"""Regression tests for autotrigger expansions with completion popup visible.
+
+Originally filed:
+- #1221: `\\begin` bA trigger with body starting `\\\\begin\\{$1}` —
+         reporter saw the `{` after `\\begin` eaten when YCM was loaded.
+- #1450: `fra` wA trigger with body `\\frac{$1}{$2} $0` —
+         reporter saw the trigger left untouched and the first chars of
+         the body missing when a completion plugin was active.
+
+Both reporters identified YCM as the catalyst. The popup-interaction class
+of bugs (queued buffer edits not applied before expand) was addressed by
+PR #1620 for the nested-snippet case. These tests pin down the top-level
+case for the exact snippet definitions in the issues, including the
+popup-visible variant via Vim's built-in keyword completion.
+"""
+
+from test.constant import COMPL_KW
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+# Baselines: no popup.
+class Issue1221_NoPopup_BeginExpands(_VimTest):
+    files = {
+        "us/all.snippets": "\n".join(
+            [
+                "snippet \\begin \"begin{arg}\" bA",
+                r"\\begin\{${1}}",
+                "${0:${VISUAL}}",
+                r"\\end\{$1}",
+                "endsnippet",
+            ]
+        )
+    }
+    keys = "\\begin"
+    wanted = "\\begin{}\n\n\\end{}"
+
+
+class Issue1450_NoPopup_FracExpands(_VimTest):
+    files = {
+        "us/all.snippets": "\n".join(
+            [
+                "snippet fra \"Frac\" wA",
+                r"\frac{$1}{$2} $0",
+                "endsnippet",
+            ]
+        )
+    }
+    keys = "fra"
+    wanted = r"\frac{}{} "
+
+
+# Popup-visible variants. Vim's built-in keyword completion stays visible
+# (completeopt=noinsert,noselect) while extra letters are typed; the iA
+# autotrigger fires with the popup still up.
+class Issue1450_KeywordPopup_FracExpands(_VimTest):
+    files = {
+        "us/all.snippets": "\n".join(
+            [
+                "snippet fra \"Frac\" wA",
+                r"\frac{$1}{$2} $0",
+                "endsnippet",
+            ]
+        )
+    }
+    text_before = "fraction fracture fractal --- some text before --- \n\n"
+    keys = COMPL_KW + "fra"
+    wanted = r"\frac{}{} "
+
+    def _extra_vim_config(self, vim_config):
+        vim_config.append("set completeopt=menu,menuone,noinsert,noselect")
+
+
+class Issue1221_KeywordPopup_BeginExpands(_VimTest):
+    files = {
+        "us/all.snippets": "\n".join(
+            [
+                "snippet \\begin \"begin{arg}\" bA",
+                r"\\begin\{${1}}",
+                "${0:${VISUAL}}",
+                r"\\end\{$1}",
+                "endsnippet",
+            ]
+        )
+    }
+    text_before = "\\beginning \\beginner \\begins --- some text before --- \n\n"
+    keys = COMPL_KW + "\\begin"
+    wanted = "\\begin{}\n\n\\end{}"
+
+    def _extra_vim_config(self, vim_config):
+        vim_config.append("set completeopt=menu,menuone,noinsert,noselect")

--- a/test/test_Issue903.py
+++ b/test/test_Issue903.py
@@ -22,7 +22,7 @@ class Issue903_FirstQuoteExpands(_VimTest):
     files = {
         "us/all.snippets": "\n".join(
             [
-                "snippet ' \"auto pair\" iA",
+                'snippet \' "auto pair" iA',
                 "'${1:${VISUAL}}'$0",
                 "endsnippet",
             ]
@@ -36,7 +36,7 @@ class Issue903_TabJumpsOutOfPair(_VimTest):
     files = {
         "us/all.snippets": "\n".join(
             [
-                "snippet ' \"auto pair\" iA",
+                'snippet \' "auto pair" iA',
                 "'${1:${VISUAL}}'$0",
                 "endsnippet",
             ]
@@ -53,7 +53,7 @@ class Issue903_SecondQuoteRetriggers(_VimTest):
     files = {
         "us/all.snippets": "\n".join(
             [
-                "snippet ' \"auto pair\" iA",
+                'snippet \' "auto pair" iA',
                 "'${1:${VISUAL}}'$0",
                 "endsnippet",
             ]

--- a/test/test_Issue903.py
+++ b/test/test_Issue903.py
@@ -1,0 +1,65 @@
+"""Reproducers for #903 — auto-pair quote with iA snippet.
+
+Snippet:
+    snippet ' "auto pair" iA
+        '${1:${VISUAL}}'$0
+    endsnippet
+
+Reporter wants:
+    '       -> '|'         (cursor between)
+    '<Tab>' -> ''|          (jump past second ', then type another ')
+
+But because the snippet is `iA` on trigger `'`, every `'` keystroke that
+lands at a word boundary re-triggers the snippet, so typing `'` after
+jumping out re-expands and the result is `''<cursor>'`.
+"""
+
+from test.constant import JF
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class Issue903_FirstQuoteExpands(_VimTest):
+    files = {
+        "us/all.snippets": "\n".join(
+            [
+                "snippet ' \"auto pair\" iA",
+                "'${1:${VISUAL}}'$0",
+                "endsnippet",
+            ]
+        )
+    }
+    keys = "'"
+    wanted = "''"
+
+
+class Issue903_TabJumpsOutOfPair(_VimTest):
+    files = {
+        "us/all.snippets": "\n".join(
+            [
+                "snippet ' \"auto pair\" iA",
+                "'${1:${VISUAL}}'$0",
+                "endsnippet",
+            ]
+        )
+    }
+    # Type `'` to expand; jump to $0; expand-or-jump should land at $0.
+    keys = "'" + JF
+    wanted = "''"
+
+
+# Demonstrates the reporter's gripe: a second `'` after jumping re-triggers
+# the iA snippet. This is unavoidable for a single-char iA trigger.
+class Issue903_SecondQuoteRetriggers(_VimTest):
+    files = {
+        "us/all.snippets": "\n".join(
+            [
+                "snippet ' \"auto pair\" iA",
+                "'${1:${VISUAL}}'$0",
+                "endsnippet",
+            ]
+        )
+    }
+    keys = "'" + JF + "'"
+    # The 2nd `'` lands at the $0 position (end of snippet). iA fires
+    # on the new `'`, producing another pair.
+    wanted = "''''"


### PR DESCRIPTION
The reports #1221, #1450, and #903 each describe autotrigger / autoexpand behaviour that we want to stay correct: the first two name YCM as the catalyst for the opening character of the body being eaten on an iA / bA / wA expansion; the third complains that a single-character `'` iA snippet re-triggers when the user types another `'` after jumping past the pair.

None of the three reproduce on current master with Vim's built-in keyword completion (or without any completion at all) in Vim or Neovim. The popup-interaction class of bugs was addressed by PR #1620 for the nested case, but the original snippets from these reports are not in the test suite, so a future refactor could regress them silently.

This adds `test/test_Issue1221.py` — the exact `\begin` and `fra` snippets from the two reports, run both without any popup and with the keyword-completion popup left open (`completeopt=menu,menuone,noinsert,noselect`). Both expand to the full body.

It also adds `test/test_Issue903.py` — the `'` iA pair snippet. First-quote expansion works, `<Tab>` jumps cleanly, and a second `'` re-triggers the snippet (giving four quotes) — this is the by-design behaviour the reporter ran into.

No production code changes.