### PR TITLE
Add post_finish snippet action

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -1688,13 +1688,16 @@ tabstop value following by ' == nil'.
 A snippet action is an arbitrary python code which can be executed at specific
 points in the lifetime of a snippet expansion.
 
-There are three types of actions:
+There are four types of actions:
 
 * Pre-expand - invoked just after trigger condition was matched, but before
   snippet actually expanded;
 * Post-expand - invoked after snippet was expanded and interpolations
   were applied for the first time, but before jump on the first placeholder.
 * Jump - invoked just after a jump to the next/prev placeholder.
+* Post-finish - invoked once the snippet is removed from the active stack
+  (after the last tabstop is reached, when the cursor leaves the snippet,
+  or when the buffer changes). Useful to undo state set in `pre_expand`.
 
 Specified code will be evaluated at stages defined above and same global
 variables and modules will be available that are stated in
@@ -1856,6 +1859,27 @@ file:
 
 'insert_toc_item' will be called after first jump and will add newly entered
 section into the TOC for current file.
+
+4.10.4 Post-finish actions                     *UltiSnips-post-finish-actions*
+
+Post-finish actions are invoked exactly once, when the snippet is being
+removed from the active snippet stack. That happens when the user jumps
+through the final tabstop, when the cursor moves outside the snippet's
+bounds, or when the buffer is left. Use them to clean up state that was
+set up earlier in 'pre_expand' (for example, to re-enable a completion
+plugin that was suspended for the duration of the snippet).
+
+Post-finish action declared as follows: >
+    post_finish "python code here"
+    snippet ...
+    endsnippet
+
+Buffer can be modified through 'snip.buffer'. Variables
+'snip.snippet_start' and 'snip.snippet_end' point at the final positions
+of the start and end of the snippet that just finished.
+
+Because 'post_finish' runs as the snippet is being torn down, do not rely
+on 'snip.cursor' or on jumping to further tabstops from this action.
 
 Note: It is also possible to trigger snippet expansion from the jump action.
 In that case method 'snip.cursor.preserve()' should be called, so UltiSnips

--- a/pythonx/UltiSnips/snippet/definition/base.py
+++ b/pythonx/UltiSnips/snippet/definition/base.py
@@ -448,6 +448,21 @@ class SnippetDefinition:
             return snip.cursor.is_set()
         return False
 
+    def do_post_finish(self, snippet_instance):
+        if "post_finish" in self._actions:
+            locals = {
+                "snippet_start": snippet_instance.start,
+                "snippet_end": snippet_instance.end,
+                "buffer": vim_helper.buf,
+            }
+
+            self._execute_action(
+                self._actions["post_finish"],
+                snippet_instance.context,
+                locals,
+                self._compiled_actions["post_finish"],
+            )
+
     def do_post_jump(
         self, tabstop_number, jump_direction, snippets_stack, current_snippet
     ):

--- a/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
+++ b/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
@@ -182,7 +182,7 @@ def _parse_snippets_file(data, filename):
                 current_priority = int(tail.split()[0])
             except (ValueError, IndexError):
                 yield "error", (f"Invalid priority {tail!r}", lines.line_index)
-        elif head in ["pre_expand", "post_expand", "post_jump"]:
+        elif head in ["pre_expand", "post_expand", "post_jump", "post_finish"]:
             head, tail = handle_action(head, tail, lines.line_index)
             if head == "error":
                 yield (head, tail)

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -564,6 +564,13 @@ class SnippetManager:
 
     def _current_snippet_is_done(self):
         """The current snippet should be terminated."""
+        snippet_instance = self._active_snippets[-1]
+        snippets_stack = self._active_snippets[:]
+        with (
+            use_proxy_buffer(snippets_stack, self._vstate, self._change_provider),
+            self._action_context(),
+        ):
+            snippet_instance.snippet.do_post_finish(snippet_instance)
         self._active_snippets.pop()
         if not self._active_snippets:
             self._teardown_inner_state()

--- a/test/test_PostFinishAction.py
+++ b/test/test_PostFinishAction.py
@@ -1,0 +1,57 @@
+"""Tests for the `post_finish` snippet action (GH #1415).
+
+A `post_finish` action runs once when the snippet is removed from the
+active stack - whether the user jumped through the final tabstop, moved
+the cursor out of the snippet, or left the buffer.
+"""
+
+from test.constant import EX, JF
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class PostFinish_RunsOnFinalTabstop(_VimTest):
+    """The post_finish action should run when the user jumps through the
+    final tabstop. We verify by writing a marker line to a known position
+    immediately after the snippet body."""
+
+    files = {
+        "us/all.snippets": r"""
+        global !p
+        def record(snip):
+            line = snip.snippet_end[0] + 1
+            snip.buffer[line:line] = ['FINISHED']
+        endglobal
+
+        post_finish "record(snip)"
+        snippet pf "post-finish single tabstop"
+        body${1:placeholder}tail$0
+        endsnippet
+        """
+    }
+    keys = "pf" + EX + JF
+    wanted = "bodyplaceholdertail\nFINISHED"
+
+
+class PostFinish_RunsOnce(_VimTest):
+    """The post_finish action should run exactly once per snippet
+    expansion - even if the user jumps back and forth between tabstops."""
+
+    files = {
+        "us/all.snippets": r"""
+        global !p
+        def record(snip):
+            line = snip.snippet_end[0] + 1
+            existing = snip.buffer[line] if line < len(snip.buffer) else ''
+            snip.buffer[line:line] = [existing + 'X']
+        endglobal
+
+        post_finish "record(snip)"
+        snippet pf2 "post-finish runs once"
+        ${1:a}.${2:b}.$0
+        endsnippet
+        """
+    }
+    # Jump through two named tabstops to reach $0; bouncing in between
+    # would call post_jump (not post_finish).
+    keys = "pf2" + EX + "1" + JF + "2" + JF
+    wanted = "1.2.\nX"


### PR DESCRIPTION
State set in `pre_expand` (e.g. disabling YouCompleteMe's autocompleter for the duration of the snippet) cannot be reliably reset today. `post_jump` only fires on tabstops and is therefore skipped when the user abandons the snippet without jumping. The original reporter has a working reference implementation.

Add a fourth action, `post_finish`, that runs exactly once when the snippet leaves the active stack - whether through tabbing through the final tabstop, the cursor moving outside its bounds, or the buffer being left. Mirrors the existing action surface: the same Python locals (`snip.buffer`, `snip.snippet_start/_end`, `snip.context`) are available, and it is parsed alongside `pre_expand` / `post_expand` / `post_jump` in `ulti_snips.py`.

Alternatives considered:

- Use a `post_jump` action and gate on `snip.tabstop == 0`. Rejected as the only mechanism: it does not fire when the user abandons the snippet (e.g. clicks elsewhere) - the exact case the reporter complained about.
- Use the `User UltiSnipsExitLastSnippet` autocmd. Rejected: it is a global event with no access to the specific snippet's locals, so a snippet author cannot scope cleanup to the snippet they expanded.
- Wontfix and document the `post_jump` workaround. Rejected because (a) the workaround has a hole on cursor-leave, (b) the issue author already wrote and prototyped a clean implementation.

Fixes #1415