### PR TITLE
Expose snip.visual_text / .visual_mode in post_jump

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -1819,6 +1819,13 @@ Next variables and methods will be also defined in the action code scope:
 * 'snip.snippet_start' - (line, column) of start of the expanded snippet;
 * 'snip.snippet_end' - (line, column) of end of the expanded snippet;
 * 'snip.expand_anon()' - alias for 'UltiSnips_Manager.expand_anon()';
+* 'snip.visual_text' - the visual selection captured when the snippet was
+  expanded from visual mode (empty string when expanded outside of visual
+  mode);
+* 'snip.visual_mode' - the corresponding |visual-mode| character ("v", "V",
+  "\<C-V>"), empty when there was no selection;
+* 'snip.visual_content' - the underlying object exposing both as attributes
+  ('.text', '.mode');
 
 The argument to 'snip.expand_anon()' is parsed as a snippet body, so the full
 snippet DSL is available: backticks run shell code, '$N' creates tabstops, and

--- a/pythonx/UltiSnips/snippet/definition/base.py
+++ b/pythonx/UltiSnips/snippet/definition/base.py
@@ -455,6 +455,10 @@ class SnippetDefinition:
             start = current_snippet.start
             end = current_snippet.end
 
+            visual_content = current_snippet.visual_content
+            visual_text = visual_content.text if visual_content else ""
+            visual_mode = visual_content.mode if visual_content else ""
+
             locals = {
                 "tabstop": tabstop_number,
                 "jump_direction": jump_direction,
@@ -462,6 +466,9 @@ class SnippetDefinition:
                 "snippet_start": start,
                 "snippet_end": end,
                 "buffer": vim_helper.buf,
+                "visual_content": visual_content,
+                "visual_text": visual_text,
+                "visual_mode": visual_mode,
             }
 
             snip = self._execute_action(

--- a/pythonx/UltiSnips/text_objects/snippet_instance.py
+++ b/pythonx/UltiSnips/text_objects/snippet_instance.py
@@ -8,11 +8,15 @@ also a TextObject.
 
 """
 
+from collections import namedtuple
+
 from UltiSnips import vim_helper
 from UltiSnips.error import PebkacError
 from UltiSnips.position import JumpDirection, Position
 from UltiSnips.text_objects.base import EditableTextObject, NoneditableTextObject
 from UltiSnips.text_objects.tabstop import TabStop
+
+_VisualContentSnapshot = namedtuple("_VisualContentSnapshot", ["mode", "text"])
 
 
 class SnippetInstance(EditableTextObject):
@@ -42,7 +46,15 @@ class SnippetInstance(EditableTextObject):
         self.locals = {"match": last_re, "context": context}
         self.globals = globals
         self._compiled_globals = _compiled_globals
-        self.visual_content = visual_content
+        # Snapshot mode + text right at launch. The live preserver gets
+        # reset() immediately after launch returns, so any later read
+        # (e.g. inside `post_jump` / `post_finish`) needs a frozen view.
+        if visual_content is None:
+            self.visual_content = _VisualContentSnapshot("", "")
+        else:
+            self.visual_content = _VisualContentSnapshot(
+                visual_content.mode, visual_content.text
+            )
         self.current_placeholder = None
 
         super().__init__(parent, start, end, initial_text)

--- a/test/test_VisualInPostJump.py
+++ b/test/test_VisualInPostJump.py
@@ -1,0 +1,56 @@
+"""Tests for `snip.visual_text` / `snip.visual_mode` in `post_jump` (GH #1524).
+
+Both attributes are now exposed alongside `snip.tabstop` / `snip.tabstops`
+so authors can build snippets that consume the visual selection without
+having to stash it in `context` first.
+"""
+
+from test.constant import ESC, EX, JF
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class VisualInPostJump_ExposesText(_VimTest):
+    """`snip.visual_text` carries the selection through to `post_jump`."""
+
+    files = {
+        "us/all.snippets": r"""
+        global !p
+        def append_visual(snip):
+            if snip.tabstop == 0:
+                line = snip.snippet_end[0] + 1
+                snip.buffer[line:line] = ['VT:' + snip.visual_text]
+        endglobal
+
+        post_jump "append_visual(snip)"
+        snippet vp "post-jump visual" b
+        BODY $1
+        endsnippet
+        """
+    }
+    # Type "hello", visually select it, expand the snippet, then jump to
+    # $0 so `post_jump` can read `snip.visual_text`.
+    keys = "hello" + ESC + "0vllll" + EX + "vp" + EX + "X" + JF
+    wanted = "BODY X\nVT:hello"
+
+
+class VisualInPostJump_EmptyWithoutSelection(_VimTest):
+    """`snip.visual_text` is the empty string when no visual selection
+    preceded the expansion - the action must not raise AttributeError."""
+
+    files = {
+        "us/all.snippets": r"""
+        global !p
+        def record(snip):
+            if snip.tabstop == 0:
+                line = snip.snippet_end[0] + 1
+                snip.buffer[line:line] = ['VT:[' + snip.visual_text + ']']
+        endglobal
+
+        post_jump "record(snip)"
+        snippet vp2 "post-jump no visual"
+        BODY$1
+        endsnippet
+        """
+    }
+    keys = "vp2" + EX + "X" + JF
+    wanted = "BODYX\nVT:[]"


### PR DESCRIPTION
Actions like `post_jump` cannot see the visual selection that triggered the snippet - `snip.visual_text` raises AttributeError - forcing users to stash the value in `context` first and read it back out (the workaround Paul Fioravanti documented in the issue). That dance is undiscoverable and rules out anonymous snippets.

Two pieces:

- Snapshot `visual_content` on `SnippetInstance.__init__` (a `(mode, text)` namedtuple). The previously stored reference was the live `VisualContentPreserver`, which gets `reset()` immediately after `launch()` returns, so anything reading `visual_content.text` later (post_expand / post_jump / post_finish actions) saw the empty post-reset value. Existing consumers in `PythonCode` / `Visual` already read at launch time and continue to work.
- Add `visual_text`, `visual_mode`, `visual_content` to the action locals in `do_post_jump`, mirroring what context-code already exposes.

Alternatives considered:

- Wontfix and document the `context` workaround. Rejected: the workaround was already in the issue thread for two years and confirmed unsatisfactory; matching the existing context-code surface is a one-line locals update.
- Reset the preserver later. Rejected: `_visual_content.reset()` is called intentionally so the next snippet expansion does not inherit the prior selection; a per-instance snapshot is the right encapsulation.
- Only expose `visual_text` (not `visual_mode` / `visual_content`). Rejected: context-code already exposes all three; keeping the action surface in lockstep is cheaper than divergence.

Fixes #1524