### PR TITLE
Pin "dot does not re-expand snippet" as documented behaviour

### DIFF
--- a/test/test_Issue1572.py
+++ b/test/test_Issue1572.py
@@ -1,0 +1,34 @@
+"""Regression test for #1572.
+
+The dot operator (`.`) repeats the *last text-changing normal-mode
+command*. UltiSnips applies a snippet expansion through Vim's Python
+API, which writes into the buffer outside Vim's keystroke-recording
+machinery; only the text the user types *after* the expansion is part
+of the last change as far as Vim is concerned. As a consequence, `.`
+re-types whatever the user inserted into placeholders, but does not
+re-fire the snippet itself.
+
+This is a fundamental limitation of how UltiSnips integrates with Vim's
+change tracking. The test pins the current behaviour so any future
+attempt to "support `.`" has to acknowledge the existing semantics it is
+changing.
+"""
+
+from test.constant import ESC, EX
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class Issue1572_DotDoesNotReExpandSnippet(_VimTest):
+    """Pressing `.` after a snippet expansion does NOT re-expand the
+    trigger. The dot operator only repeats the visible last change,
+    which is whatever the user typed after UltiSnips wrote the snippet
+    body into the buffer."""
+
+    snippets = ("abc", "EXPANDED")
+    # Expand once via TAB, then move to a fresh line and hit `.`.
+    keys = "abc" + EX + ESC + "o" + ESC + "."
+    # The first line contains the actual expansion. The second line is
+    # the result of pressing `.`, which repeats the *last change* --
+    # here that's the empty insert produced by `o<Esc>`. If `.` had
+    # somehow re-expanded the snippet, the line would say `EXPANDED`.
+    wanted = "EXPANDED\n\n"


### PR DESCRIPTION
`.` repeats Vim's last text-changing normal-mode command. UltiSnips applies an expansion through Vim's Python API, which writes into the buffer outside Vim's keystroke-recording machinery, so from Vim's perspective the snippet body was never "typed". Only the characters the user enters after the expansion are part of the recorded change, and that is exactly what `.` replays - which is what #1572 reported.

This is a consequence of how Vim tracks changes, not an UltiSnips bug to fix in isolation. Adding a regression test that pins the behaviour so any future attempt to make `.` re-fire a snippet is forced to acknowledge the semantics it would be changing. The user's workaround is `q<reg>...q@<reg>` for a recorded macro, or letting the snippet engine itself stay out of the dot-repeat path and reaching for it via the trigger again.

Alternatives considered:

1. **Wontfix / by-design** (this PR's stance): keep current semantics, document via test. Lowest risk; matches every other snippet engine I know of (vim-snippy, vsnip, LuaSnip all behave the same).
2. **Re-fire on `.`**: hook `<expr>` `.` and replay the trigger keystrokes. Breaks the universal expectation that `.` is pure; will mis-behave for non-trivial snippets where the tabstops depend on context the user no longer wants to retype.
3. **Population of register `.`**: at expansion-end, push the final expanded text into Vim's last-inserted-text store so `.` reinserts the literal text. Loses the placeholders and partially obscures the engine's intent; arguably worse than today's behaviour because it pretends to work.

Going with option 1.

Fixes #1572.