### PR TITLE
Show w-option snippets in UltiSnipsListSnippets across non-word boundaries

### DIFF
--- a/pythonx/UltiSnips/snippet/definition/base.py
+++ b/pythonx/UltiSnips/snippet/definition/base.py
@@ -394,11 +394,6 @@ class SnippetDefinition:
             )
             match = self._trigger.startswith(words_suffix)
             self._matched = words_suffix
-
-            # TODO(sirver): list_snippets() function cannot handle partial-trigger
-            # matches yet, so for now fail if we trimmed the prefix.
-            if words_suffix != words:
-                match = False
         elif "i" in self._opts:
             # In-word snippets can appear after arbitrary non-word
             # characters, so check if the trigger starts with any

--- a/test/test_ListSnippets.py
+++ b/test/test_ListSnippets.py
@@ -56,6 +56,15 @@ class ListAllAvailable_InWordWithPrefix_ExpectCorrectResult(_VimTest):
     wanted = "!exists('')"
 
 
+# Word-boundary snippets should be listed when a partial trigger sits
+# after a non-word character, and selecting one must replace only the
+# partial suffix - not the preceding non-word chunk.
+class ListAllAvailable_WordOptionPartialAfterPunctuation_ExpectCorrectResult(_VimTest):
+    snippets = (("foo", "FOO", "foo word-snippet", "w"),)
+    keys = "x.fo" + LS + "1\n"
+    wanted = "x.FOO"
+
+
 # GH #1226: a number larger than the list length used to be clamped to
 # the last item, silently picking a snippet the user didn't choose (and a
 # negative answer from a mouse click above the menu could IndexError).


### PR DESCRIPTION
`SnippetDefinition.could_match` (`pythonx/UltiSnips/snippet/definition/base.py`) is the filter behind `g:UltiSnipsListSnippets` - it walks every snippet and returns those whose trigger could still match as the user keeps typing. For the `w` option (trigger must start at a word boundary), it computed `words` as the last N words before the cursor, trimmed any non-empty prefix up to the last word boundary via the `\v^.+<(.+)` substitute to get `words_suffix`, recognised that the trigger started with that suffix and set `self._matched = words_suffix` - and then immediately forced `match = False` whenever `words_suffix != words`. A 2019-vintage TODO explained the guard: "list_snippets() function cannot handle partial-trigger matches yet, so for now fail if we trimmed the prefix."

That hasn't been true for a while. `SnippetManager._do_snippet` (`pythonx/UltiSnips/snippet_manager.py`) already computes `text_before = before[:-len(snippet.matched)]` and uses that as the replacement start, so any `_matched` shorter than the typed text works correctly. The `i` option exercises exactly this path through `:UltiSnipsListSnippets` today - `ListAllAvailable_InWordWithPrefix_ExpectCorrectResult` types `!exists`, picks from the list, and the leading `!` is preserved because `_matched = "exists"` strips only the trigger portion.

Drop the four-line guard. The `_matched = words_suffix` assignment that was already happening now reaches `_do_snippet`, which strips only the typed partial and inserts the expansion in its place. Add a regression test (`ListAllAvailable_WordOptionPartialAfterPunctuation_ExpectCorrectResult`): trigger `foo` with option `w`, buffer `x.fo`, `<c-tab>`, pick option 1 - expect `x.FOO`.