### PR TITLE
Drop two stale TODOs

### DIFF
--- a/pythonx/UltiSnips/snippet/source/file/base.py
+++ b/pythonx/UltiSnips/snippet/source/file/base.py
@@ -92,8 +92,6 @@ class SnippetFileSource(SnippetSource):
                 priority, triggers = data
                 self._snippets[ft].clear_snippets(priority, triggers)
             elif event == "extends":
-                # TODO(sirver): extends information is more global
-                # than one snippet source.
                 (filetypes,) = data
                 self.update_extends(ft, filetypes)
             elif event == "snippet":

--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -114,8 +114,6 @@ def _get_potential_snippet_filenames_to_edit(
     return potentials
 
 
-# TODO(sirver): This class is still too long. It should only contain public
-# facing methods, most of the private methods should be moved outside of it.
 class SnippetManager:
     """The main entry point for all UltiSnips functionality.
 


### PR DESCRIPTION
Drop two stale TODOs - really do not want to do these things ever. 

`pythonx/UltiSnips/snippet/source/file/base.py`: the 12-year-old `TODO(sirver): extends information is more global than one snippet source` (added in `fe7cb4c`, 2014) is an architectural note about whether an `extends` directive should resolve across all snippet sources or stay source-local. The current per-source design has been stable through the entire snipMate integration and no bug has been filed against it.

`pythonx/UltiSnips/snippet_manager.py`: the `TODO(sirver): This class is still too long. It should only contain public facing methods, most of the private methods should be moved outside of it.` has sat on the head of `SnippetManager` for years without progress, and splitting it cleanly is dangerous - every Vim entrypoint routes through this class.
