### PR TITLE
Add UltiSnips#SnippetLocations and :UltiSnipsListLocations

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -110,6 +110,45 @@ function! UltiSnips#SnippetsInCurrentScope(...) abort
     return g:current_ulti_dict
 endfunction
 
+function! UltiSnips#SnippetLocations() abort
+    " Returns a list of {filename, lnum, text} dicts (quickfix-list format)
+    " describing where each snippet known to UltiSnips is defined. Snippets
+    " whose location is not a file (e.g. those added via
+    " UltiSnips#AddSnippetWithPriority) are omitted.
+    call UltiSnips#SnippetsInCurrentScope(1)
+    let l:result = []
+    for [l:trigger, l:info] in items(g:current_ulti_dict_info)
+        let l:idx = strridx(l:info.location, ':')
+        if l:idx <= 0
+            continue
+        endif
+        let l:lnum = str2nr(strpart(l:info.location, l:idx + 1))
+        if l:lnum <= 0
+            continue
+        endif
+        let l:text = l:trigger
+        if !empty(l:info.description)
+            let l:text .= ' - ' . l:info.description
+        endif
+        call add(l:result, {
+            \ 'filename': strpart(l:info.location, 0, l:idx),
+            \ 'lnum': l:lnum,
+            \ 'text': l:text,
+            \ })
+    endfor
+    return sort(l:result, {a, b -> a.text ==# b.text ? 0 : (a.text <# b.text ? -1 : 1)})
+endfunction
+
+function! UltiSnips#ListSnippetLocations() abort
+    let l:locs = UltiSnips#SnippetLocations()
+    if empty(l:locs)
+        echo "UltiSnips: no snippet definitions with file locations found."
+        return
+    endif
+    call setqflist([], 'r', {'title': 'UltiSnips snippet locations', 'items': l:locs})
+    copen
+endfunction
+
 function! UltiSnips#CanExpandSnippet() abort
 	return py3eval("UltiSnips_Manager.can_expand()")
 endfunction

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -12,6 +12,7 @@ UltiSnips                                      *snippet* *snippets* *UltiSnips*
    3.1 Commands                                 |UltiSnips-commands|
       3.1.1 UltiSnipsEdit                       |UltiSnipsEdit|
       3.1.2 UltiSnipsAddFiletypes               |UltiSnipsAddFiletypes|
+      3.1.3 UltiSnipsListLocations              |UltiSnipsListLocations|
    3.2 Triggers                                 |UltiSnips-triggers|
       3.2.1 Trigger key mappings                |UltiSnips-trigger-key-mappings|
       3.2.2 Using your own trigger functions    |UltiSnips-trigger-functions|
@@ -25,6 +26,8 @@ UltiSnips                                      *snippet* *snippets* *UltiSnips*
       3.4.4 UltiSnips#CanExpandSnippet          |UltiSnips#CanExpandSnippet|
       3.4.5 UltiSnips#CanJumpForwards           |UltiSnips#CanJumpForwards|
       3.4.6 UltiSnips#CanJumpBackwards          |UltiSnips#CanJumpBackwards|
+      3.4.7 UltiSnips#ToggleAutoTrigger         |UltiSnips#ToggleAutoTrigger|
+      3.4.8 UltiSnips#SnippetLocations          |UltiSnips#SnippetLocations|
    3.5 Missing python support                   |UltiSnips-python-warning|
 4. Authoring snippets                           |UltiSnips-authoring-snippets|
    4.1 Basics                                   |UltiSnips-basics|
@@ -241,6 +244,20 @@ snippets you can call >
    :UltiSnipsAddFiletypes ruby.programming
 
 The priority will then be rails -> ruby -> programming -> all.
+
+
+ 3.1.3 UltiSnipsListLocations                          *:UltiSnipsListLocations*
+
+The UltiSnipsListLocations command populates the |quickfix| list with one
+entry per snippet definition known to UltiSnips and opens the list with
+|:copen|. Entries point at the file and line where each snippet is defined,
+so the usual quickfix navigation (|:cnext|, |:cprev|, |<CR>|) jumps to the
+matching snippet. Snippets registered programmatically through
+|UltiSnips#AddSnippetWithPriority| have no file location and are omitted.
+
+See |UltiSnips#SnippetLocations| for the underlying function if you want to
+build your own picker (e.g. fuzzy-finder integration) instead of using the
+quickfix list.
 
 3.2 Triggers                                             *UltiSnips-triggers*
 ------------
@@ -558,6 +575,28 @@ in the Insert mode: >
 By default, `autotrigger` is enabled (relevant for snippets with the option 'A').
 If you want to disable it by default, add the following line to your vimrc: >
     let g:UltiSnipsAutoTrigger = 0
+
+ 3.4.8 UltiSnips#SnippetLocations          *UltiSnips#SnippetLocations*
+
+UltiSnips#SnippetLocations() returns a list of dictionaries with the keys
+'filename', 'lnum', and 'text' - the same shape used by |setqflist()|. Each
+entry points at the file and line where a snippet is defined. Snippets
+without an on-disk location (e.g. those registered with
+|UltiSnips#AddSnippetWithPriority|) are omitted.
+
+This is the structured equivalent of |:UltiSnipsListSnippets| meant for
+plugin authors. Typical use - feed the list to a fuzzy finder or jump
+directly to a single entry: >
+
+    function! GotoSnippet(trigger) abort
+      for entry in UltiSnips#SnippetLocations()
+        if entry.text =~# '^' . a:trigger . '\>'
+          execute 'edit ' . fnameescape(entry.filename)
+          execute entry.lnum
+          return
+        endif
+      endfor
+    endfunction
 
 
 3.5 Warning about missing python support           *UltiSnips-python-warning*

--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -91,6 +91,8 @@ command! -bang -nargs=? -complete=customlist,UltiSnips#FileTypeComplete UltiSnip
 
 command! -nargs=1 UltiSnipsAddFiletypes :call UltiSnips#AddFiletypes(<q-args>)
 
+command! UltiSnipsListLocations :call UltiSnips#ListSnippetLocations()
+
 augroup UltiSnips_AutoTrigger
     au!
     au InsertCharPre * call UltiSnips#TrackChange()

--- a/test/test_SnippetLocations.py
+++ b/test/test_SnippetLocations.py
@@ -1,0 +1,68 @@
+"""Tests for `UltiSnips#SnippetLocations` and `:UltiSnipsListLocations`
+(GH #1198).
+"""
+
+from test.vim_test_case import VimTestCase as _VimTest
+
+C_L = chr(12)  # <C-L>, used to dump the result into the buffer.
+
+
+class SnippetLocations_ReturnsFileBackedSnippets(_VimTest):
+    """`UltiSnips#SnippetLocations()` returns one quickfix-shaped entry per
+    snippet defined in a file, with the trigger and description in `text`."""
+
+    files = {
+        "us/all.snippets": r"""
+        snippet alpha "first one"
+        AAA
+        endsnippet
+
+        snippet beta "second one"
+        BBB
+        endsnippet
+        """
+    }
+
+    def _extra_vim_config(self, vim_config):
+        vim_config.extend(
+            [
+                "function! S_DumpLocations()",
+                "  let entries = UltiSnips#SnippetLocations()",
+                "  return join(map(copy(entries),"
+                ' \'v:val.text . "@" . fnamemodify(v:val.filename, ":t")'
+                " . \":\" . v:val.lnum'), ',')",
+                "endfunction",
+                "inoremap <silent> <C-L> <C-R>=S_DumpLocations()<CR>",
+            ]
+        )
+
+    keys = C_L
+    wanted = "alpha - first one@all.snippets:2,beta - second one@all.snippets:6"
+
+
+class SnippetLocations_OmitsProgrammaticSnippets(_VimTest):
+    """Snippets added through `UltiSnips#AddSnippetWithPriority` carry the
+    placeholder location 'added' (no `:line`) and should be skipped."""
+
+    snippets = (("addedone", "AAA"),)
+    files = {
+        "us/all.snippets": r"""
+        snippet onlyfile "from file"
+        FFF
+        endsnippet
+        """
+    }
+
+    def _extra_vim_config(self, vim_config):
+        vim_config.extend(
+            [
+                "function! S_DumpTriggers()",
+                "  let entries = UltiSnips#SnippetLocations()",
+                "  return join(map(copy(entries), 'v:val.text'), ',')",
+                "endfunction",
+                "inoremap <silent> <C-L> <C-R>=S_DumpTriggers()<CR>",
+            ]
+        )
+
+    keys = C_L
+    wanted = "onlyfile - from file"


### PR DESCRIPTION
There is no built-in way to jump from a `:UltiSnipsEdit` context to *the specific line where a snippet is defined*. Users have been resorting to ad-hoc Python one-liners against `_snips()` and hand-parsing `s.location`.

Expose the same information through two layers:

- `UltiSnips#SnippetLocations()` returns a list of `{filename, lnum, text}` records (the `setqflist()` shape). Snippets without an on-disk location (e.g. those registered through `UltiSnips#AddSnippetWithPriority`) are skipped.
- `:UltiSnipsListLocations` calls that function, fills the quickfix list, and opens it via `:copen` - picking an entry jumps to the snippet definition with standard quickfix bindings.

Plugin authors who want a different UI (fuzzy finder, custom popup, etc) can build on top of the function directly.

Alternatives considered:

- Add a `:UltiSnipsGotoDefinition <trigger>` command that jumps directly without a quickfix list. Rejected as the primary entry point: the original issue asked for *discovery* (browsing all snippets), not just direct navigation. Such a command is one `:execute` line on top of `UltiSnips#SnippetLocations()`, kept out for now to avoid bikeshedding the filtering UX.
- Build a popup picker inside UltiSnips. Rejected: every Vim ecosystem (Telescope, fzf.vim, vim.ui.select, popup_menu, native quickfix) wants its own UI; shipping just the data and one sensible default keeps us out of that argument.
- Wontfix and rely on `g:current_ulti_dict_info`. Rejected: the existing dict requires callers to parse `location` strings into `filename`/`lnum` and to know which scope flag to pass; a one-call function is a strictly nicer API and unlocks `setqflist()` directly.

Fixes #1198