### PR TITLE
Include SnipMate files in :UltiSnipsEdit! picker

### DIFF
--- a/pythonx/UltiSnips/snippet/source/__init__.py
+++ b/pythonx/UltiSnips/snippet/source/__init__.py
@@ -8,6 +8,5 @@ from UltiSnips.snippet.source.file.snipmate import SnipMateFileSource
 from UltiSnips.snippet.source.file.ulti_snips import (
     UltiSnipsFileSource,
     find_all_snippet_directories,
-    find_all_snippet_files,
     find_snippet_files,
 )

--- a/pythonx/UltiSnips/snippet/source/base.py
+++ b/pythonx/UltiSnips/snippet/source/base.py
@@ -25,6 +25,13 @@ class SnippetSource:
         ensure.
         """
 
+    def get_all_snippet_files_for(self, ft):
+        """Returns the set of on-disk snippet files this source would load
+        for filetype 'ft'. Returns an empty set for sources that don't
+        back snippets with files (added programmatically, dynamic
+        sources, etc.). File-backed subclasses override this."""
+        return set()
+
     def _get_existing_deep_extends(self, base_filetypes):
         """Helper for get all existing filetypes extended by base filetypes."""
         deep_extends = self.get_deep_extends(base_filetypes)

--- a/pythonx/UltiSnips/snippet/source/file/base.py
+++ b/pythonx/UltiSnips/snippet/source/file/base.py
@@ -49,7 +49,7 @@ class SnippetFileSource(SnippetSource):
     def refresh(self):
         self.__init__()
 
-    def _get_all_snippet_files_for(self, ft):
+    def get_all_snippet_files_for(self, ft):
         """Returns a set of all files that define snippets for 'ft'."""
         raise NotImplementedError()
 
@@ -65,7 +65,7 @@ class SnippetFileSource(SnippetSource):
     def _load_snippets_for(self, ft):
         """Load all snippets for the given 'ft'."""
         assert ft not in self._snippets
-        for fn in self._get_all_snippet_files_for(ft):
+        for fn in self.get_all_snippet_files_for(ft):
             self._parse_snippets(ft, fn)
         # Now load for the parents
         for parent_ft in self.get_deep_extends([ft]):

--- a/pythonx/UltiSnips/snippet/source/file/snipmate.py
+++ b/pythonx/UltiSnips/snippet/source/file/snipmate.py
@@ -106,7 +106,7 @@ def _parse_snippets_file(data, filename):
 class SnipMateFileSource(SnippetFileSource):
     """Manages all snipMate snippet definitions found in rtp."""
 
-    def _get_all_snippet_files_for(self, ft):
+    def get_all_snippet_files_for(self, ft):
         return _snipmate_files_for(ft)
 
     def _parse_snippet_file(self, filedata, filename):

--- a/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
+++ b/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
@@ -63,6 +63,7 @@ def find_all_snippet_directories() -> list[str]:
     return all_dirs
 
 
+# TODO(robot): this function is private now; might as well inline it below.
 def find_all_snippet_files(ft) -> set[str]:
     """Returns all snippet files matching 'ft' in the given runtime path
     directory."""

--- a/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
+++ b/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
@@ -63,23 +63,6 @@ def find_all_snippet_directories() -> list[str]:
     return all_dirs
 
 
-# TODO(robot): this function is private now; might as well inline it below.
-def find_all_snippet_files(ft) -> set[str]:
-    """Returns all snippet files matching 'ft' in the given runtime path
-    directory."""
-    patterns = ["%s.snippets", "%s_*.snippets", str(Path("%s") / "*")]
-    ret = set()
-    for directory in find_all_snippet_directories():
-        if not Path(directory).is_dir():
-            continue
-        for pattern in patterns:
-            for fn in Path(directory).glob(pattern % ft):
-                # Canonicalize so symlinked or duplicated runtimepath entries
-                # don't make the same file appear twice.
-                ret.add(normalize_file_path(str(fn)))
-    return ret
-
-
 def _handle_snippet_or_global(
     filename, line, lines, python_globals, priority, pre_expand, context
 ):
@@ -212,8 +195,20 @@ def _parse_snippets_file(data, filename):
 class UltiSnipsFileSource(SnippetFileSource):
     """Manages all snippets definitions found in rtp for ultisnips."""
 
-    def _get_all_snippet_files_for(self, ft):
-        return find_all_snippet_files(ft)
+    def get_all_snippet_files_for(self, ft):
+        """Returns all snippet files matching 'ft' in the given runtime
+        path directory."""
+        patterns = ["%s.snippets", "%s_*.snippets", str(Path("%s") / "*")]
+        ret = set()
+        for directory in find_all_snippet_directories():
+            if not Path(directory).is_dir():
+                continue
+            for pattern in patterns:
+                for fn in Path(directory).glob(pattern % ft):
+                    # Canonicalize so symlinked or duplicated runtimepath
+                    # entries don't make the same file appear twice.
+                    ret.add(normalize_file_path(str(fn)))
+        return ret
 
     def _parse_snippet_file(self, filedata, filename):
         yield from _parse_snippets_file(filedata, filename)

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -22,7 +22,6 @@ from UltiSnips.snippet.source import (
     SnipMateFileSource,
     UltiSnipsFileSource,
     find_all_snippet_directories,
-    find_all_snippet_files,
     find_snippet_files,
 )
 from UltiSnips.snippet.source.file.common import (
@@ -335,6 +334,18 @@ class SnippetManager:
             self._do_snippet(snip, before)
             return True
         return False
+
+    def _all_snippet_files_for(self, ft):
+        """Returns every snippet file that any registered file-based source
+        would load for filetype 'ft'. Used by :UltiSnipsEdit! to build the
+        picker list."""
+        files = set()
+        for _, source in self._snippet_sources:
+            collect = getattr(source, "_get_all_snippet_files_for", None)
+            if collect is None:
+                continue
+            files.update(collect(ft))
+        return files
 
     def register_snippet_source(self, name, snippet_source):
         """Registers a new 'snippet_source' with the given 'name'.
@@ -998,7 +1009,7 @@ class SnippetManager:
 
         if bang:
             for ft in filetypes:
-                potentials.update(find_all_snippet_files(ft))
+                potentials.update(self._all_snippet_files_for(ft))
         else:
             if not potentials:
                 _show_user_warning(

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -335,19 +335,14 @@ class SnippetManager:
             return True
         return False
 
-    # TODO(robot): This is pretty ugly - it calls to a private function in the snippet sources that you apparentlý
-    # are not sure that it is defined every time. Instead, elevate _get_all_snippet_files_for in the sources 
-    # to be a public function and make sure it always is defined, returning maybe an empty set.
-    def _all_snippet_files_for(self, ft):
-        """Returns every snippet file that any registered file-based source
-        would load for filetype 'ft'. Used by :UltiSnipsEdit! to build the
-        picker list."""
+    def all_snippet_files_for(self, ft):
+        """Returns every snippet file that any registered source would load
+        for filetype 'ft'. Used by :UltiSnipsEdit! to build the picker
+        list. Sources that don't back snippets with files contribute an
+        empty set via the base-class default."""
         files = set()
         for _, source in self._snippet_sources:
-            collect = getattr(source, "_get_all_snippet_files_for", None)
-            if collect is None:
-                continue
-            files.update(collect(ft))
+            files.update(source.get_all_snippet_files_for(ft))
         return files
 
     def register_snippet_source(self, name, snippet_source):
@@ -1012,7 +1007,7 @@ class SnippetManager:
 
         if bang:
             for ft in filetypes:
-                potentials.update(self._all_snippet_files_for(ft))
+                potentials.update(self.all_snippet_files_for(ft))
         else:
             if not potentials:
                 _show_user_warning(

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -335,6 +335,9 @@ class SnippetManager:
             return True
         return False
 
+    # TODO(robot): This is pretty ugly - it calls to a private function in the snippet sources that you apparentlý
+    # are not sure that it is defined every time. Instead, elevate _get_all_snippet_files_for in the sources 
+    # to be a public function and make sure it always is defined, returning maybe an empty set.
     def _all_snippet_files_for(self, ft):
         """Returns every snippet file that any registered file-based source
         would load for filetype 'ft'. Used by :UltiSnipsEdit! to build the

--- a/test/test_Issue1360.py
+++ b/test/test_Issue1360.py
@@ -2,7 +2,7 @@
 
 `:UltiSnipsEdit!` must list SnipMate snippet files in addition to
 UltiSnips files when `g:UltiSnipsEnableSnipMate` is on. The picker list
-is built from ``SnippetManager._all_snippet_files_for(ft)``; here we
+is built from ``SnippetManager.all_snippet_files_for(ft)``; here we
 exercise that helper directly through ``py3`` so we don't have to drive
 the interactive ``inputlist()`` prompt.
 """
@@ -14,7 +14,7 @@ import os
 import vim
 from UltiSnips import UltiSnips_Manager
 
-files = sorted(UltiSnips_Manager._all_snippet_files_for("blubi"))
+files = sorted(UltiSnips_Manager.all_snippet_files_for("blubi"))
 # Keep only the last two path components so the assertion does not
 # depend on the (random) temp directory name.
 short = [os.sep.join(f.split(os.sep)[-2:]) for f in files]

--- a/test/test_Issue1360.py
+++ b/test/test_Issue1360.py
@@ -1,0 +1,39 @@
+"""Regression test for #1360.
+
+`:UltiSnipsEdit!` must list SnipMate snippet files in addition to
+UltiSnips files when `g:UltiSnipsEnableSnipMate` is on. The picker list
+is built from ``SnippetManager._all_snippet_files_for(ft)``; here we
+exercise that helper directly through ``py3`` so we don't have to drive
+the interactive ``inputlist()`` prompt.
+"""
+
+from test.vim_test_case import VimTestCase as _VimTest
+
+_QUERY = """
+import os
+import vim
+from UltiSnips import UltiSnips_Manager
+
+files = sorted(UltiSnips_Manager._all_snippet_files_for("blubi"))
+# Keep only the last two path components so the assertion does not
+# depend on the (random) temp directory name.
+short = [os.sep.join(f.split(os.sep)[-2:]) for f in files]
+vim.current.buffer[:] = [" ".join(short)]
+"""
+
+
+class Issue1360_EditBangListsSnipMate(_VimTest):
+    files = {
+        "us/blubi.snippets": "snippet usonly\nfrom ultisnips dir\nendsnippet\n",
+        "snippets/blubi.snippets": "snippet smonly\n\tfrom snipmate dir\n",
+    }
+    keys = ""
+    text_before = ""
+    text_after = ""
+    wanted = "snippets/blubi.snippets us/blubi.snippets"
+
+    def _extra_vim_config(self, vim_config):
+        self._create_file("query_1360.py", _QUERY)
+
+    def _before_test(self):
+        self.vim.send_to_vim(f":py3file {self.name_temp('query_1360.py')}\n")


### PR DESCRIPTION
`:UltiSnipsEdit!` is meant to surface every snippet file the plugin would load for a filetype so the user can jump straight to the one they want. The picker built its candidate set by calling `find_all_snippet_files(ft)` directly, which is UltiSnips-format only, so SnipMate `snippets/*.snippets` files were silently dropped from the list even when `g:UltiSnipsEnableSnipMate` was on.

Walk the registered snippet sources instead: each `SnippetFileSource` already knows how to enumerate its own files, so the bang variant of the command picks them all up uniformly and a future source would be included automatically. Adds an integration test that drops both file types in place and inspects the helper's output.

Fixes #1360.