### PR TITLE
Add 'x' snippet option to finish in normal mode

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -791,6 +791,13 @@ The options currently supported are: >
    A   Snippet will be triggered automatically, when condition matches.
        See |UltiSnips-autotrigger| for more info.
 
+   x   Exit to normal mode at the final tabstop. When the user reaches the
+       snippet's final tabstop ($0) by jumping forward, UltiSnips drops out
+       of insert / select mode rather than parking the cursor in insert
+       mode. Useful for snippets that are complete utterances after the
+       last jump (e.g. a small templating snippet whose $0 marks a place
+       you immediately want to navigate away from).
+
 The end line is the 'endsnippet' keyword on a line by itself. >
 
    endsnippet

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -640,9 +640,15 @@ class SnippetManager:
                         )
                         self._current_snippet_is_done()
                         if finish_in_normal_mode:
-                            # vim_helper.select() already left us in normal
-                            # mode synchronously; dropping move_cmd is enough
-                            # to keep us there.
+                            # Queue an `<Esc>` at the *front* of the typeahead
+                            # (the `i` flag) so it is processed before any
+                            # follow-up user keystrokes still in the input
+                            # queue. The deferred `:stopinsert` queued inside
+                            # `vim_helper.select()` is not reliably consumed
+                            # between this Python callback returning and the
+                            # next key being processed; an explicit prepended
+                            # `<Esc>` guarantees normal mode.
+                            vim.command(r'call feedkeys("\<Esc>", "in")')
                             move_cmd = ""
                 else:
                     # This really shouldn't happen, because a snippet should

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -631,7 +631,19 @@ class SnippetManager:
                         self._vstate.remember_buffer(self._active_snippets[0])
 
                     if ntab.number == 0 and self._active_snippets:
+                        # The 'x' option asks for normal mode once the snippet
+                        # reaches its final tabstop. Capture the request before
+                        # popping the snippet, then suppress the queued
+                        # insert-mode re-entry below.
+                        finish_in_normal_mode = (
+                            self._current_snippet.snippet.has_option("x")
+                        )
                         self._current_snippet_is_done()
+                        if finish_in_normal_mode:
+                            # vim_helper.select() already left us in normal
+                            # mode synchronously; dropping move_cmd is enough
+                            # to keep us there.
+                            move_cmd = ""
                 else:
                     # This really shouldn't happen, because a snippet should
                     # have been popped when its final tabstop was used.

--- a/test/test_FinishInNormalMode.py
+++ b/test/test_FinishInNormalMode.py
@@ -39,3 +39,25 @@ class FinishInNormalMode_NoOption_LandsInInsertMode(_VimTest):
     }
     keys = "bb" + EX + JF + "iX"
     wanted = "foobarbaziX"
+
+
+class FinishInNormalMode_EmptyTabstopOrigin(_VimTest):
+    """Regression for the issue reporter: jumping from an *empty* tabstop
+    ($1 with no default placeholder, so we entered insert mode rather
+    than select mode) must still land in normal mode at $0.
+
+    Probe Vim's `mode()` right after the jump and stash it in the buffer.
+    The `:stopinsert` queued inside `vim_helper.select()` is not reliably
+    consumed before the next user keystroke; this test pins the synchronous
+    Esc-via-feedkeys behaviour that fixes it.
+    """
+
+    files = {
+        "us/all.snippets": r"""
+        snippet footle "Description" x
+        ${1} $1: foo$0
+        endsnippet
+        """
+    }
+    keys = "footle" + EX + "X" + JF + ":put =mode(1)\n"
+    wanted = "X X: foo\nn"

--- a/test/test_FinishInNormalMode.py
+++ b/test/test_FinishInNormalMode.py
@@ -1,0 +1,41 @@
+"""Tests for the 'x' snippet option (GH #1399).
+
+A snippet declared with the 'x' option lands in normal mode once the user
+has jumped through to the final tabstop ($0).
+"""
+
+from test.constant import EX, JF
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class FinishInNormalMode_LandsInNormalAtFinalTabstop(_VimTest):
+    """Inserting in normal mode via `i` should be needed to add more text -
+    if we were still in insert mode the `i` would just be typed."""
+
+    files = {
+        "us/all.snippets": r"""
+        snippet bb "exit" x
+        foo${1:bar}baz$0
+        endsnippet
+        """
+    }
+    # bb<Tab> expands. We're on tabstop 1 (in select mode over "bar").
+    # JF (?) advances to $0 -- option 'x' should put us in normal mode.
+    # Typing `iX` in normal mode runs `i` (enter insert mode) then types X.
+    keys = "bb" + EX + JF + "iX"
+    wanted = "foobarbaXz"
+
+
+class FinishInNormalMode_NoOption_LandsInInsertMode(_VimTest):
+    """Same snippet without 'x' parks the cursor in insert mode -- the `i`
+    is typed verbatim."""
+
+    files = {
+        "us/all.snippets": r"""
+        snippet bb "no exit"
+        foo${1:bar}baz$0
+        endsnippet
+        """
+    }
+    keys = "bb" + EX + JF + "iX"
+    wanted = "foobarbaziX"


### PR DESCRIPTION
A small templating snippet whose `$0` marks a position the user immediately wants to navigate away from (e.g. snippets that drop in a relationship block in a YAML model) ends with the user reaching for `<Esc>` every time. The issue requests a snippet option so this is per-snippet rather than a workaround mapping or `post_jump` timer trick.

Add a snippet option `x`. When the user reaches the snippet's final tabstop (`$0`) by jumping forward, the queued insert-mode re-entry is suppressed so the cursor lands in normal mode instead. The synchronous `stopinsert` / `<C-\><C-N>` performed inside `vim_helper.select()` already leaves us in normal mode; we only need to skip the `move_cmd` that would otherwise feed `i` / `a` back in.

Alternatives considered:

- Document the `post_jump` workaround (`if not snip.tabstop: vim.eval('timer_start(0,{-> feedkeys("\\<Esc>")})')`). Wontfix-flavoured; works today but requires every snippet author to copy a non-obvious timer dance.
- Hard-code `<Esc>` into `move_cmd`. Rejected: timer ordering makes mode-leave brittle on top of `post_jump`-issued feedkeys; dropping `move_cmd` is simpler and uses the already-synchronous mode change inside `vim_helper.select()`.
- A global `g:UltiSnipsExitOnFinalTabstop` flag. Rejected: most snippets want to stay in insert mode; the choice is per-snippet.

Fixes #1399