### PR TITLE
Add UltiSnips#FindAutoTriggerConflicts() for #1506

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -126,6 +126,10 @@ function! UltiSnips#ToggleAutoTrigger() abort
     return py3eval("UltiSnips_Manager._toggle_autotrigger()")
 endfunction
 
+function! UltiSnips#FindAutoTriggerConflicts() abort
+    return py3eval("UltiSnips_Manager.find_autotrigger_prefix_conflicts()")
+endfunction
+
 function! UltiSnips#SaveLastVisualSelection() range abort
     py3 UltiSnips_Manager._save_last_visual_selection()
     return ""

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -25,6 +25,8 @@ UltiSnips                                      *snippet* *snippets* *UltiSnips*
       3.4.4 UltiSnips#CanExpandSnippet          |UltiSnips#CanExpandSnippet|
       3.4.5 UltiSnips#CanJumpForwards           |UltiSnips#CanJumpForwards|
       3.4.6 UltiSnips#CanJumpBackwards          |UltiSnips#CanJumpBackwards|
+      3.4.7 UltiSnips#FindAutoTriggerConflicts  |UltiSnips#FindAutoTriggerConflicts|
+      3.4.8 UltiSnips#ToggleAutoTrigger         |UltiSnips#ToggleAutoTrigger|
    3.5 Missing python support                   |UltiSnips-python-warning|
 4. Authoring snippets                           |UltiSnips-authoring-snippets|
    4.1 Basics                                   |UltiSnips-basics|
@@ -526,7 +528,27 @@ situation. This is useful in conditional mappings.
 This function returns 1 if UltiSnips can jump backwards in the current
 situation. This is useful in conditional mappings.
 
- 3.4.7 UltiSnips#ToggleAutoTrigger              *UltiSnips#ToggleAutoTrigger*
+ 3.4.7 UltiSnips#FindAutoTriggerConflicts *UltiSnips#FindAutoTriggerConflicts*
+
+This function returns the list of `[short, long]` trigger pairs where the
+`short` trigger is configured to autotrigger (option `A`) and is also a literal
+prefix of `long`. In that situation typing `long` is impossible: the
+`A`-snippet fires the moment the user finishes typing `short`, so the engine
+never sees the extra characters that would distinguish `long`. Regex triggers
+(option `r`) are skipped because prefix containment isn't well-defined for
+them.
+
+It walks the snippets visible in the current scope (including those inherited
+through `extends`). Example: >
+
+   :echo UltiSnips#FindAutoTriggerConflicts()
+   [['bs', 'bst']]
+
+Wire it into a `:checkhealth`-style command, run it after editing a snippet
+file, or include it in CI to keep a personal snippet collection
+non-overlapping.
+
+ 3.4.8 UltiSnips#ToggleAutoTrigger              *UltiSnips#ToggleAutoTrigger*
 
 This function toggles the `autotrigger` functionality. Its return value
 corresponds to the new state of the `autotrigger` (0: disabled, 1: enabled).

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -933,6 +933,31 @@ class SnippetManager:
     def can_jump_backwards(self):
         return self.can_jump(JumpDirection.BACKWARD)
 
+    def find_autotrigger_prefix_conflicts(self):
+        """Return ``[(short_trigger, long_trigger), ...]`` pairs where the
+        short trigger fires automatically (option ``A``) and is a literal
+        prefix of the long trigger, so the user can never type far enough
+        to reach the longer trigger. Regex triggers (option ``r``) are
+        skipped because prefix containment isn't meaningful for them."""
+        all_snips = self._snips("", True)
+        auto_triggers = set()
+        all_triggers = set()
+        for snip in all_snips:
+            if snip.has_option("r"):
+                continue
+            trigger = snip.trigger
+            all_triggers.add(trigger)
+            if snip.has_option("A"):
+                auto_triggers.add(trigger)
+        conflicts = []
+        for short in sorted(auto_triggers):
+            conflicts.extend(
+                [short, other]
+                for other in sorted(all_triggers)
+                if other != short and other.startswith(short)
+            )
+        return conflicts
+
     def _toggle_autotrigger(self):
         self._autotrigger = not self._autotrigger
         return self._autotrigger

--- a/test/test_Issue1506.py
+++ b/test/test_Issue1506.py
@@ -1,0 +1,137 @@
+"""Tests for #1506.
+
+`UltiSnips#FindAutoTriggerConflicts()` walks the snippets visible in
+the current scope and returns the pairs ``(short, long)`` where the
+short trigger fires automatically (``A`` option) and is a literal
+prefix of the long trigger - so the long one can never fire because
+the autotrigger ``short`` snaps first.
+"""
+
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class Issue1506_NoConflictsWhenTriggersAreDisjoint(_VimTest):
+    """Two autotrigger snippets with unrelated trigger words: no
+    conflicts."""
+
+    files = {
+        "us/all.snippets": r"""
+        snippet alpha "" "True" Ae
+        ALPHA
+        endsnippet
+        snippet beta "" "True" Ae
+        BETA
+        endsnippet
+        """
+    }
+    keys = ""
+    text_before = ""
+    text_after = ""
+    wanted = "[]"
+
+    def _before_test(self):
+        self.vim.send_to_vim(
+            ":call setline('.', string(UltiSnips#FindAutoTriggerConflicts()))\n"
+        )
+
+
+class Issue1506_DetectsAutoShadowingNonAuto(_VimTest):
+    """`bs` is autotriggered; `bst` is a plain (TAB-triggered) snippet.
+    The user can never reach `bst` because typing 'bs' fires `bs`
+    first - this is the original bug-report scenario."""
+
+    files = {
+        "us/all.snippets": r"""
+        snippet bs "" "True" Ae
+        BS
+        endsnippet
+        snippet bst "" "True" e
+        BST
+        endsnippet
+        """
+    }
+    keys = ""
+    text_before = ""
+    text_after = ""
+    wanted = "[['bs', 'bst']]"
+
+    def _before_test(self):
+        self.vim.send_to_vim(
+            ":call setline('.', string(UltiSnips#FindAutoTriggerConflicts()))\n"
+        )
+
+
+class Issue1506_DetectsAutoShadowingAuto(_VimTest):
+    """Both `bs` and `bst` are autotriggered. `bs` fires first, so
+    `bst` is shadowed. Conflict reported."""
+
+    files = {
+        "us/all.snippets": r"""
+        snippet bs "" "True" Ae
+        BS
+        endsnippet
+        snippet bst "" "True" Ae
+        BST
+        endsnippet
+        """
+    }
+    keys = ""
+    text_before = ""
+    text_after = ""
+    wanted = "[['bs', 'bst']]"
+
+    def _before_test(self):
+        self.vim.send_to_vim(
+            ":call setline('.', string(UltiSnips#FindAutoTriggerConflicts()))\n"
+        )
+
+
+class Issue1506_NonAutoPrefixIsNotAConflict(_VimTest):
+    """If the short trigger is *not* an autotrigger, there is no
+    conflict: the user has to press TAB explicitly, so they can type
+    past `bs` to reach `bst`."""
+
+    files = {
+        "us/all.snippets": r"""
+        snippet bs "" "True" e
+        BS
+        endsnippet
+        snippet bst "" "True" Ae
+        BST
+        endsnippet
+        """
+    }
+    keys = ""
+    text_before = ""
+    text_after = ""
+    wanted = "[]"
+
+    def _before_test(self):
+        self.vim.send_to_vim(
+            ":call setline('.', string(UltiSnips#FindAutoTriggerConflicts()))\n"
+        )
+
+
+class Issue1506_IgnoresRegexTriggers(_VimTest):
+    """Regex triggers are skipped: prefix containment isn't a
+    well-defined relationship for them."""
+
+    files = {
+        "us/all.snippets": r"""
+        snippet xy "" "True" Ae
+        XY
+        endsnippet
+        snippet "xy.*" "" "True" rAe
+        XY_REGEX
+        endsnippet
+        """
+    }
+    keys = ""
+    text_before = ""
+    text_after = ""
+    wanted = "[]"
+
+    def _before_test(self):
+        self.vim.send_to_vim(
+            ":call setline('.', string(UltiSnips#FindAutoTriggerConflicts()))\n"
+        )


### PR DESCRIPTION
When a snippet uses the `A` (autotrigger) flag and its trigger is a literal prefix of another snippet's trigger, the autotrigger fires the moment the user finishes typing the short trigger - so the longer trigger can never be reached. The bug-report author had this exact pain with their TeX snippet collection (`bs` shadowing `bst`, etc.) and ended up writing an external C++ utility to flag conflicts.

This PR provides it as a built-in. `UltiSnips#FindAutoTriggerConflicts()` walks the snippets visible in the current scope (including those inherited via `extends`), picks the `A`-flagged simple triggers, and returns the `[short, long]` pairs where the autotrigger is a prefix of another trigger. Regex triggers (`r`) are skipped because prefix containment isn't well-defined for them. Documented next to the existing predicate trio, with the original failing example as the doc.

Alternatives considered:

1. **This PR**: dedicated entry point that returns the pairs. Cheapest for users (one call, structured result), easy to wire into a `:checkhealth`-style command or CI.
2. **Extend `UltiSnips#SnippetsInCurrentScope`**: add `options` to `ulti_dict_info` and let users compute conflicts themselves. More flexible but pushes the prefix-detection algorithm onto every caller, and the existing function's contract is "describe what could expand here", not "describe everything for analytics".
3. **Wontfix and point to external tooling**: keeps the API tight but ignores a real workflow concern that the author already hit hard enough to write C++ for.

Going with option 1.

Fixes #1506.