### PR TITLE
Correct VIM version check

### DIFF
--- a/plugin/UltiSnips.vim
+++ b/plugin/UltiSnips.vim
@@ -6,7 +6,7 @@ let did_plugin_ultisnips=1
 " CI tests against Vim 9.1+, but older versions down to 8.2 may still work.
 " Neovim reports a low 'version' (801) for Vim compatibility, so skip the
 " check there — Neovim compatibility is validated separately in CI.
-if !has('nvim') && version < 820
+if !has('nvim') && version < 802
    echohl WarningMsg
    echom  "UltiSnips requires Vim >= 8.2"
    echohl None


### PR DESCRIPTION
Fixes the VIM 8.2 version check on startup to check against the correct value.