### PR TITLE
Add UltiSnips-add-snippets help tags

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -442,6 +442,8 @@ complete definition as listed by the |:smap| command. >
 UltiSnips provides some functions for extending core functionality.
 
 
+                                              *UltiSnips-add-snippet*
+                                              *UltiSnips-add-snippets*
  3.4.1 UltiSnips#AddSnippetWithPriority    *UltiSnips#AddSnippetWithPriority*
 
 The first function is UltiSnips#AddSnippetWithPriority(trigger, value, description,


### PR DESCRIPTION
`:h UltiSnips-add-snippets` errors with E149 because no help tag of that name exists. Users naturally search for the topic name (plural and singular) rather than the exact function name `UltiSnips#AddSnippetWithPriority`.

Add both `UltiSnips-add-snippet` and `UltiSnips-add-snippets` as aliases on the section that documents `UltiSnips#AddSnippetWithPriority` (section 3.4.1).

Fixes #1082