### PR TITLE
Fire UltiSnipsJumped User autocommand at every tabstop landing

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -360,6 +360,7 @@ to make it possible to override these "inner" settings, it fires the following
 
 UltiSnipsEnterFirstSnippet
 UltiSnipsExitLastSnippet
+UltiSnipsJumped
 
 For example, to call a pair of custom functions in response to these events,
 you might do: >
@@ -373,6 +374,19 @@ Note that snippet expansion may be nested, in which case
 |UltiSnipsEnterFirstSnippet| will fire only as the first (outermost) snippet
 is entered, and |UltiSnipsExitLastSnippet| will only fire once the last
 (outermost) snippet have been exited.
+
+|UltiSnipsJumped| fires every time the cursor lands on a tabstop, including
+the very first tabstop after expansion. The final $0 stop is excluded - it
+is part of the snippet tear-down, for which |UltiSnipsExitLastSnippet| is
+the right hook. A typical use case is asking a completion engine to pop up
+its menu as soon as the cursor reaches a placeholder: >
+
+   " Trigger omni-completion every time UltiSnips parks the cursor on a
+   " tabstop. The timer hop is just to defer the feedkeys() out of the
+   " autocmd context so it doesn't fight with UltiSnips's own keystrokes.
+   autocmd! User UltiSnipsJumped
+   autocmd User UltiSnipsJumped call timer_start(0,
+       \ {-> feedkeys("\<C-X>\<C-O>", "n")})
 
 
  3.2.4 Direct use of Python API                   *UltiSnips-use-python-api*

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -623,6 +623,14 @@ class SnippetManager:
                     self._vstate.remember_unnamed_register(self._ctab.current_text)
                 if not ntab_short_and_near:
                     self._ignore_movements = True
+                # Let users hook a global handler that runs every time the
+                # cursor lands on a new tabstop -- including the initial
+                # expansion, since _do_snippet's first jump comes through
+                # this method. The final $0 is excluded because the snippet
+                # is torn down right after, and `UltiSnipsExitLastSnippet`
+                # is the right hook for that.
+                if self._ctab is None or self._ctab.number != 0:
+                    vim.command("silent doautocmd <nomodeline> User UltiSnipsJumped")
 
             # Reset the flag so we observe only what *this* post_jump action
             # does. _do_snippet sets it to True at its tail when called from

--- a/test/test_Issue1500.py
+++ b/test/test_Issue1500.py
@@ -1,0 +1,71 @@
+"""Tests for #1500.
+
+`UltiSnipsJumped` is a `User` autocommand that fires every time the
+cursor lands on a tabstop. It is the global hook that lets external
+plugins (completion engines in particular) react to the snippet
+engine moving the cursor, without having to add a `post_jump` action
+to every snippet.
+
+The final `$0` tabstop is excluded because the snippet is being torn
+down right after - the right hook for that case is
+`UltiSnipsExitLastSnippet`, which already exists.
+"""
+
+from test.vim_test_case import VimTestCase as _VimTest
+
+_AUTOCMD_SETUP = (
+    "let g:_1500_count = 0",
+    "augroup Issue1500",
+    "  autocmd!",
+    "  autocmd User UltiSnipsJumped let g:_1500_count += 1",
+    "augroup END",
+)
+
+
+class Issue1500_FiresOnInitialExpansion(_VimTest):
+    """Even the very first jump that lands the cursor on `$1` after
+    expansion goes through `_jump`, so `UltiSnipsJumped` fires once.
+    We verify by surfacing `g:_1500_count` into the buffer at the end."""
+
+    snippets = ("trg", "$1$0")
+    text_before = ""
+    text_after = ""
+    # trg<Tab> expands; X fills $1; <C-O>:let @c=...<CR> stores the count
+    # in the named register; <C-R>c pastes it.
+    keys = "trg\tX\x0f:let @c = 'count=' . g:_1500_count\r\x12c"
+    wanted = "Xcount=1"
+
+    def _extra_vim_config(self, vim_config):
+        vim_config.extend(_AUTOCMD_SETUP)
+
+
+class Issue1500_FiresOnEverySubsequentJump(_VimTest):
+    """Each `JumpForwards` step fires the event again so a completion
+    engine can pop up its menu at every tabstop."""
+
+    snippets = ("trg", "$1 then $2 then $3")
+    text_before = ""
+    text_after = ""
+    keys = "trg\tA?B?C\x0f:let @c = 'count=' . g:_1500_count\r\x12c"
+    wanted = "A then B then Ccount=3"
+
+    def _extra_vim_config(self, vim_config):
+        vim_config.extend(_AUTOCMD_SETUP)
+
+
+class Issue1500_DoesNotFireForFinalTabStop(_VimTest):
+    """A snippet body that ends in an implicit `$0` should NOT trigger
+    `UltiSnipsJumped` when the user runs out of stops - the snippet
+    is being torn down, and `UltiSnipsExitLastSnippet` is the
+    appropriate event for that case."""
+
+    snippets = ("trg", "$1 done")
+    text_before = ""
+    text_after = ""
+    # Initial expansion lands on $1 (counts 1). Then `?` (JF) jumps to
+    # $0 -- that jump should NOT increment the counter.
+    keys = "trg\tX?\x0f:let @c = 'count=' . g:_1500_count\r\x12c"
+    wanted = "X donecount=1"
+
+    def _extra_vim_config(self, vim_config):
+        vim_config.extend(_AUTOCMD_SETUP)


### PR DESCRIPTION
`#1500` asks how to make a completion engine (mucomplete/VimTeX in the report) pop up the moment UltiSnips parks the cursor on a placeholder. The existing User events only fire once per outer snippet (Enter/Exit), and per-snippet `post_jump` actions force every snippet author to opt in manually -- neither matches a "global, completion-driving" hook.

This PR adds a third User event, `UltiSnipsJumped`, that fires after every successful jump, including the initial `_jump` that lands on $1 right after expansion. The final $0 stop is deliberately excluded: the snippet is mid-teardown at that point, and `UltiSnipsExitLastSnippet` is the right hook for that case. Docs gain a worked example showing how to wire it to `<C-X><C-O>` through a 0-tick timer so the feedkeys doesn't fight UltiSnips's own pending keystrokes. Three regression tests pin the semantics (initial fires once, each subsequent jump fires once more, final $0 does not).

Alternatives considered:

1. **This PR** (new global event): one autocmd hook covers every snippet in the user's collection, no per-snippet boilerplate. Matches the precedent set by `UltiSnipsEnterFirstSnippet` / `UltiSnipsExitLastSnippet`.
2. **`post_jump` only**: keeps the API surface tighter but every snippet author has to opt in, including in third-party snippet collections like `honza/vim-snippets`. Not viable for the use case in the issue.
3. **Always run completion ourselves**: opens `<C-X><C-O>` automatically. Too opinionated -- breaks setups that drive completion differently and leaks UltiSnips into a concern that isn't ours.

Going with option 1.

Fixes #1500.