### PR TITLE
Drop self-deprecating maintenance framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ Please add pull requests and issues there.
 
 UltiSnips was started in Jun 2009 by @SirVer. In Dec 2015, maintenance was
 handed over to [@seletskiy](https://github.com/seletskiy) who ran out of time
-in early 2017. Since Jun 2019, @SirVer is maintaining UltiSnips again on a
-very constrained time budget. If you can help triaging issues it would be
-greatly appreciated.
+in early 2017. Since Jun 2019, @SirVer has been maintaining UltiSnips again.
 
 
 Quick Start

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,9 +7,8 @@ No new feature will be accepted without good test coverage, passing CI and prope
 
 ## Before you add a feature
 
-UltiSnips is so rich on features that it borders on feature creep.
-It is also an understaffed and undermaintained project.
-Since every feature needs to be maintained forever, we are very careful about new ones.
+UltiSnips has a deep feature set, and every feature needs to be maintained
+forever, so we like to align on a design before code is written.
 Please create alignment before putting too much work into a novel idea.
 There are several ways of doing this:
 
@@ -17,7 +16,7 @@ There are several ways of doing this:
 2. Open a PR with a hackish or minimal implementation, i.e. no tests and no docs.
 3. Write a short (<= 1 page) design doc in a Gist or on Google Docs.
 
-Should there be agreement that your feature idea adds enough value to offset the maintenance burden, you can go ahead and implement it, including tests and documentation.
+Once there is agreement on the shape of the feature, you can go ahead and implement it, including tests and documentation.
 
 ## Debugging
 


### PR DESCRIPTION
The README and CONTRIBUTING.md described UltiSnips as understaffed / undermaintained and asked readers to help triage issues. That framing no longer matches reality - the project is actively maintained with a healthy throughput of fixes and feature work.