### PR TITLE
Keep snippet alive when cursor visits the preview window

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -167,7 +167,7 @@ function! UltiSnips#CursorMoved() abort
     py3 UltiSnips_Manager._cursor_moved()
 endf
 
-function! s:is_aux_window(winnr) abort
+function! UltiSnips#IsAuxWindow(winnr) abort
     " Auxiliary windows that should not tear down an active snippet:
     "   - the preview window
     "   - neovim floating windows
@@ -199,7 +199,7 @@ function! s:is_aux_window(winnr) abort
 endfunction
 
 function! s:leaving_buffer_impl() abort
-    if !(s:is_aux_window(winnr('#')) || s:is_aux_window(winnr()))
+    if !(UltiSnips#IsAuxWindow(winnr('#')) || UltiSnips#IsAuxWindow(winnr()))
         py3 UltiSnips_Manager._leaving_buffer()
     endif
 endfunction

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -399,7 +399,15 @@ class SnippetManager:
             # against an unrelated buffer corrupts both the buffer and the
             # snippet state — drop the snippets here so the caller sees a
             # clean slate.
+            #
+            # Excursions into auxiliary windows (the preview window,
+            # quickfix/loclist, neovim floats) are different: the user
+            # expects to come back to the snippet, so just bail out
+            # without touching the snippet state. `UltiSnips#LeavingBuffer`
+            # already applies the same classification.
             if vim.current.buffer.number != self._snippet_buffer_number:
+                if vim_helper.eval("UltiSnips#IsAuxWindow(winnr())") == "1":
+                    return
                 self._leaving_buffer()
                 return
 

--- a/test/test_PreviewWindow.py
+++ b/test/test_PreviewWindow.py
@@ -26,9 +26,7 @@ class _PreviewBase(_VimTest):
         vim_config.append("function! UltiSnipsTest_OpenPreview() abort")
         vim_config.append("  execute 'pedit ' . g:_preview_file")
         vim_config.append("endfunction")
-        vim_config.append(
-            "inoremap <c-l> <cmd>call UltiSnipsTest_OpenPreview()<cr>"
-        )
+        vim_config.append("inoremap <c-l> <cmd>call UltiSnipsTest_OpenPreview()<cr>")
 
 
 class PreviewWindow_OpenedDuringSnippet_KeepsSnippet(_PreviewBase):
@@ -46,11 +44,16 @@ class PreviewWindow_OpenedThenFocused_DoesNotHang(_PreviewBase):
     # still get back to the snippet buffer and complete the jump.
     preview_lines = 500
     keys = (
-        "sel" + EX + "users" + "\x0c"
+        "sel"
+        + EX
+        + "users"
+        + "\x0c"
         # Leave insert mode, jump to the preview window, then back to the
         # snippet buffer. If this hangs, the test framework's per-test
         # timeout will surface the failure.
         + "\x1b\x17w\x17W"
-        + "a" + JF + "id, name"
+        + "a"
+        + JF
+        + "id, name"
     )
     wanted = "select id, name from users "

--- a/test/test_PreviewWindow.py
+++ b/test/test_PreviewWindow.py
@@ -1,0 +1,58 @@
+"""Regression tests for `:pedit` / preview-window interactions while a
+snippet is active (GH #1168).
+
+The original bug: a multi-step snippet was active, the user opened a
+preview window with `:pedit` (or any plugin that did, e.g. `:DB` from
+vim-dadbod), and then navigating *into* the preview hung Vim for large
+previews. The preview window now classifies as an "aux" window that
+LeavingBuffer ignores, so the snippet stays intact and navigating in
+and out of the preview should be cheap.
+"""
+
+import textwrap
+
+from test.constant import EX, JF
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class _PreviewBase(_VimTest):
+    snippets = ("sel", "select ${2:*} from ${1:table} $0", "select", "i")
+    preview_lines = 20
+
+    def _extra_vim_config(self, vim_config):
+        preview_file = self._temp_dir / "preview_content.txt"
+        preview_file.write_text(
+            "\n".join(f"row {i}" for i in range(self.preview_lines)) + "\n"
+        )
+        vim_config.append(f"let g:_preview_file = '{preview_file}'")
+        vim_config.append("function! UltiSnipsTest_OpenPreview() abort")
+        vim_config.append("  execute 'pedit ' . g:_preview_file")
+        vim_config.append("endfunction")
+        vim_config.append(
+            "inoremap <c-l> <cmd>call UltiSnipsTest_OpenPreview()<cr>"
+        )
+
+
+class PreviewWindow_OpenedDuringSnippet_KeepsSnippet(_PreviewBase):
+    # Expand snippet, fill first tabstop, open preview, jump back into
+    # the snippet (jump should still work because the preview window is
+    # classified as an aux window).
+    keys = "sel" + EX + "users" + "\x0c" + JF + "id, name"
+    wanted = "select id, name from users "
+
+
+class PreviewWindow_OpenedThenFocused_DoesNotHang(_PreviewBase):
+    # The original report: opening the preview is fine; *navigating* into
+    # it with `<C-w>w` was the part that hung for large content. This
+    # test exercises that path with a long file and verifies we can
+    # still get back to the snippet buffer and complete the jump.
+    preview_lines = 500
+    keys = (
+        "sel" + EX + "users" + "\x0c"
+        # Leave insert mode, jump to the preview window, then back to the
+        # snippet buffer. If this hangs, the test framework's per-test
+        # timeout will surface the failure.
+        + "\x1b\x17w\x17W"
+        + "a" + JF + "id, name"
+    )
+    wanted = "select id, name from users "

--- a/test/test_PreviewWindow.py
+++ b/test/test_PreviewWindow.py
@@ -9,8 +9,6 @@ LeavingBuffer ignores, so the snippet stays intact and navigating in
 and out of the preview should be cheap.
 """
 
-import textwrap
-
 from test.constant import EX, JF
 from test.vim_test_case import VimTestCase as _VimTest
 


### PR DESCRIPTION
`CursorMoved` on a different buffer used to call `_leaving_buffer` unconditionally, tearing the active snippet down whenever the cursor visited an auxiliary window (`:pedit` preview, quickfix, neovim floats). `UltiSnips#LeavingBuffer` already classifies those windows and skips the teardown, but CursorMoved did not - so navigating into the preview window broke the next jump even though the buffer-enter path deliberately kept the snippet around.

Promote `s:is_aux_window` to a public `UltiSnips#IsAuxWindow` so the Python side can reuse the classifier, and bail out of `CursorMoved` early when the current window is auxiliary. Real buffer switches (e.g. `:bd!`) still tear down via the existing fall-through.

Add regression tests covering the snippet surviving `:pedit` both without focus changes (open-only) and with focus changes (navigate in and out of the preview).

Fixes #1168