### PR TITLE
Source defaults before Python import; gate after-plugin remap

### DIFF
--- a/after/plugin/UltiSnips_after.vim
+++ b/after/plugin/UltiSnips_after.vim
@@ -1,5 +1,14 @@
 " Called after everything else to reclaim keys (Needed for Supertab)
 
+" Bail out if plugin/UltiSnips.vim itself bailed (Python missing or
+" libpython load failure). The :UltiSnipsEdit command is registered
+" only after the Python check passes, so its absence is a load-failure
+" signal — don't reinstall the key mappings on top of a half-loaded
+" plugin. See #1658, #1679.
+if !exists(':UltiSnipsEdit')
+    finish
+endif
+
 if exists("b:did_after_plugin_ultisnips_after")
    finish
 endif

--- a/after/plugin/UltiSnips_after.vim
+++ b/after/plugin/UltiSnips_after.vim
@@ -1,10 +1,9 @@
 " Called after everything else to reclaim keys (Needed for Supertab)
 
-" Bail out if plugin/UltiSnips.vim itself bailed (Python missing or
-" libpython load failure). The :UltiSnipsEdit command is registered
-" only after the Python check passes, so its absence is a load-failure
-" signal — don't reinstall the key mappings on top of a half-loaded
-" plugin. See #1658, #1679.
+" Bail out if plugin/UltiSnips.vim itself bailed (Python missing or libpython
+" load failure). The :UltiSnipsEdit command is registered only after the
+" Python check passes, so its absence is a load-failure signal — don't
+" reinstall the key mappings on top of a half-loaded plugin (#1658, #1679).
 if !exists(':UltiSnipsEdit')
     finish
 endif

--- a/autoload/UltiSnips/map_keys.vim
+++ b/autoload/UltiSnips/map_keys.vim
@@ -1,57 +1,6 @@
-if exists("b:did_autoload_ultisnips_map_keys")
-   finish
-endif
-let b:did_autoload_ultisnips_map_keys = 1
-
-" The trigger used to expand a snippet.
-" NOTE: expansion and forward jumping can, but needn't be the same trigger
-if !exists("g:UltiSnipsExpandTrigger")
-    let g:UltiSnipsExpandTrigger = "<tab>"
-endif
-
-" The trigger used to display all triggers that could possible
-" match in the current position. Use empty to disable.
-if !exists("g:UltiSnipsListSnippets")
-    let g:UltiSnipsListSnippets = "<c-tab>"
-endif
-
-" The trigger used to jump forward to the next placeholder.
-" NOTE: expansion and forward jumping can be the same trigger.
-if !exists("g:UltiSnipsJumpForwardTrigger")
-    let g:UltiSnipsJumpForwardTrigger = "<c-j>"
-endif
-
-" The trigger to jump backward inside a snippet
-if !exists("g:UltiSnipsJumpBackwardTrigger")
-    let g:UltiSnipsJumpBackwardTrigger = "<c-k>"
-endif
-
-" Should UltiSnips unmap select mode mappings automagically?
-if !exists("g:UltiSnipsRemoveSelectModeMappings")
-    let g:UltiSnipsRemoveSelectModeMappings = 1
-end
-
-" If UltiSnips should remove Mappings, which should be ignored
-if !exists("g:UltiSnipsMappingsToIgnore")
-    let g:UltiSnipsMappingsToIgnore = []
-endif
-
-" UltiSnipsEdit will use this variable to decide if a new window
-" is opened when editing. default is "normal", allowed are also
-" "tabdo", "vertical", "horizontal", and "context".
-if !exists("g:UltiSnipsEditSplit")
-    let g:UltiSnipsEditSplit = 'normal'
-endif
-
-" A list of directory names that are searched for snippets.
-if !exists("g:UltiSnipsSnippetDirectories")
-    let g:UltiSnipsSnippetDirectories = [ "UltiSnips" ]
-endif
-
-" Enable or Disable snipmate snippet expansion.
-if !exists("g:UltiSnipsEnableSnipMate")
-    let g:UltiSnipsEnableSnipMate = 1
-endif
+" Defaults for the public `g:UltiSnips*` globals live in plugin/UltiSnips.vim
+" so the Python module (which reads `g:UltiSnipsExpandTrigger` etc. at import
+" time) finds them set regardless of the user's vimrc. See #1679.
 
 function! UltiSnips#map_keys#MapKeys() abort
     if exists("g:UltiSnipsExpandOrJumpTrigger")

--- a/autoload/UltiSnips/map_keys.vim
+++ b/autoload/UltiSnips/map_keys.vim
@@ -1,6 +1,57 @@
-" Defaults for the public `g:UltiSnips*` globals live in plugin/UltiSnips.vim
-" so the Python module (which reads `g:UltiSnipsExpandTrigger` etc. at import
-" time) finds them set regardless of the user's vimrc. See #1679.
+if exists("b:did_autoload_ultisnips_map_keys")
+   finish
+endif
+let b:did_autoload_ultisnips_map_keys = 1
+
+" The trigger used to expand a snippet.
+" NOTE: expansion and forward jumping can, but needn't be the same trigger
+if !exists("g:UltiSnipsExpandTrigger")
+    let g:UltiSnipsExpandTrigger = "<tab>"
+endif
+
+" The trigger used to display all triggers that could possible
+" match in the current position. Use empty to disable.
+if !exists("g:UltiSnipsListSnippets")
+    let g:UltiSnipsListSnippets = "<c-tab>"
+endif
+
+" The trigger used to jump forward to the next placeholder.
+" NOTE: expansion and forward jumping can be the same trigger.
+if !exists("g:UltiSnipsJumpForwardTrigger")
+    let g:UltiSnipsJumpForwardTrigger = "<c-j>"
+endif
+
+" The trigger to jump backward inside a snippet
+if !exists("g:UltiSnipsJumpBackwardTrigger")
+    let g:UltiSnipsJumpBackwardTrigger = "<c-k>"
+endif
+
+" Should UltiSnips unmap select mode mappings automagically?
+if !exists("g:UltiSnipsRemoveSelectModeMappings")
+    let g:UltiSnipsRemoveSelectModeMappings = 1
+end
+
+" If UltiSnips should remove Mappings, which should be ignored
+if !exists("g:UltiSnipsMappingsToIgnore")
+    let g:UltiSnipsMappingsToIgnore = []
+endif
+
+" UltiSnipsEdit will use this variable to decide if a new window
+" is opened when editing. default is "normal", allowed are also
+" "tabdo", "vertical", "horizontal", and "context".
+if !exists("g:UltiSnipsEditSplit")
+    let g:UltiSnipsEditSplit = 'normal'
+endif
+
+" A list of directory names that are searched for snippets.
+if !exists("g:UltiSnipsSnippetDirectories")
+    let g:UltiSnipsSnippetDirectories = [ "UltiSnips" ]
+endif
+
+" Enable or Disable snipmate snippet expansion.
+if !exists("g:UltiSnipsEnableSnipMate")
+    let g:UltiSnipsEnableSnipMate = 1
+endif
 
 function! UltiSnips#map_keys#MapKeys() abort
     if exists("g:UltiSnipsExpandOrJumpTrigger")

--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -13,6 +13,46 @@ if !has('nvim') && version < 820
    finish
 endif
 
+" Default the public globals before the Python import below. The autoload
+" file `autoload/UltiSnips/map_keys.vim` used to default these as a
+" side-effect of being sourced from `MapKeys()`, which ran *after* the
+" Python import — and the Python module reads
+" `g:UltiSnipsExpandTrigger` / `g:UltiSnipsJumpForwardTrigger` /
+" `g:UltiSnipsJumpBackwardTrigger` at module load, so a user who hadn't
+" set them in their vimrc would see a spurious "Python 3 is present but
+" unusable" warning with a `KeyError: 'Key not found:
+" UltiSnipsExpandTrigger'`. See #1679.
+"
+" NOTE: expansion and forward jumping can, but needn't be, the same
+" trigger.
+if !exists('g:UltiSnipsExpandTrigger')
+    let g:UltiSnipsExpandTrigger = '<tab>'
+endif
+if !exists('g:UltiSnipsListSnippets')
+    let g:UltiSnipsListSnippets = '<c-tab>'
+endif
+if !exists('g:UltiSnipsJumpForwardTrigger')
+    let g:UltiSnipsJumpForwardTrigger = '<c-j>'
+endif
+if !exists('g:UltiSnipsJumpBackwardTrigger')
+    let g:UltiSnipsJumpBackwardTrigger = '<c-k>'
+endif
+if !exists('g:UltiSnipsRemoveSelectModeMappings')
+    let g:UltiSnipsRemoveSelectModeMappings = 1
+endif
+if !exists('g:UltiSnipsMappingsToIgnore')
+    let g:UltiSnipsMappingsToIgnore = []
+endif
+if !exists('g:UltiSnipsEditSplit')
+    let g:UltiSnipsEditSplit = 'normal'
+endif
+if !exists('g:UltiSnipsSnippetDirectories')
+    let g:UltiSnipsSnippetDirectories = ['UltiSnips']
+endif
+if !exists('g:UltiSnipsEnableSnipMate')
+    let g:UltiSnipsEnableSnipMate = 1
+endif
+
 " UltiSnips needs Python 3. Bail with a clear message if Vim wasn't
 " compiled with python3 support at all, so we don't fall through to the
 " runtime-check below (which would just say "Python is broken" without

--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -13,46 +13,6 @@ if !has('nvim') && version < 820
    finish
 endif
 
-" Default the public globals before the Python import below. The autoload
-" file `autoload/UltiSnips/map_keys.vim` used to default these as a
-" side-effect of being sourced from `MapKeys()`, which ran *after* the
-" Python import — and the Python module reads
-" `g:UltiSnipsExpandTrigger` / `g:UltiSnipsJumpForwardTrigger` /
-" `g:UltiSnipsJumpBackwardTrigger` at module load, so a user who hadn't
-" set them in their vimrc would see a spurious "Python 3 is present but
-" unusable" warning with a `KeyError: 'Key not found:
-" UltiSnipsExpandTrigger'`. See #1679.
-"
-" NOTE: expansion and forward jumping can, but needn't be, the same
-" trigger.
-if !exists('g:UltiSnipsExpandTrigger')
-    let g:UltiSnipsExpandTrigger = '<tab>'
-endif
-if !exists('g:UltiSnipsListSnippets')
-    let g:UltiSnipsListSnippets = '<c-tab>'
-endif
-if !exists('g:UltiSnipsJumpForwardTrigger')
-    let g:UltiSnipsJumpForwardTrigger = '<c-j>'
-endif
-if !exists('g:UltiSnipsJumpBackwardTrigger')
-    let g:UltiSnipsJumpBackwardTrigger = '<c-k>'
-endif
-if !exists('g:UltiSnipsRemoveSelectModeMappings')
-    let g:UltiSnipsRemoveSelectModeMappings = 1
-endif
-if !exists('g:UltiSnipsMappingsToIgnore')
-    let g:UltiSnipsMappingsToIgnore = []
-endif
-if !exists('g:UltiSnipsEditSplit')
-    let g:UltiSnipsEditSplit = 'normal'
-endif
-if !exists('g:UltiSnipsSnippetDirectories')
-    let g:UltiSnipsSnippetDirectories = ['UltiSnips']
-endif
-if !exists('g:UltiSnipsEnableSnipMate')
-    let g:UltiSnipsEnableSnipMate = 1
-endif
-
 " UltiSnips needs Python 3. Bail with a clear message if Vim wasn't
 " compiled with python3 support at all, so we don't fall through to the
 " runtime-check below (which would just say "Python is broken" without
@@ -67,6 +27,17 @@ endif
 if !has('python3')
     finish
 endif
+
+" Apply default values for the public `g:UltiSnips*` globals before the
+" Python module imports. The defaults live at the head of
+" `autoload/UltiSnips/map_keys.vim` and run as a side effect of sourcing
+" that file; `MapKeys()` itself is harmless to call here. The Python
+" module reads `g:UltiSnipsExpandTrigger` / `g:UltiSnipsJumpForwardTrigger`
+" / `g:UltiSnipsJumpBackwardTrigger` at module load via `vim.vars[...]`,
+" so without the autoload's defaults a user who hadn't set those globals
+" in their vimrc would see a spurious "Python 3 is present but unusable"
+" warning with a `KeyError`. See #1679.
+call UltiSnips#map_keys#MapKeys()
 
 " `has('python3')` is necessary but not sufficient: Vim can be compiled
 " with dynamic Python support and still fail to load libpython at
@@ -124,7 +95,5 @@ augroup UltiSnips_AutoTrigger
         au TextChangedP * call UltiSnips#TrackChange()
     endif
 augroup END
-
-call UltiSnips#map_keys#MapKeys()
 
 " vim: ts=8 sts=4 sw=4

--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -28,16 +28,12 @@ if !has('python3')
     finish
 endif
 
-" Apply default values for the public `g:UltiSnips*` globals before the
-" Python module imports. The defaults live at the head of
-" `autoload/UltiSnips/map_keys.vim` and run as a side effect of sourcing
-" that file; `MapKeys()` itself is harmless to call here. The Python
-" module reads `g:UltiSnipsExpandTrigger` / `g:UltiSnipsJumpForwardTrigger`
-" / `g:UltiSnipsJumpBackwardTrigger` at module load via `vim.vars[...]`,
-" so without the autoload's defaults a user who hadn't set those globals
-" in their vimrc would see a spurious "Python 3 is present but unusable"
-" warning with a `KeyError`. See #1679.
-call UltiSnips#map_keys#MapKeys()
+" We are sourcing map_keys.vim here, because we want the UltiSnips trigger
+" variables to be defined before trying to load the Python code. However, we
+" do not want to map the keys yet - in case something goes wrong with the
+" loading, we do not want to have spuriously mapped keys; i.e. a half loaded
+" plugin (see #1658, #1679).
+runtime autoload/UltiSnips/map_keys.vim
 
 " `has('python3')` is necessary but not sufficient: Vim can be compiled
 " with dynamic Python support and still fail to load libpython at
@@ -95,5 +91,7 @@ augroup UltiSnips_AutoTrigger
         au TextChangedP * call UltiSnips#TrackChange()
     endif
 augroup END
+
+call UltiSnips#map_keys#MapKeys()
 
 " vim: ts=8 sts=4 sw=4


### PR DESCRIPTION
Source defaults before Python import; gate after-plugin remap

`plugin/UltiSnips.vim` forces the `py3 from UltiSnips import UltiSnips_Manager` at plugin load (added in #1658, so a libpython load failure or missing-package error is caught with one warning instead of being re-raised on every keystroke). The Python module reads `g:UltiSnipsExpandTrigger`, `g:UltiSnipsJumpForwardTrigger`, and `g:UltiSnipsJumpBackwardTrigger` at import time via `vim.vars[...]` (the form without a fallback, switched to in #1605). The defaults for those globals are set as a side effect of `autoload/UltiSnips/map_keys.vim` being sourced, which only happened from the `call UltiSnips#map_keys#MapKeys()` line at the *end* of `plugin/UltiSnips.vim` — i.e. after the Python import. A user who hadn't set the triggers in their vimrc therefore saw:

```
UltiSnips: Python 3 is present but unusable; disabling UltiSnips.
           KeyError: 'Key not found: UltiSnipsExpandTrigger'
```

even with a perfectly working Python 3.

`plugin/UltiSnips.vim` now runs `runtime autoload/UltiSnips/map_keys.vim` immediately after the `has('python3')` build check and *before* the Python try block. Sourcing the autoload runs its `if !exists | let g:... = ... | endif` defaults block but does not call the function, so the public globals are defaulted in time for the Python module to read them at import. The `call UltiSnips#map_keys#MapKeys()` line stays at the bottom of the file so the keymaps are only installed once the Python check has passed — a load failure can `finish` cleanly without leaving the plugin half-initialised.

`after/plugin/UltiSnips_after.vim` (the "reclaim keys for SuperTab" hook) is sourced unconditionally by Vim regardless of whether `plugin/UltiSnips.vim` finished early; gate it on `exists(':UltiSnipsEdit')` (the command is only registered after the Python check passes) so it doesn't reinstall the keymaps on top of a half-loaded plugin either.

Fixes #1679.
