### PR TITLE
Always populate g:current_ulti_dict_info from SnippetsInCurrentScope

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -102,10 +102,8 @@ endfunction
 
 function! UltiSnips#SnippetsInCurrentScope(...) abort
     let g:current_ulti_dict = {}
+    let g:current_ulti_dict_info = {}
     let all = get(a:, 1, 0)
-    if all
-      let g:current_ulti_dict_info = {}
-    endif
     py3 UltiSnips_Manager.snippets_in_current_scope(int(vim.eval("all")))
     return g:current_ulti_dict
 endfunction

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -483,6 +483,12 @@ for the current buffer, you can simply pass 1 (which means all) as first
 argument of this function, and use a global variable g:current_ulti_dict_info
 to get the result (see example below).
 
+Regardless of whether the function is called with no argument (matching
+snippets only) or with 1 (all snippets), |g:current_ulti_dict_info| is also
+populated with a dictionary keyed by trigger, where each value has a
+'description' and a 'location' (a "path:linenumber" string pointing at the
+snippet definition, or an empty string for snippets added programmatically).
+
 This function does not add any new functionality to ultisnips directly but
 allows to use third party plugins to integrate the current available snippets.
 For example, all completion plugins that integrate with UltiSnips use this

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -259,18 +259,16 @@ class SnippetManager:
 
             ulti_dict[key] = description
 
-            if search_all:
-                ulti_dict_info[key] = {
-                    "description": description,
-                    "location": location,
-                }
+            ulti_dict_info[key] = {
+                "description": description,
+                "location": location,
+            }
 
         # Assign the full dict at once rather than mutating
         # vim.vars["current_ulti_dict"][key] — neovim's Python API returns a
         # copy for dict values, so per-key mutation is silently lost.
         vim.vars["current_ulti_dict"] = ulti_dict
-        if search_all:
-            vim.vars["current_ulti_dict_info"] = ulti_dict_info
+        vim.vars["current_ulti_dict_info"] = ulti_dict_info
 
     @err_to_scratch_buffer.wrap
     def list_snippets(self):

--- a/test/test_UltiSnipFunc.py
+++ b/test/test_UltiSnipFunc.py
@@ -132,6 +132,53 @@ class VerifyVimDict3(_VimTest):
     wanted = "te'123êabc"
 
 
+class SnippetsInCurrentScope_PopulatesInfoForMatching(_VimTest):
+    """`g:current_ulti_dict_info` should be populated for the matching scope
+    even when `UltiSnips#SnippetsInCurrentScope` is called without the
+    'all' argument (GH #981)."""
+
+    snippets = (("hello", "world"),)
+
+    def _extra_vim_config(self, vim_config):
+        vim_config.extend(
+            [
+                "function! S_SnippetInfoMatching()",
+                "  call UltiSnips#SnippetsInCurrentScope()",
+                "  return '|'.get(get(g:current_ulti_dict_info, 'hello', {}),"
+                " 'location', '!nokey!')",
+                "endfunction",
+                "inoremap <silent> <C-L> <C-R>=S_SnippetInfoMatching()<CR>",
+            ]
+        )
+
+    keys = "hello" + chr(12)
+    wanted = "hello|added"
+
+
+class SnippetsInCurrentScope_PopulatesInfoForAll(_VimTest):
+    """Calling `UltiSnips#SnippetsInCurrentScope(1)` still populates the
+    info dict, with one entry per known snippet."""
+
+    snippets = (
+        ("alpha", "AAA"),
+        ("beta", "BBB"),
+    )
+
+    def _extra_vim_config(self, vim_config):
+        vim_config.extend(
+            [
+                "function! S_SnippetInfoAll()",
+                "  call UltiSnips#SnippetsInCurrentScope(1)",
+                "  return join(sort(keys(g:current_ulti_dict_info)), ',')",
+                "endfunction",
+                "inoremap <silent> <C-L> <C-R>=S_SnippetInfoAll()<CR>",
+            ]
+        )
+
+    keys = chr(12)
+    wanted = "alpha,beta"
+
+
 class AddNewSnippetSource(_VimTest):
     keys = (
         "blumba"


### PR DESCRIPTION
`UltiSnips#SnippetsInCurrentScope()` returned only `{trigger: description}` for the matching scope; consumers that wanted the snippet's defining file/line had to either call with `1` (which switches to "all snippets, not just matching") or parse the output of `:UltiSnipsListSnippets`. Neither is script-friendly.

Always populate `g:current_ulti_dict_info` (`{trigger: {description, location}}`) alongside `g:current_ulti_dict`, regardless of whether the function is called with no argument (matching subset) or `1` (all). Backwards compatible: callers that already relied on the all-snippets case keep working, and the matching case now gains location info too.

Alternatives considered:
- Add a separate `UltiSnips#SnippetsInCurrentScopeWithInfo()` function. Rejected: doubles the public surface for a one-line change in behaviour; consumers would still have to read the same global side-channel.
- Add a second optional argument (e.g. `with_info`) to opt in. Rejected: needless ceremony - populating a single extra global is essentially free, and the field is documented.
- Wontfix and point users at `:UltiSnipsListSnippets`. Rejected: the docs already advertise `g:current_ulti_dict_info` as the structured API; the current behaviour just makes it unavailable in the most common code path.

Fixes #981