### PR TITLE
Detect UltiSnips syntax in snipMate snippets/ directory

### DIFF
--- a/pythonx/UltiSnips/snippet/source/file/snipmate.py
+++ b/pythonx/UltiSnips/snippet/source/file/snipmate.py
@@ -81,6 +81,25 @@ def _parse_snippet(line, lines, filename):
     )
 
 
+# Directives that only exist in UltiSnips files. When we see one of these at
+# the top level of a snipMate file the user almost certainly placed an
+# UltiSnips-format file into a 'snippets/' directory. Several closed issues
+# (#233, #828, #1214, #1387, #1489) trace back to this confusion.
+_ULTISNIPS_DIRECTIVES = frozenset(
+    {
+        "endsnippet",
+        "global",
+        "priority",
+        "pre_expand",
+        "post_expand",
+        "post_jump",
+        "post_finish",
+        "clearsnippets",
+        "context",
+    }
+)
+
+
 def _parse_snippets_file(data, filename):
     """Parse 'data' assuming it is a .snippets file.
 
@@ -99,6 +118,19 @@ def _parse_snippets_file(data, filename):
             snippet = _parse_snippet(line, lines, filename)
             if snippet is not None:
                 yield snippet
+        elif head in _ULTISNIPS_DIRECTIVES:
+            yield (
+                "error",
+                (
+                    f"{head!r} is UltiSnips syntax, but this file lives in a "
+                    "'snippets/' directory which is reserved for snipMate. "
+                    "Move the file to a directory named 'UltiSnips' (see "
+                    ":help g:UltiSnipsSnippetDirectories) or set "
+                    "'g:UltiSnipsEnableSnipMate = 0' to stop loading snipMate "
+                    "snippets",
+                    lines.line_index,
+                ),
+            )
         elif head and not head.startswith("#"):
             yield "error", (f"Invalid line {line.rstrip()!r}", lines.line_index)
 

--- a/test/test_SnipMate.py
+++ b/test/test_SnipMate.py
@@ -245,3 +245,55 @@ snippet .
     }
     keys = "os." + EX + "foo\n." + EX
     wanted = "os.\tfoo\nself."
+
+
+class snipMate_UltiSnipsSyntaxInSnippetsDir_endsnippet(_VimTest):
+    # See #233, #1489: people regularly drop an UltiSnips-format file into
+    # `snippets/` (the snipMate-reserved directory) and get an opaque
+    # 'Invalid line' error. Verify we now point them at the fix.
+    files = {
+        "snippets/_.snippets": """
+snippet hello "greeting" b
+\tThis is a test snippet
+endsnippet
+"""
+    }
+    keys = "hello" + EX
+    wanted = "hello" + EX
+    expected_error = (
+        r"'endsnippet' is UltiSnips syntax, but this file lives in a "
+        r"'snippets/' directory which is reserved for snipMate"
+    )
+
+
+class snipMate_UltiSnipsSyntaxInSnippetsDir_priority(_VimTest):
+    files = {
+        "snippets/_.snippets": """
+priority 50
+snippet hello
+\tworld
+"""
+    }
+    keys = "hello" + EX
+    wanted = "hello" + EX
+    expected_error = (
+        r"'priority' is UltiSnips syntax, but this file lives in a "
+        r"'snippets/' directory which is reserved for snipMate"
+    )
+
+
+class snipMate_UltiSnipsSyntaxInSnippetsDir_globalp(_VimTest):
+    files = {
+        "snippets/_.snippets": """
+global !p
+def foo():
+    return 'bar'
+endglobal
+"""
+    }
+    keys = "hello" + EX
+    wanted = "hello" + EX
+    expected_error = (
+        r"'global' is UltiSnips syntax, but this file lives in a "
+        r"'snippets/' directory which is reserved for snipMate"
+    )


### PR DESCRIPTION
Multiple closed issues (#233, #828, #1214, #1387, #1489) trace back to the same confusion: users put UltiSnips-format snippets into a directory called `snippets/`, which is reserved for snipMate. Today the snipMate parser silently mis-parses these files - either an opaque `Invalid line 'endsnippet'` error, or no error at all while snippets quietly fail to expand.

The existing `PebkacError` only fires when `snippets` is listed in `g:UltiSnipsSnippetDirectories`; it does nothing for the much more common case of a user creating `~/.vim/snippets/foo.snippets` directly with UltiSnips syntax.

This PR detects UltiSnips-only directives (`endsnippet`, `priority`, `global`, `pre_expand`, `post_expand`, `post_jump`, `post_finish`, `clearsnippets`, `context`) at the top level of a snipMate file and emits an actionable error: the file lives in a snipMate-reserved directory, so either rename it to `UltiSnips/` or set `g:UltiSnipsEnableSnipMate = 0`.