### PR TITLE
Make post_jump and post_expand actions cooperate with cursor and expand_anon

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -819,6 +819,16 @@ class SnippetManager:
             self._visual_content.reset()
             self._active_snippets.append(snippet_instance)
 
+            # Park the cursor at the snippet's end before `post_expand`
+            # runs. Without this, the cursor sits wherever the buffer
+            # write left it — typically at the trigger's old position,
+            # which is *inside* the body for a non-empty snippet. Any
+            # `snip.expand_anon` in the action would then splice the
+            # anon body into the middle of ours instead of appending it
+            # cleanly. See #1434.
+            vim_helper.buf.cursor = Position(
+                snippet_instance.end.line, snippet_instance.end.col
+            )
             with (
                 use_proxy_buffer(
                     self._active_snippets, self._vstate, self._change_provider
@@ -834,7 +844,37 @@ class SnippetManager:
             self._vstate.remember_buffer(self._active_snippets[0])
             self._change_provider.reset()
 
+            # Three shapes show up here depending on which action
+            # nested another snippet via `snip.expand_anon`:
+            #
+            #   1. No nesting. `_active_snippets[-1]` is `snippet_instance`
+            #      (the snippet we just launched). Jump into our first
+            #      tabstop as usual.
+            #
+            #   2. `pre_expand` nested. The action ran *before* our
+            #      `launch`, so the inner snippet was appended first and
+            #      our own append put us on top of it. `_active_snippets[-1]`
+            #      is still `snippet_instance` — but `current_text` on the
+            #      outer reflects only our body, which is empty when the
+            #      user is wrapping content with an anon snippet, so the
+            #      old `_current_snippet.current_text != ""` branch
+            #      naturally pops the empty wrapper.
+            #
+            #   3. `post_expand` nested. The action ran *after* our
+            #      append, so the inner sits on top of us. The nested
+            #      `_do_snippet` already jumped to its own first tabstop;
+            #      a second jump here would skip it. Drop ourselves from
+            #      the stack so the inner is the live snippet.
             if (
+                self._snip_expanded_in_action
+                and self._active_snippets
+                and self._active_snippets[-1] is not snippet_instance
+            ):
+                # Shape 3 — post_expand nested an inner snippet.
+                self._active_snippets.remove(snippet_instance)
+                if not self._active_snippets:
+                    self._teardown_inner_state()
+            elif (
                 not self._snip_expanded_in_action
                 or self._current_snippet.current_text != ""
             ):

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -653,7 +653,18 @@ class SnippetManager:
                 snip_expanded_in_action = self._snip_expanded_in_action
 
             if move_cmd and not snip_expanded_in_action:
-                vim_helper.feedkeys(move_cmd)
+                # Rebuild `move_cmd` against `ntab`'s current
+                # positions. If the action edited the buffer the
+                # tabstop's start/end have already been shifted to
+                # follow; the string we captured before the action ran
+                # would now drive the cursor to the old offsets and the
+                # select-mode range would land in the wrong place. The
+                # rebuild also re-anchors the cursor at the new start,
+                # which is the intent when an action sets `snip.cursor`
+                # to mirror a buffer shift it made. See #1013.
+                move_cmd = vim_helper.select(ntab.start, ntab.end)
+                if move_cmd:
+                    vim_helper.feedkeys(move_cmd)
 
         return jumped
 

--- a/test/test_Issue1013.py
+++ b/test/test_Issue1013.py
@@ -1,0 +1,53 @@
+"""Regression test for #1013.
+
+`snip.cursor.set(...)` in a post_jump action is honoured when the target
+tabstop is empty, but is dropped when the target has default text — the
+select-mode coordinates are captured *before* the action runs and the
+action's cursor move is discarded.
+"""
+
+from test.constant import EX, JF
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class Issue1013_PostJumpCursorMoveHonouredWhenTargetHasDefault(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        global !p
+        def shift_cursor():
+            snip.buffer[snip.cursor[0]] = "prepended" + snip.buffer[snip.cursor[0]]
+            snip.cursor.set(snip.cursor[0], snip.cursor[1] + 9)
+        endglobal
+
+        post_jump "if snip.tabstop == 0: shift_cursor()"
+        snippet testdef
+        [${1}][${0:default}]
+        endsnippet
+        """
+    }
+    # Triggering and jumping to $0 should leave the placeholder "default"
+    # selected; the post_jump prepends 9 chars and adjusts the cursor by
+    # +9, so the select-mode range needs to shift accordingly.
+    keys = "testdef" + EX + JF + "REPLACED"
+    wanted = "prepended[][REPLACED]"
+
+
+class Issue1013_PostJumpCursorMoveOnEmptyTargetStillWorks(_VimTest):
+    """Control case — cursor.set on an empty $0 should keep working."""
+
+    files = {
+        "us/all.snippets": r"""
+        global !p
+        def shift_cursor():
+            snip.buffer[snip.cursor[0]] = "prepended" + snip.buffer[snip.cursor[0]]
+            snip.cursor.set(snip.cursor[0], snip.cursor[1] + 9)
+        endglobal
+
+        post_jump "if snip.tabstop == 0: shift_cursor()"
+        snippet testnodef
+        [${1}][${0}]
+        endsnippet
+        """
+    }
+    keys = "testnodef" + EX + JF
+    wanted = "prepended[][]"

--- a/test/test_Issue1243.py
+++ b/test/test_Issue1243.py
@@ -1,0 +1,36 @@
+"""Regression test for #1243.
+
+Reporter had a `2*2matrix` snippet whose `pre_expand` calls
+`snip.expand_anon` to generate a `\\begin{pmatrix}` body of the requested
+shape. At top level that worked, but typing the trigger inside another
+snippet's tabstop (e.g. inside the `equation` snippet's `$1`) returned
+out-of-order tabstops in the matrix.
+
+The simplified shape: an outer snippet with `$1/$0` and an inner snippet
+whose `pre_expand` builds a body with several tabstops via `expand_anon`.
+After expanding the outer and triggering the inner inside `$1`, jumping
+forward should walk through the inner's tabstops in order before
+returning to the outer's `$0`.
+"""
+
+from test.constant import EX, JF
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class Issue1243_NestedAnonExpandsTabstopsInOrder(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        snippet outer "outer" bA
+        OS
+        $1
+        OE
+        $0
+        endsnippet
+
+        pre_expand "snip.buffer[snip.line] = ''; snip.expand_anon('M\n\t$1 & $2\n\t$3 & $4\nE$0')"
+        snippet mtx "mtx" wA
+        endsnippet
+        """
+    }
+    keys = "outer" + EX + "mtx" + "1" + JF + "2" + JF + "3" + JF + "4" + JF + JF + "END"
+    wanted = "OS\nM\n\t1 & 2\n\t3 & 4\nE\nOE\nEND"

--- a/test/test_Issue1427.py
+++ b/test/test_Issue1427.py
@@ -1,0 +1,37 @@
+"""Regression test for #1427.
+
+After an undo unwinds the buffer state created by an expansion, the
+snippet must be considered finished. Reporter's repro at the time was
+that `_active_snippets` still held the (now stale) snippet, so the next
+`<Tab>` ran the post_jump action — and the `snip.expand_anon('aaa')`
+inside it dropped the literal `aaa` into a buffer that, to the user,
+had no snippet in it.
+
+The fix in #1648 ("Drop snippet on re-entering insert mode outside its
+bounds") closes this hole: the `i` after the `dd` re-enters insert mode
+on a different line than the snippet was tracking, the snippet is dropped,
+and the subsequent `<Tab>` is a plain tab.
+"""
+
+from test.constant import ESC, EX
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class Issue1427_TabAfterUndoIsLiteralTab(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        post_jump "snip.expand_anon('aaa')"
+        snippet sn "description"
+        A $1 B
+        endsnippet
+        """
+    }
+    # sn<TAB>             expand
+    # <Esc>               leave insert; cursor leaves snippet bounds
+    # u                   undo unwinds the buffer state
+    # i                   re-enter insert mode on a now-empty line; the
+    #                     snippet must be dropped here
+    # <TAB>               tab must be a literal tab, NOT a jump that
+    #                     fires the post_jump action and drops `aaa`.
+    keys = "sn" + EX + ESC + "u" + "o" + EX
+    wanted = "sn\n\t"

--- a/test/test_Issue1434.py
+++ b/test/test_Issue1434.py
@@ -1,0 +1,58 @@
+"""Regression tests for #1434.
+
+Three sub-bugs with `snip.expand_anon` called from snippet actions:
+
+  1. post_expand on an EMPTY outer snippet: anon's first tabstop is
+     skipped — Vim lands directly on $2.
+  2. post_expand on a NON-EMPTY outer snippet: anon's first tabstop is
+     skipped AND the body is split across the outer snippet's text.
+  3. post_jump on an EMPTY outer snippet: cursor lands one column to the
+     left of where it should after expand_anon.
+"""
+
+from test.constant import EX, JF
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class Issue1434_PostExpandAnonOnEmptySnippet(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        post_expand "snip.expand_anon('1:$1;2:$2;')"
+        snippet aa "description"
+        endsnippet
+        """
+    }
+    # Trigger the empty snippet; the post_expand should drop in
+    # `1:$1;2:$2;` and select $1 first. Typing `A` lands in $1.
+    keys = "aa" + EX + "A" + JF + "B"
+    wanted = "1:A;2:B;"
+
+
+class Issue1434_PostExpandAnonOnNonEmptySnippet(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        post_expand "snip.expand_anon('1:$1;2:$2;')"
+        snippet aa "description"
+        XXYY
+        endsnippet
+        """
+    }
+    keys = "aa" + EX + "A" + JF + "B"
+    # The anon snippet should land *after* XXYY (or wherever the outer
+    # snippet's cursor parked), not split through the middle of it.
+    wanted = "XXYY1:A;2:B;"
+
+
+class Issue1434_PostJumpAnonOnEmptySnippet(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        post_jump "snip.expand_anon('1:$1;2:$2;')"
+        snippet aa "description"
+        endsnippet
+        """
+    }
+    # Empty outer snippet: pressing Tab fires post_jump → expand_anon.
+    # The anon should put us at $1 and typing `A` should land between
+    # `1:` and `;` cleanly.
+    keys = "aa" + EX + "A" + JF + "B"
+    wanted = "1:A;2:B;"

--- a/test/test_Issue1579.py
+++ b/test/test_Issue1579.py
@@ -1,0 +1,26 @@
+"""Documentation test for #1579 example 1.
+
+The reporter wants `$N` in the outer body to mirror `$N` in a
+pre_expand-created inner anon snippet. UltiSnips never has — each
+call to `expand_anon` is its own snippet with its own tabstop
+namespace; the outer's $1 and the inner's $1 are unrelated objects.
+Jumping fills them in nesting order, not by index.
+
+Pinning the observable behaviour so it can't drift silently.
+"""
+
+from test.constant import EX, JF
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class Issue1579_TabstopNamespacesAreIndependent(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        pre_expand "snip.buffer[snip.line] = ''; snip.expand_anon('[$1][$2]')"
+        snippet try "try"
+        ($1)($2)
+        endsnippet
+        """
+    }
+    keys = "try" + EX + "A" + JF + "B" + JF + "C" + JF + "D"
+    wanted = "[(A)(B)C][D]"


### PR DESCRIPTION
#1013 — `post_jump` actions that move the cursor (`snip.cursor.set(...)`) or edit the buffer used to be silent no-ops when the target tabstop carried default text. The select-mode keys that drive the visual selection were captured *before* the action ran, so even when the tabstop's start/end shifted to follow a buffer edit, the queued keys still picked out the old offsets. Rebuild the move command from `ntab`'s current positions right before feeding it.

#1434 — `snip.expand_anon` called from a `post_expand` action produced two distinct broken shapes. First, the cursor sits wherever the buffer write left it after `launch`, which is *inside* a non-empty body; the anon body got spliced into the middle. Second, when the action did nest a snippet the resulting stack is `[outer, inner]`, and the old logic checked `_current_snippet.current_text` — the inner's text, always non-empty — so it always jumped again, skipping the inner's first tabstop. Park the cursor at `snippet_instance.end` before the action runs, and detect the post-expand-nested shape by stack identity so we cleanly remove the wrapper outer instead.

The `pre_expand` nesting case still goes through the original `_current_snippet.current_text` branch — there the outer is on top of the inner and the check refers to the outer, which is what we want; the existing `SnippetActions_CanExpandAnonOnPreExpand` family stays green.

Also pinning three siblings as regression tests; they turn out to be already-fixed or by-design and will be closed by hand with pointers to this PR:

- #1427: closed by #1648's drop-on-insert-re-entry-outside-bounds change.
- #1243: the reporter's matrix-in-equation tab-order bug doesn't reproduce on master (likely fixed by #1620 + this branch's expand_anon-from-post_expand fix). Pinned as a small outer/inner repro.
- #1579: each `expand_anon` call is its own snippet with its own tabstop namespace; the outer's $1 and an inner anon's $1 are independent. Pinned the observable order.

Fixes #1013.
Fixes #1434.