### PR TITLE
Cancel snippet selection when inputlist() answer is out of range

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -40,8 +40,13 @@ def _ask_user(a, formatted):
         if rv is None or rv == "0":
             return None
         rv = int(rv)
-        if rv > len(a):
-            rv = len(a)
+        # Vim's inputlist() returns -1 when the user clicks outside the menu,
+        # and may return values outside `1..len(a)` when the user types a
+        # number that doesn't correspond to a listed snippet (e.g. by clicking
+        # the prompt line below the list). Treat any out-of-range answer as a
+        # cancellation rather than picking an arbitrary entry.
+        if rv < 1 or rv > len(a):
+            return None
         return a[rv - 1]
     except vim_helper.error:
         # Likely "invalid expression", but might be translated. We have no way

--- a/test/test_ListSnippets.py
+++ b/test/test_ListSnippets.py
@@ -54,3 +54,12 @@ class ListAllAvailable_InWordWithPrefix_ExpectCorrectResult(_VimTest):
     snippets = (("exists", "exists('${1}')", "exists check", "i"),)
     keys = "!exists" + LS + "1\n"
     wanted = "!exists('')"
+
+
+# GH #1226: a number larger than the list length used to be clamped to
+# the last item, silently picking a snippet the user didn't choose (and a
+# negative answer from a mouse click above the menu could IndexError).
+# Treat any out-of-range answer as a cancellation.
+class ListAllAvailable_OutOfRangeAnswer_Cancels(_ListAllSnippets):
+    keys = "hallo test" + LS + "99\n"
+    wanted = "hallo test"

--- a/test/test_MultipleMatches.py
+++ b/test/test_MultipleMatches.py
@@ -19,9 +19,12 @@ class Multiple_SimpleCaseSelectSecond_ECR(_MultipleMatches):
     wanted = "Case2"
 
 
-class Multiple_SimpleCaseSelectTooHigh_ESelectLast(_MultipleMatches):
-    keys = "test" + EX + "5\n"
-    wanted = "Case2"
+# GH #1226: an inputlist() answer larger than the list used to be clamped to
+# the last entry (silently picking a snippet the user didn't choose).
+# Out-of-range answers now cancel, like every other invalid input.
+class Multiple_SimpleCaseSelectTooHigh_Cancels(_MultipleMatches):
+    keys = "test" + EX + "5\n" + "hi"
+    wanted = "testhi"
 
 
 class Multiple_SimpleCaseSelectZero_EEscape(_MultipleMatches):


### PR DESCRIPTION
Vim's `inputlist()` can return -1 (clicking outside the menu) or a value larger than the snippet list (typed too-large number, or clicking the prompt line below the list). The previous code clamped values above `len(snippets)` to the last item - silently selecting a snippet the user did not pick - and indexed negative values directly, which `IndexError`ed for clicks above the menu.

Treat any answer outside `[1, len(snippets)]` as a cancellation.

Fixes #1226