### PR TITLE
Keep snip.mkline indented when the result is built in one expression

### DIFF
--- a/pythonx/UltiSnips/text_objects/python_code.py
+++ b/pythonx/UltiSnips/text_objects/python_code.py
@@ -82,6 +82,7 @@ class SnippetUtil:
         self._cur = cur
         self._rv = ""
         self._changed = False
+        self._mkline_seen_first = False
         self.reset_indent()
 
     def shift(self, amount=1):
@@ -116,9 +117,24 @@ class SnippetUtil:
         """
         if indent is None:
             indent = self.indent
-            # this deals with the fact that the first line is
-            # already properly indented
-            if "\n" not in self._rv:
+            # The first line emitted by mkline shares the buffer position
+            # where the snippet expansion landed, which already provides
+            # the snippet's initial indent. Subsequent lines start on a
+            # fresh line and need the full indent prepended.
+            #
+            # `snip.rv` is the historical signal for "we have already
+            # emitted something", but only `snip +=` / explicit
+            # `snip.rv += mkline(...)` updates it between calls. Users
+            # who build the result in a single expression
+            # (`snip.rv = mkline(...) + "\n" + mkline(...)`,
+            # `"\n".join(snip.mkline(x) for x in ...)`) leave `rv` empty
+            # until the end, so every mkline call used to under-indent.
+            # Track our own call counter so the second-and-later mkline
+            # within a python block keeps the full indent regardless of
+            # how the user is assembling the result.
+            first_line = "\n" not in self._rv and not self._mkline_seen_first
+            self._mkline_seen_first = True
+            if first_line:
                 try:
                     indent = indent[len(self._initial_indent) :]
                 except IndexError:

--- a/test/test_MklineMultiline.py
+++ b/test/test_MklineMultiline.py
@@ -1,0 +1,54 @@
+"""Regression tests for `snip.mkline` when the user constructs a multi-line
+string in one expression instead of appending line-by-line (GH #1233).
+
+`snip.mkline` infers "is this the first line of the python block's output?"
+from `self._rv`. That works for the `snip += line` pattern (which mutates
+`snip.rv` between calls), but if the user builds the result in a single
+expression - `snip.rv = mkline(...) + "\\n" + mkline(...)` - both calls
+see an empty `_rv` and both strip the snippet's initial indent, so every
+line after the first under-indents.
+"""
+
+from test.constant import EX
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class Mkline_TwoCallsInOneExpression_BothShifted(_VimTest):
+    snippets = (
+        "test",
+        r"""hi
+`!p
+snip.shift()
+snip.rv = snip.mkline("hello()") + "\n" + snip.mkline("hello()")`
+end""",
+    )
+    keys = "\ttest" + EX
+    wanted = "\thi\n\t\thello()\n\t\thello()\n\tend"
+
+
+class Mkline_GeneratorJoin_AllShifted(_VimTest):
+    snippets = (
+        "test",
+        r"""hi
+`!p
+snip.shift()
+snip.rv = "\n".join(snip.mkline(x) for x in ("a", "b", "c"))`
+end""",
+    )
+    keys = "\ttest" + EX
+    wanted = "\thi\n\t\ta\n\t\tb\n\t\tc\n\tend"
+
+
+# The OP's pattern in GH #1233: `snip.mkline` called twice with `map`,
+# joined with newlines. Same root cause as the two-call test above.
+class Mkline_MapJoin_AllShifted(_VimTest):
+    snippets = (
+        "test",
+        r"""hi
+`!p
+snip.shift()
+snip.rv = "\n".join(map(snip.mkline, ["a", "b", "c"]))`
+end""",
+    )
+    keys = "\ttest" + EX
+    wanted = "\thi\n\t\ta\n\t\tb\n\t\tc\n\tend"


### PR DESCRIPTION
`snip.mkline` used `snip.rv` being empty as the signal for "this is the first line of the python block's output, the buffer already provides the initial indent." That works for the `snip += line` pattern (which mutates `snip.rv` between calls) but breaks when the user assembles the result in a single expression:

- `snip.rv = mkline(...) + "\n" + mkline(...)`
- `"\n".join(snip.mkline(x) for x in items)`
- `map(snip.mkline, items)`

In all three cases every `mkline` call sees an empty `_rv`, every call is treated as "the first line", and every line after the first under-indents by the snippet's initial indent (#1233).

Track a separate "mkline has emitted something this python block" flag that flips on the first mkline call and is reset between python blocks. The flag is independent of how (or whether) the user feeds the result back into `snip.rv`, so map/join/`+`-built results indent correctly. The `snip +=` flow is unchanged because the first call still sees the flag as `False`.

Fixes #1233