### PR TITLE
Inject buffer into _Tabs at construction

### DIFF
--- a/pythonx/UltiSnips/snippet/definition/base.py
+++ b/pythonx/UltiSnips/snippet/definition/base.py
@@ -387,7 +387,7 @@ class SnippetDefinition:
             match = self._trigger.startswith(words_suffix)
             self._matched = words_suffix
 
-            # TODO: list_snippets() function cannot handle partial-trigger
+            # TODO(sirver): list_snippets() function cannot handle partial-trigger
             # matches yet, so for now fail if we trimmed the prefix.
             if words_suffix != words:
                 match = False

--- a/pythonx/UltiSnips/text_objects/python_code.py
+++ b/pythonx/UltiSnips/text_objects/python_code.py
@@ -23,8 +23,9 @@ def cached_compile(*args):
 class _Tabs:
     """Allows access to tabstop content via t[] inside of python code."""
 
-    def __init__(self, to):
+    def __init__(self, to, buf):
         self._to = to
+        self._buf = buf
 
     def __getitem__(self, no):
         ts = self._to._get_tabstop(self._to, int(no))
@@ -36,8 +37,7 @@ class _Tabs:
         ts = self._to._get_tabstop(self._to, int(no))
         if ts is None:
             return
-        # TODO(sirver): The buffer should be passed into the object on construction.
-        ts.overwrite(vim_helper.buf, value)
+        ts.overwrite(self._buf, value)
 
 
 class _VisualContent(NamedTuple):
@@ -283,7 +283,7 @@ class PythonCode(NoneditableTextObject):
         ct = self.current_text
         self._locals.update(
             {
-                "t": _Tabs(self._parent),
+                "t": _Tabs(self._parent, buf),
                 "fn": Path(path).name,
                 "path": path,
                 "cur": ct,

--- a/test/test_SnippetActions.py
+++ b/test/test_SnippetActions.py
@@ -411,7 +411,7 @@ a0"""
 class SnippetActions_PostActionModifiesCharAfterSnippet(_VimTest):
     # In neovim, modifying a buffer line in a post_expand action invalidates the
     # cursor mark, which triggers a spurious "line under the cursor was modified"
-    # error. TODO: investigate the mark handling difference.
+    # error. TODO(sirver): investigate the mark handling difference.
     skip_if = lambda self: (
         "Mark invalidated by buffer modification"
         if self.vim_flavor == "neovim"


### PR DESCRIPTION
`_Tabs.__setitem__` (the object behind `t[n] = "..."` in `!p` blocks) was reading `vim_helper.buf` at call time. Pass the buffer into the constructor instead and store it on the instance, so the object carries its own buffer reference rather than reaching into a module global. The call site in `PythonCode._update` already has the buffer in hand (it is the `buf` argument forwarded from `update_textobjects`), so this is behavior-preserving — the global and the parameter point at the same buffer object during the update cycle. Removes a `TODO(sirver)` that flagged the indirection.

Drive-by: normalise two `TODO:` comments in `pythonx/UltiSnips/snippet/definition/base.py` and `test/test_SnippetActions.py` to the project's `TODO(sirver):` convention.