### PR TITLE
Resolve symlinks when matching snippets dir to vim config dir

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -988,9 +988,19 @@ class SnippetManager:
             # Likely the array contains things like ["UltiSnips",
             # "mycoolsnippets"] There is no more obvious way to edit than in
             # the users vim config directory.
+            #
+            # `dot_vim_dirs` has already been canonicalised by
+            # `vim_helper.get_dot_vim()`, but the snippet dirs come straight
+            # from a runtimepath glob and keep symlinks intact. A user with
+            # a symlinked snippets directory (or, on macOS, a `$HOME` that
+            # lives under the auto-resolved `/private/var/...`) would see
+            # the two sides disagree and never populate `potentials`
+            # (#1543). Compare resolved forms so the check is independent
+            # of which leg of the path is a symlink.
             for snippet_dir in all_snippet_directories:
+                snippet_parent_resolved = Path(snippet_dir).parent.resolve()
                 for dot_vim_dir in dot_vim_dirs:
-                    if Path(dot_vim_dir) != Path(snippet_dir).parent:
+                    if Path(dot_vim_dir).resolve() != snippet_parent_resolved:
                         continue
                     potentials.update(
                         _get_potential_snippet_filenames_to_edit(snippet_dir, filetypes)

--- a/test/test_UltiSnipsEditSymlink.py
+++ b/test/test_UltiSnipsEditSymlink.py
@@ -26,12 +26,10 @@ class UltiSnipsEdit_SymlinkedConfigHome_FindsSnippet(_VimTest):
         return self._expected_file
 
     def _extra_vim_config(self, vim_config):
-        # Set up:
-        #   self._temp_dir/real_snippets/python.snippets   (target)
-        #   self._temp_dir/.vim/                           (dot-vim home)
-        #   self._temp_dir/.vim/UltiSnips -> real_snippets (symlink)
-        # then route $HOME through a symlinked alias of self._temp_dir
-        # so `get_dot_vim()` (which resolves) and `find_all_snippet_directories()`
+        # Lay out a real snippets directory, a dot-vim home, and a symlink
+        # from the dot-vim home into the snippets directory. Then route
+        # $HOME through a symlinked alias of `self._temp_dir` so
+        # `get_dot_vim()` (which resolves) and `find_all_snippet_directories()`
         # (which doesn't) disagree on the path layout (#1543).
         snippets_target = self._temp_dir / "real_snippets"
         snippets_target.mkdir(parents=True, exist_ok=True)

--- a/test/test_UltiSnipsEditSymlink.py
+++ b/test/test_UltiSnipsEditSymlink.py
@@ -1,0 +1,73 @@
+"""Regression test for `:UltiSnipsEdit` when the snippets directory is
+reached through a symlink (GH #1543).
+
+The non-bang `:UltiSnipsEdit` path checks that each candidate snippet
+directory sits inside one of the user's vim config directories. When
+either leg of that comparison goes through a symlink (a symlinked
+`UltiSnips/` dir, or a `$HOME` that the OS resolves to a different
+mountpoint), the unresolved string compare missed the match and
+`:UltiSnipsEdit` reported "UltiSnips was not able to find a default
+directory for snippets". The test routes the dot-vim discovery through
+a symlinked `$HOME`/`$XDG_CONFIG_HOME` so the regression path is forced.
+"""
+
+import contextlib
+
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class UltiSnipsEdit_SymlinkedConfigHome_FindsSnippet(_VimTest):
+    keys = ""
+    text_before = ""
+    text_after = ""
+
+    @property
+    def wanted(self):
+        return self._expected_file
+
+    def _extra_vim_config(self, vim_config):
+        # Set up:
+        #   self._temp_dir/real_snippets/python.snippets   (target)
+        #   self._temp_dir/.vim/                           (dot-vim home)
+        #   self._temp_dir/.vim/UltiSnips -> real_snippets (symlink)
+        # then route $HOME through a symlinked alias of self._temp_dir
+        # so `get_dot_vim()` (which resolves) and `find_all_snippet_directories()`
+        # (which doesn't) disagree on the path layout (#1543).
+        snippets_target = self._temp_dir / "real_snippets"
+        snippets_target.mkdir(parents=True, exist_ok=True)
+        (snippets_target / "python.snippets").write_text(
+            'snippet hi "" b\nhello\nendsnippet\n'
+        )
+
+        dot_vim = self._temp_dir / ".vim"
+        dot_vim.mkdir(parents=True, exist_ok=True)
+        link = dot_vim / "UltiSnips"
+        with contextlib.suppress(FileExistsError):
+            link.symlink_to(snippets_target, target_is_directory=True)
+
+        sym_home = self._temp_dir.parent / (self._temp_dir.name + "_home_sym")
+        with contextlib.suppress(FileExistsError):
+            sym_home.symlink_to(self._temp_dir, target_is_directory=True)
+
+        vim_config.append(f"let $HOME = '{sym_home}'")
+        vim_config.append(f"set runtimepath+={sym_home}/.vim")
+        # Two-entry list forces the multi-dir branch in `_file_to_edit`,
+        # which is the one that does the parent vs. dot-vim comparison.
+        vim_config.append(
+            f"let g:UltiSnipsSnippetDirectories=['{sym_home}/.vim/UltiSnips', 'UltiSnips']"
+        )
+
+        self._expected_file = str((snippets_target / "python.snippets").resolve())
+
+    def _before_test(self):
+        helper = self._temp_dir / "_run_edit.py"
+        helper.write_text(
+            "import traceback, vim\n"
+            "from UltiSnips.snippet_manager import UltiSnips_Manager\n"
+            "try:\n"
+            "    out = UltiSnips_Manager._file_to_edit('python', '')\n"
+            "except Exception:\n"
+            "    out = traceback.format_exc()\n"
+            "vim.current.buffer[:] = (str(out) or '<empty>').splitlines()\n"
+        )
+        self.vim.send_to_vim(f":py3file {helper}\n")


### PR DESCRIPTION
`:UltiSnipsEdit` (no bang) walks each discovered snippets directory and only keeps the ones that sit directly inside one of the user's vim config directories. `vim_helper.get_dot_vim()` already normalises the latter via `Path.resolve()`, but the snippet dirs come from a runtimepath glob and keep symlinks intact, so:

- a user who symlinks their `UltiSnips/` directory (the OP's setup in #1543),
- or whose `$HOME` lives under a path the OS auto-resolves (macOS `/var` → `/private/var`),

sees the two sides disagree on otherwise-identical paths. `potentials` stays empty and the command prints "UltiSnips was not able to find a default directory for snippets."

Resolve both sides of the comparison so the check is independent of which leg of the path is a symlink. Add an integration test that routes the dot-vim discovery through a symlinked `$HOME` and asserts that `_file_to_edit` returns the resolved snippets file instead of an empty string.

Fixes #1543