### PR TITLE
Fix ExpandPossibleShorterSnippet doc example so it expands without a trailing space

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -478,14 +478,19 @@ Another example on how to use this function consider the following function
 and mapping definition:
 
 function! ExpandPossibleShorterSnippet()
-  if len(UltiSnips#SnippetsInCurrentScope()) == 1 "only one candidate...
-    let curr_key = keys(UltiSnips#SnippetsInCurrentScope())[0]
-    normal diw
-    exe "normal a" . curr_key
-    exe "normal a "
-    return 1
+  let snippets = UltiSnips#SnippetsInCurrentScope()
+  if len(snippets) != 1
+    return 0
   endif
-  return 0
+  let trigger = keys(snippets)[0]
+  let [lnum, col] = [line('.'), col('.') - 1]
+  let line = getline(lnum)
+  let prefix_len = strlen(matchstr(strpart(line, 0, col), '\k*$'))
+  let head = strpart(line, 0, col - prefix_len)
+  let tail = strpart(line, col)
+  call setline(lnum, head . trigger . tail)
+  call cursor(lnum, strlen(head . trigger) + 1)
+  return 1
 endfunction
 inoremap <silent> <C-L> <C-R>=(ExpandPossibleShorterSnippet() == 0? '': UltiSnips#ExpandSnippet())<CR>
 

--- a/test/test_ExpandPossibleShorterSnippet.py
+++ b/test/test_ExpandPossibleShorterSnippet.py
@@ -1,0 +1,58 @@
+"""Regression test for the `ExpandPossibleShorterSnippet` example in
+`:help UltiSnips#SnippetsInCurrentScope` (GH #951).
+
+If a user copies the example verbatim, typing the shortened prefix should
+expand the matching snippet with no extra characters appended.
+"""
+
+from test.constant import EX
+from test.vim_test_case import VimTestCase as _VimTest
+
+EXPAND_SHORTER = chr(12)  # C-L, the keybinding the docs use.
+
+
+class _ShorterSnippetBase(_VimTest):
+    snippets = (("lorem", "Lorem ipsum dolor", "lorem ipsum"),)
+
+    def _extra_vim_config(self, vim_config):
+        vim_config.extend(
+            [
+                "function! ExpandPossibleShorterSnippet()",
+                "  let snippets = UltiSnips#SnippetsInCurrentScope()",
+                "  if len(snippets) != 1",
+                "    return 0",
+                "  endif",
+                "  let trigger = keys(snippets)[0]",
+                "  let [lnum, col] = [line('.'), col('.') - 1]",
+                "  let line = getline(lnum)",
+                "  let prefix_len = strlen(matchstr(strpart(line, 0, col), '\\k*$'))",
+                "  let head = strpart(line, 0, col - prefix_len)",
+                "  let tail = strpart(line, col)",
+                "  call setline(lnum, head . trigger . tail)",
+                "  call cursor(lnum, strlen(head . trigger) + 1)",
+                "  return 1",
+                "endfunction",
+                "inoremap <silent> <C-L> <C-R>=(ExpandPossibleShorterSnippet() == 0? '': UltiSnips#ExpandSnippet())<CR>",
+            ]
+        )
+
+
+class ShorterSnippet_Expands_NoTrailingSpace(_ShorterSnippetBase):
+    keys = "lor" + EXPAND_SHORTER
+    wanted = "Lorem ipsum dolor"
+
+
+class ShorterSnippet_ExpandsAfterText(_ShorterSnippetBase):
+    keys = "hello lo" + EXPAND_SHORTER
+    wanted = "hello Lorem ipsum dolor"
+
+
+class ShorterSnippet_NoExpand_WhenMultipleMatches(_VimTest):
+    snippets = (
+        ("lorem", "Lorem ipsum dolor", "lorem"),
+        ("login", "user.login()", "login"),
+    )
+    keys = "lo" + EXPAND_SHORTER
+    wanted = "lo"
+
+    _extra_vim_config = _ShorterSnippetBase._extra_vim_config

--- a/test/test_ExpandPossibleShorterSnippet.py
+++ b/test/test_ExpandPossibleShorterSnippet.py
@@ -5,7 +5,6 @@ If a user copies the example verbatim, typing the shortened prefix should
 expand the matching snippet with no extra characters appended.
 """
 
-from test.constant import EX
 from test.vim_test_case import VimTestCase as _VimTest
 
 EXPAND_SHORTER = chr(12)  # C-L, the keybinding the docs use.


### PR DESCRIPTION
The `:help UltiSnips#SnippetsInCurrentScope` example asked users to copy a `:normal diw` + `:normal a<trigger>` + `:normal a ` sequence. The trailing `:normal a ` was there to land the cursor where `UltiSnips#ExpandSnippet()` would recognise the trigger, but the space then survived the expansion and ended up in the buffer (#951).

Dropping the trailing-space line on its own does not work either: after `:normal a<trigger>`, the cursor lands on the last character of the trigger, so `line_till_cursor` is one byte short, the snippet does not match, and the fall-through inserts a literal Tab.

Replace the example with a `setline`/`cursor` implementation that edits the line directly and places the cursor past the trigger. Add an integration test that runs the documented snippet end-to-end so the example cannot silently regress.

Fixes #951