### PR TITLE
Add :UltiSnipsRemoveFiletypes (opposite of UltiSnipsAddFiletypes)

### DIFF
--- a/autoload/UltiSnips.vim
+++ b/autoload/UltiSnips.vim
@@ -60,6 +60,11 @@ function! UltiSnips#AddFiletypes(filetypes) abort
     return ""
 endfunction
 
+function! UltiSnips#RemoveFiletypes(filetypes) abort
+    py3 UltiSnips_Manager.remove_buffer_filetypes(vim.eval("a:filetypes"))
+    return ""
+endfunction
+
 function! UltiSnips#FileTypeComplete(arglead, cmdline, cursorpos) abort
     let ret = {}
     let items = map(

--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -12,7 +12,8 @@ UltiSnips                                      *snippet* *snippets* *UltiSnips*
    3.1 Commands                                 |UltiSnips-commands|
       3.1.1 UltiSnipsEdit                       |UltiSnipsEdit|
       3.1.2 UltiSnipsAddFiletypes               |UltiSnipsAddFiletypes|
-      3.1.3 UltiSnipsListLocations              |UltiSnipsListLocations|
+      3.1.3 UltiSnipsRemoveFiletypes            |UltiSnipsRemoveFiletypes|
+      3.1.4 UltiSnipsListLocations              |UltiSnipsListLocations|
    3.2 Triggers                                 |UltiSnips-triggers|
       3.2.1 Trigger key mappings                |UltiSnips-trigger-key-mappings|
       3.2.2 Using your own trigger functions    |UltiSnips-trigger-functions|
@@ -246,7 +247,24 @@ snippets you can call >
 The priority will then be rails -> ruby -> programming -> all.
 
 
- 3.1.3 UltiSnipsListLocations                          *:UltiSnipsListLocations*
+ 3.1.3 UltiSnipsRemoveFiletypes                      *:UltiSnipsRemoveFiletypes*
+
+The UltiSnipsRemoveFiletypes command is the counterpart of
+|:UltiSnipsAddFiletypes|. It disables the snippets for the listed filetypes
+in the current buffer, even when those filetypes were inherited from
+'filetype' itself (for example after `set filetype=html.css`). The argument
+uses the same dotted syntax.
+
+For example, if `set filetype=html.css` brings in the html snippets but you
+only want the css ones, place the following in `ftplugin/css.vim` (or run
+it ad-hoc): >
+
+   :UltiSnipsRemoveFiletypes html
+
+A subsequent |:UltiSnipsAddFiletypes| with the same filetype re-enables it.
+
+
+ 3.1.4 UltiSnipsListLocations                          *:UltiSnipsListLocations*
 
 The UltiSnipsListLocations command populates the |quickfix| list with one
 entry per snippet definition known to UltiSnips and opens the list with

--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -90,6 +90,7 @@ command! -bang -nargs=? -complete=customlist,UltiSnips#FileTypeComplete UltiSnip
     \ :call UltiSnips#Edit(<q-bang>, <q-args>)
 
 command! -nargs=1 UltiSnipsAddFiletypes :call UltiSnips#AddFiletypes(<q-args>)
+command! -nargs=1 UltiSnipsRemoveFiletypes :call UltiSnips#RemoveFiletypes(<q-args>)
 
 command! UltiSnipsListLocations :call UltiSnips#ListSnippetLocations()
 

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -133,6 +133,7 @@ class SnippetManager:
 
         self._active_snippets = []
         self._added_buffer_filetypes = defaultdict(list)
+        self._removed_buffer_filetypes = defaultdict(set)
 
         self._vstate = VimState()
         self._visual_content = VisualContentPreserver()
@@ -371,25 +372,50 @@ class SnippetManager:
                 break
 
     def get_buffer_filetypes(self):
-        return (
+        removed = self._removed_buffer_filetypes[vim_helper.buf.number]
+        fts = (
             self._added_buffer_filetypes[vim_helper.buf.number]
             + vim_helper.buf.filetypes
             + ["all"]
         )
+        return [ft for ft in fts if ft not in removed]
 
     def add_buffer_filetypes(self, filetypes: str):
         """'filetypes' is a dotted filetype list, for example 'cuda.cpp'"""
         buf_fts = self._added_buffer_filetypes[vim_helper.buf.number]
+        removed = self._removed_buffer_filetypes[vim_helper.buf.number]
         idx = -1
         for ft in filetypes.split("."):
             ft = ft.strip()
             if not ft:
                 continue
+            # Adding a filetype overrides a previous removal so the user can
+            # cleanly re-enable a filetype they had disabled.
+            removed.discard(ft)
             try:
                 idx = buf_fts.index(ft)
             except ValueError:
                 self._added_buffer_filetypes[vim_helper.buf.number].insert(idx + 1, ft)
                 idx += 1
+
+    def remove_buffer_filetypes(self, filetypes: str):
+        """Disable snippets for the given filetypes in the current buffer.
+
+        Accepts the same dotted filetype syntax as |add_buffer_filetypes|
+        (e.g. 'html.css'). Filetypes that came from `&filetype`, from a
+        previous `add_buffer_filetypes`, or implicitly through `all` are all
+        eligible to be removed. Removal is persistent for the lifetime of the
+        buffer; a later `add_buffer_filetypes` re-enables the filetype.
+        """
+        buf_fts = self._added_buffer_filetypes[vim_helper.buf.number]
+        removed = self._removed_buffer_filetypes[vim_helper.buf.number]
+        for ft in filetypes.split("."):
+            ft = ft.strip()
+            if not ft:
+                continue
+            removed.add(ft)
+            if ft in buf_fts:
+                buf_fts.remove(ft)
 
     @err_to_scratch_buffer.wrap
     def _cursor_moved(self):

--- a/test/test_RemoveFiletypes.py
+++ b/test/test_RemoveFiletypes.py
@@ -1,0 +1,75 @@
+"""Tests for `:UltiSnipsRemoveFiletypes` (GH #792).
+
+Removes the snippets that come from a filetype the buffer would otherwise
+inherit (via `&filetype`, via a previous `:UltiSnipsAddFiletypes`, or the
+implicit `all`).
+"""
+
+from test.constant import EX
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class RemoveFiletypes_DisablesInheritedFiletype(_VimTest):
+    """`set filetype=html.css` brings in both html and css snippets;
+    `:UltiSnipsRemoveFiletypes html` should suppress the html one."""
+
+    files = {
+        "us/html.snippets": r"""
+        snippet ftrm "html"
+        FROM_HTML
+        endsnippet
+        """,
+        "us/css.snippets": r"""
+        snippet ftrm "css"
+        FROM_CSS
+        endsnippet
+        """,
+    }
+
+    def _before_test(self):
+        self.vim.send_to_vim(":set filetype=html.css\n")
+        self.vim.send_to_vim(":UltiSnipsRemoveFiletypes html\n")
+
+    keys = "ftrm" + EX
+    wanted = "FROM_CSS"
+
+
+class RemoveFiletypes_RestoredByAdd(_VimTest):
+    """A subsequent `:UltiSnipsAddFiletypes` re-enables a previously removed
+    filetype."""
+
+    files = {
+        "us/html.snippets": r"""
+        snippet ftrm "html"
+        FROM_HTML
+        endsnippet
+        """,
+    }
+
+    def _before_test(self):
+        self.vim.send_to_vim(":set filetype=html\n")
+        self.vim.send_to_vim(":UltiSnipsRemoveFiletypes html\n")
+        self.vim.send_to_vim(":UltiSnipsAddFiletypes html\n")
+
+    keys = "ftrm" + EX
+    wanted = "FROM_HTML"
+
+
+class RemoveFiletypes_DisablesAddedFiletype(_VimTest):
+    """A filetype injected through `:UltiSnipsAddFiletypes` can also be
+    removed."""
+
+    files = {
+        "us/extra.snippets": r"""
+        snippet ftrm "extra"
+        FROM_EXTRA
+        endsnippet
+        """,
+    }
+
+    def _before_test(self):
+        self.vim.send_to_vim(":UltiSnipsAddFiletypes extra\n")
+        self.vim.send_to_vim(":UltiSnipsRemoveFiletypes extra\n")
+
+    keys = "ftrm" + EX
+    wanted = "ftrm" + EX


### PR DESCRIPTION
Users with `autocmd FileType css set filetype=html.css` (e.g. to get YouCompleteMe / ctags completion working in css) end up with both html and css snippets active and have no way to suppress one side. The issue (open since 2018, three +1s) requests an explicit removal command.

Implementation:

- Track a per-buffer `_removed_buffer_filetypes` set in `SnippetManager`.
- `get_buffer_filetypes()` filters both `&filetype`-derived and previously added filetypes through that set, so removal works regardless of where the filetype came from.
- A subsequent `:UltiSnipsAddFiletypes` clears the removal so the user can toggle freely.
- Expose via `UltiSnips#RemoveFiletypes(...)` and `:UltiSnipsRemoveFiletypes`, mirroring the add side.

Alternatives considered:

- `:UltiSnipsSetFiletypes` (replaces the entire filetype list). Rejected: collides with Vim's `set filetype=...` semantics and prevents `+ ["all"]` from doing its job; the explicit add/remove pair is more composable.
- Wontfix and document the `_removed` Python attribute. Rejected: requires user code to import private state and re-resolve on every buffer; not maintainable.
- Restrict removal to filetypes that were added via the matching command. Rejected: the OP's exact scenario (`set filetype=html.css`) has no preceding `:UltiSnipsAddFiletypes`, so that restriction would not fix the issue.

Fixes #792