### PR TITLE
Drop UltiSnips internal trace for user-snippet errors

### DIFF
--- a/pythonx/UltiSnips/err_to_scratch_buffer.py
+++ b/pythonx/UltiSnips/err_to_scratch_buffer.py
@@ -63,7 +63,17 @@ def wrap(func):
         except Exception as e:
             if RemotePDB.is_enable():
                 RemotePDB.pm()
-            msg = """An error occurred. This is either a bug in UltiSnips or a bug in a
+            if hasattr(e, "snippet_code"):
+                # The exception happened inside user-authored snippet
+                # python code (snippet_code is attached by
+                # SnippetDefinition._make_debug_exception). The internal
+                # UltiSnips stack frames are not useful to the user; the
+                # offending line is already pointed at by the
+                # "Executed snippet code" block in _report_exception.
+                msg = "UltiSnips Error:\n\n"
+                msg += f"{type(e).__name__}: {e}".strip()
+            else:
+                msg = """An error occurred. This is either a bug in UltiSnips or a bug in a
 snippet definition. If you think this is a bug, please report it to
 https://github.com/SirVer/ultisnips/issues/new
 Please read and follow:
@@ -71,7 +81,7 @@ https://github.com/SirVer/ultisnips/blob/master/docs/CONTRIBUTING.md#reproducing
 
 Following is the full stack trace:
 """
-            msg += traceback.format_exc()
+                msg += traceback.format_exc()
             if RemotePDB.is_enable():
                 host, port = RemotePDB.get_host_port()
                 msg += (

--- a/test/test_ErrorReporting.py
+++ b/test/test_ErrorReporting.py
@@ -1,0 +1,31 @@
+"""Verify the scratch-buffer error display stays focused on what the user
+needs to fix, not on UltiSnips internals.
+
+Before: a raise inside a user's `!p` block dumped the full UltiSnips
+internal stack trace from `expand` -> `_try_expand` -> ... into the
+scratch buffer, drowning the actual exception message and the offending
+snippet line.
+
+Now: only the exception type/message and the offending snippet code are
+shown. The full traceback path remains for genuinely-unattributed
+exceptions (real UltiSnips bugs).
+"""
+
+from test.constant import EX
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class ErrorReporting_SnippetCodeIsConcise(_VimTest):
+    files = {
+        "us/all.snippets": """
+snippet bad "Bad snippet"
+`!p snip.rv = 1 / 0`
+endsnippet
+"""
+    }
+    keys = "bad" + EX
+    expected_error = (
+        r"(?s)UltiSnips Error:\s+ZeroDivisionError: division by zero.*"
+        r"Executed snippet code:"
+    )
+    forbidden_in_error = r"Following is the full stack trace"

--- a/test/vim_test_case.py
+++ b/test/vim_test_case.py
@@ -20,6 +20,7 @@ class VimTestCase(unittest.TestCase, TempFileManager):
     text_before = " --- some text before --- \n\n"
     text_after = "\n\n --- some text after --- "
     expected_error = ""
+    forbidden_in_error = ""
     wanted = ""
     keys = ""
     sleeptime = 0.00
@@ -50,6 +51,8 @@ class VimTestCase(unittest.TestCase, TempFileManager):
         for i in range(self.retries):
             if self.output and self.expected_error:
                 self.assertRegex(self.output, self.expected_error)
+                if self.forbidden_in_error:
+                    self.assertNotRegex(self.output, self.forbidden_in_error)
                 return
             if self.output != wanted or self.output is None:
                 # Redo this, but slower


### PR DESCRIPTION
When a user's `!p` block or pre/post-expand action raises, the exception is caught by `err_to_scratch_buffer.wrap` and rendered into a scratch buffer. Today the buffer leads with a full Python traceback through UltiSnips' own call stack (snippet_manager.expand -> _try_expand -> _do_snippet -> launch -> update_textobjects -> _update -> exec). For a user-attributable error - which is what these are - the internal frames are noise; the offending snippet line is already pointed at by the "Executed snippet code" block.

Drop the full stack trace whenever the exception carries `snippet_code` (set by `SnippetDefinition._make_debug_exception` and the `!p` interpolation path). The display collapses to:

```
UltiSnips Error:

ZeroDivisionError: division by zero
Executed snippet code:
1 > snip.rv = 1 / 0
```

Genuinely-unattributed exceptions (real UltiSnips bugs) keep the full traceback and the "please report" preamble - the user can still file a meaningful bug report.

Test framework gains a `forbidden_in_error` field so the regression test in `test_ErrorReporting.py` can assert both the new concise message and the absence of `Following is the full stack trace`.