### PR TITLE
Add 'p' snippet option for partial prefix expansion

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -851,6 +851,14 @@ The options currently supported are: >
        python expression. This option can be specified along with other
        options, like 'b'. See |UltiSnips-custom-context-snippets| for more info.
 
+   p   Partial prefix expansion - With this option the snippet expands when a
+       non-empty prefix of its trigger has been typed. For example, with the
+       trigger 'import' and option 'p', typing any of 'i', 'im', 'imp', 'impo',
+       'impor' or 'import' and pressing the expansion key replaces what was
+       typed with the snippet body. Only the characters the user actually
+       typed are removed, not the whole trigger. If several snippets resolve
+       to the same prefix you will be prompted to choose between them.
+
    A   Snippet will be triggered automatically, when condition matches.
        See |UltiSnips-autotrigger| for more info.
 

--- a/pythonx/UltiSnips/snippet/definition/base.py
+++ b/pythonx/UltiSnips/snippet/definition/base.py
@@ -333,6 +333,14 @@ class SnippetDefinition:
                 match = vim_helper.eval(f'"{boundary_chars}" =~# "\\\\v.<."') != "0"
         elif "i" in self._opts:
             match = words.endswith(self._trigger)
+        elif "p" in self._opts:
+            # Partial prefix: match if the user typed a non-empty prefix of
+            # the trigger. The typed prefix (not the full trigger) is what
+            # gets removed before expansion, so the user only loses what
+            # they actually typed.
+            match = bool(words) and self._trigger.startswith(words)
+            if match:
+                self._matched = words
         else:
             match = words == self._trigger
 

--- a/syntax/snippets.vim
+++ b/syntax/snippets.vim
@@ -82,7 +82,7 @@ syn match snipSnippetDocContextString ,"[^"]*", contained nextgroup=snipSnippetC
 syn match snipSnippetContext ,"[^"]\+", contained skipwhite contains=snipSnippetContextP
 syn region snipSnippetContextP start=,"\@<=., end=,", contained contains=@Python nextgroup=snipSnippetOptions skipwhite keepend
 syn match snipSnippetOptions ,\S\+, contained contains=snipSnippetOptionFlag
-syn match snipSnippetOptionFlag ,[biwrtsmxAe], contained
+syn match snipSnippetOptionFlag ,[biwrtspmxAe], contained
 
 " Command substitution {{{4
 

--- a/test/test_PartialPrefix.py
+++ b/test/test_PartialPrefix.py
@@ -1,0 +1,87 @@
+"""Tests for the 'p' snippet option (GH #1207).
+
+A snippet declared with the 'p' option expands when the user has typed
+any non-empty prefix of the trigger. Only the characters the user actually
+typed are removed before the expansion is inserted.
+"""
+
+from test.constant import EX
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class PartialPrefix_ExpandsOnSingleChar(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        snippet import "imp" p
+        IMPORT_BODY
+        endsnippet
+        """
+    }
+    keys = "i" + EX
+    wanted = "IMPORT_BODY"
+
+
+class PartialPrefix_ExpandsOnIntermediatePrefix(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        snippet import "imp" p
+        IMPORT_BODY
+        endsnippet
+        """
+    }
+    keys = "imp" + EX
+    wanted = "IMPORT_BODY"
+
+
+class PartialPrefix_ExpandsOnFullTrigger(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        snippet import "imp" p
+        IMPORT_BODY
+        endsnippet
+        """
+    }
+    keys = "import" + EX
+    wanted = "IMPORT_BODY"
+
+
+class PartialPrefix_PreservesTextBeforeTypedPrefix(_VimTest):
+    """Only the typed prefix is consumed - text before it stays put."""
+
+    files = {
+        "us/all.snippets": r"""
+        snippet import "imp" p
+        IMPORT_BODY
+        endsnippet
+        """
+    }
+    keys = "hello imp" + EX
+    wanted = "hello IMPORT_BODY"
+
+
+class PartialPrefix_DoesNotMatchOnEmpty(_VimTest):
+    """Without typing anything (just <Tab>), the trigger shouldn't expand."""
+
+    files = {
+        "us/all.snippets": r"""
+        snippet import "imp" p
+        IMPORT_BODY
+        endsnippet
+        """
+    }
+    keys = EX
+    wanted = EX
+
+
+class PartialPrefix_WithoutOption_StillRequiresFullTrigger(_VimTest):
+    """A plain snippet (no 'p') still requires the full trigger."""
+
+    files = {
+        "us/all.snippets": r"""
+        snippet import "imp"
+        IMPORT_BODY
+        endsnippet
+        """
+    }
+    keys = "imp" + EX
+    wanted = "imp" + EX


### PR DESCRIPTION
Users want to declare a snippet whose trigger is, e.g., 'import', and have any non-empty prefix ('i', 'im', 'imp', 'impo', 'impor', 'import') expand. The existing workaround is an awkward regex trigger like `i(?:m(?:p(?:o(?:rt?)?)?)?)?`. SirVer indicated in the issue that a snippet option for this is welcome.

Add a new option letter 'p' (Partial prefix). In `matches()`, when the option is set, we match if the typed word is a non-empty prefix of the trigger and only consume what the user actually typed - so any text before the prefix stays untouched. `could_match()` needs no change because its default branch already accepts partial-prefix typing.

Alternatives considered:

- A `g:UltiSnipsAllowPartialPrefix` global. Rejected: users want this per-snippet (e.g. 'import' yes, but not 'i' as a separate snippet), and a global flag would change behaviour for the whole snippet collection.
- `:UltiSnipsExpandSnippetOrShorter` mapping built from `UltiSnips#SnippetsInCurrentScope` (the existing docs example). Wontfix-flavoured alternative; works only when exactly one snippet matches the typed prefix and forces users to bind a separate key.
- Recommend completion plugins (deoplete / nvim-cmp). Wontfix-flavoured alternative; doesn't expand the snippet with its tabstops, only inserts the trigger text.

Fixes #1207