### PR TITLE
Bail out cleanly when Python 3 is unavailable

### DIFF
--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -13,29 +13,32 @@ if !has('nvim') && version < 820
    finish
 endif
 
+" UltiSnips needs Python 3. Bail with a clear message if Vim wasn't
+" compiled with python3 support at all, so we don't fall through to the
+" runtime-check below (which would just say "Python is broken" without
+" distinguishing missing-from-build vs broken-at-load).
+if !has('python3') && !get(g:, 'UltiSnipsNoPythonWarning', 0)
+    echohl WarningMsg
+    echom 'UltiSnips requires Vim compiled with +python3 support; disabling UltiSnips.'
+    echom '          See :help UltiSnips-requirements for setup.'
+    echom '          Silence this message with `let g:UltiSnipsNoPythonWarning = 1`.'
+    echohl None
+endif
+if !has('python3')
+    finish
+endif
 
-" TODO(robot): should we not have here a simple block to check for python3,
-" similar to the warning above for the required vim version? This means, this
-" check we no longor need.
-
-" Bail out cleanly when Python 3 is unusable, instead of letting every
-" autocmd and mapping below re-raise E370/E263 (Vim can't load libpython)
-" or `NameError: UltiSnips_Manager` (the package isn't on the Python path)
-" on every keystroke (#1237, #1209).
-"
 " `has('python3')` is necessary but not sufficient: Vim can be compiled
-" with dynamic Python support and still fail to load the library at
-" runtime. We force the lazy load now by asking Python to flip a
-" Vim-side flag — if either the libpython load or the UltiSnips package
-" import fails, the flag stays zero.
-"
-" The documented `g:UltiSnipsNoPythonWarning` opt-out
-" (see |UltiSnips-python-warning|) silences the message itself.
+" with dynamic Python support and still fail to load libpython at
+" runtime, or have UltiSnips off the Python path entirely. Force the
+" lazy load now by asking Python to flip a Vim-side flag — if either
+" libpython or the UltiSnips package import fails, the flag stays zero
+" and we bail before registering autocmds that would otherwise re-raise
+" E370 / E263 / NameError on every keystroke (#1237, #1209).
 let s:ultisnips_python3_ok = 0
 let s:ultisnips_python3_error = ''
-if has('python3')
-    try
-        py3 << EOF
+try
+    py3 << EOF
 try:
     import vim
     from UltiSnips import UltiSnips_Manager
@@ -45,17 +48,15 @@ except Exception as _err:
     _msg = _tb.format_exception_only(type(_err), _err)[-1].strip()
     vim.command("let s:ultisnips_python3_error = " + repr(_msg))
 EOF
-    catch
-        " Catchable Python load failures (E370, E263) end up here, in which
-        " case `s:ultisnips_python3_error` was never set — fall through to
-        " the generic message below.
-    endtry
-endif
-" TODO(robot): This can then be a more specific error that Python is borked somehow
+catch
+    " Catchable Python load failures (E370, E263) land here; the import
+    " block above never ran so s:ultisnips_python3_error stays empty.
+    let s:ultisnips_python3_error = v:exception
+endtry
 if !s:ultisnips_python3_ok
     if !get(g:, 'UltiSnipsNoPythonWarning', 0)
         echohl WarningMsg
-        echom 'UltiSnips: Python 3 is not usable in this Vim; disabling UltiSnips.'
+        echom 'UltiSnips: Python 3 is present but unusable; disabling UltiSnips.'
         if !empty(s:ultisnips_python3_error)
             echom '           ' . s:ultisnips_python3_error
         endif

--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -13,6 +13,11 @@ if !has('nvim') && version < 820
    finish
 endif
 
+
+" TODO(robot): should we not have here a simple block to check for python3,
+" similar to the warning above for the required vim version? This means, this
+" check we no longor need.
+
 " Bail out cleanly when Python 3 is unusable, instead of letting every
 " autocmd and mapping below re-raise E370/E263 (Vim can't load libpython)
 " or `NameError: UltiSnips_Manager` (the package isn't on the Python path)
@@ -33,7 +38,7 @@ if has('python3')
         py3 << EOF
 try:
     import vim
-    from UltiSnips import UltiSnips_Manager  # noqa: F401
+    from UltiSnips import UltiSnips_Manager
     vim.command('let s:ultisnips_python3_ok = 1')
 except Exception as _err:
     import traceback as _tb
@@ -46,6 +51,7 @@ EOF
         " the generic message below.
     endtry
 endif
+" TODO(robot): This can then be a more specific error that Python is borked somehow
 if !s:ultisnips_python3_ok
     if !get(g:, 'UltiSnipsNoPythonWarning', 0)
         echohl WarningMsg

--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -13,6 +13,53 @@ if !has('nvim') && version < 820
    finish
 endif
 
+" Bail out cleanly when Python 3 is unusable, instead of letting every
+" autocmd and mapping below re-raise E370/E263 (Vim can't load libpython)
+" or `NameError: UltiSnips_Manager` (the package isn't on the Python path)
+" on every keystroke (#1237, #1209).
+"
+" `has('python3')` is necessary but not sufficient: Vim can be compiled
+" with dynamic Python support and still fail to load the library at
+" runtime. We force the lazy load now by asking Python to flip a
+" Vim-side flag — if either the libpython load or the UltiSnips package
+" import fails, the flag stays zero.
+"
+" The documented `g:UltiSnipsNoPythonWarning` opt-out
+" (see |UltiSnips-python-warning|) silences the message itself.
+let s:ultisnips_python3_ok = 0
+let s:ultisnips_python3_error = ''
+if has('python3')
+    try
+        py3 << EOF
+try:
+    import vim
+    from UltiSnips import UltiSnips_Manager  # noqa: F401
+    vim.command('let s:ultisnips_python3_ok = 1')
+except Exception as _err:
+    import traceback as _tb
+    _msg = _tb.format_exception_only(type(_err), _err)[-1].strip()
+    vim.command("let s:ultisnips_python3_error = " + repr(_msg))
+EOF
+    catch
+        " Catchable Python load failures (E370, E263) end up here, in which
+        " case `s:ultisnips_python3_error` was never set — fall through to
+        " the generic message below.
+    endtry
+endif
+if !s:ultisnips_python3_ok
+    if !get(g:, 'UltiSnipsNoPythonWarning', 0)
+        echohl WarningMsg
+        echom 'UltiSnips: Python 3 is not usable in this Vim; disabling UltiSnips.'
+        if !empty(s:ultisnips_python3_error)
+            echom '           ' . s:ultisnips_python3_error
+        endif
+        echom '           See :help UltiSnips-requirements for setup.'
+        echom '           Silence this message with `let g:UltiSnipsNoPythonWarning = 1`.'
+        echohl None
+    endif
+    finish
+endif
+
 " Enable Post debug server config
 if !exists("g:UltiSnipsDebugServerEnable")
    let g:UltiSnipsDebugServerEnable = 0

--- a/test/test_NoPython.py
+++ b/test/test_NoPython.py
@@ -1,0 +1,72 @@
+"""Regression tests for #1237 (and #1209's symptom):
+
+If the Python 3 interpreter or the UltiSnips package can't be loaded,
+the plugin must disable itself instead of spamming a stack trace on
+every keystroke.
+
+We can't actually launch Vim without Python (the test framework needs
+it), so we simulate the import failure: after the normal plugin load,
+poison `sys.modules['UltiSnips']`, clear the `did_plugin_ultisnips`
+guard, and re-source `plugin/UltiSnips.vim`. With the fix, the plugin
+must `finish` before defining `:UltiSnipsEdit` again.
+"""
+
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class _ReloadBase(_VimTest):
+    keys = ""
+    wanted = ""
+    text_before = ""
+    text_after = ""
+
+    def _reload_plugin_with_broken_import(self):
+        """Send commands that simulate the import failure and re-source
+        the plugin file."""
+        plugin_file = self._repo_root() / "plugin" / "UltiSnips.vim"
+        self.vim.send_to_vim(":let g:UltiSnipsNoPythonWarning = 1\n")
+        # Poison UltiSnips's `sys.modules` entry so the plugin's
+        # `from UltiSnips import UltiSnips_Manager` raises ImportError.
+        # We do this *after* the test framework's own import succeeded.
+        self.vim.send_to_vim(":py3 import sys\n")
+        self.vim.send_to_vim(
+            ":py3 for _k in [k for k in list(sys.modules) "
+            "if k == 'UltiSnips' or k.startswith('UltiSnips.')]: "
+            "del sys.modules[_k]\n"
+        )
+        self.vim.send_to_vim(":py3 sys.modules['UltiSnips'] = None\n")
+        self.vim.send_to_vim(":unlet! did_plugin_ultisnips\n")
+        self.vim.send_to_vim(":silent! delcommand UltiSnipsEdit\n")
+        self.vim.send_to_vim(":silent! autocmd! UltiSnips_AutoTrigger\n")
+        self.vim.send_to_vim(f":source {plugin_file}\n")
+
+    def _repo_root(self):
+        from pathlib import Path
+
+        return Path(__file__).resolve().parent.parent
+
+
+class NoPython_PluginBailsBeforeRegisteringCommand(_ReloadBase):
+    """After the simulated import failure, `:UltiSnipsEdit` must NOT
+    exist - the plugin has bailed before reaching the `command!` line."""
+
+    wanted = "exists=0"
+
+    def _before_test(self):
+        self._reload_plugin_with_broken_import()
+        self.vim.send_to_vim(
+            ":py3 vim.current.buffer[:] = "
+            '[\'exists=\' + vim.eval(\'exists(":UltiSnipsEdit") ? "1" : "0"\')]\n'
+        )
+
+
+class NoPython_NoSpamOnInsertModeKeystrokes(_ReloadBase):
+    """With the plugin disabled, the autocmds are unregistered, so
+    typing in insert mode produces no UltiSnips errors — the buffer just
+    receives the typed characters."""
+
+    keys = "hello world"
+    wanted = "hello world"
+
+    def _before_test(self):
+        self._reload_plugin_with_broken_import()


### PR DESCRIPTION
Vim happily kept calling `UltiSnips#TrackChange` from `TextChangedI` / `InsertCharPre` on every keystroke even when `py3` could not load libpython (E370 / E263) or when the UltiSnips package itself was not on `sys.path` (NameError on `UltiSnips_Manager`). Each keystroke re-spammed the same stack trace, making Vim unusable on hosts where the plugin is checked into a shared dotfiles repo but Python is missing.

At plugin-load time, force the lazy `py3` import now and ask Python to flip a Vim-side flag. If either the libpython load or `from UltiSnips import UltiSnips_Manager` fails, emit one `WarningMsg` message (suppressible via the documented `g:UltiSnipsNoPythonWarning`, see `:help UltiSnips-python-warning`) and `finish` before defining any commands, autocmds, or mappings.

The opt-out variable was already documented but never wired up; this patch finally implements the behaviour the docs promise.

Closes #1237. Also addresses the symptom reported in #1209 and #1377 when the import fails for any other reason.