### PR TITLE
Fix expand_anon dropping bodies with no tabstop in post_expand

### DIFF
--- a/pythonx/UltiSnips/snippet_manager.py
+++ b/pythonx/UltiSnips/snippet_manager.py
@@ -863,6 +863,13 @@ class SnippetManager:
                 self._visual_content.text, self._active_snippets
             )
 
+        # `pre_expand` may have nested an anonymous snippet (the "wrap"
+        # pattern from #1579 / #1592). Capture that fact before our own
+        # body is launched so the post-expand book-keeping below can
+        # tell apart "inner was already there before us" from "inner
+        # came and went during our `post_expand`".
+        pre_expand_nested = self._snip_expanded_in_action
+
         if cursor_set_in_action:
             text_before = vim_helper.buf.line_till_cursor
             before = vim_helper.buf.line_till_cursor
@@ -921,36 +928,58 @@ class SnippetManager:
             self._vstate.remember_buffer(self._active_snippets[0])
             self._change_provider.reset()
 
-            # Three shapes show up here depending on which action
+            # Four shapes show up here depending on which action
             # nested another snippet via `snip.expand_anon`:
             #
-            #   1. No nesting. `_active_snippets[-1]` is `snippet_instance`
-            #      (the snippet we just launched). Jump into our first
-            #      tabstop as usual.
+            #   1. No nesting. `_snip_expanded_in_action` is False.
+            #      Jump into our first tabstop as usual (this is also
+            #      what fires `post_jump` on the implicit `$0` for
+            #      bodyless snippets).
             #
             #   2. `pre_expand` nested. The action ran *before* our
             #      `launch`, so the inner snippet was appended first and
             #      our own append put us on top of it. `_active_snippets[-1]`
-            #      is still `snippet_instance` — but `current_text` on the
-            #      outer reflects only our body, which is empty when the
-            #      user is wrapping content with an anon snippet, so the
-            #      old `_current_snippet.current_text != ""` branch
-            #      naturally pops the empty wrapper.
+            #      is still `snippet_instance`. If outer has its own
+            #      body the user expects to fill outer's tabstops first
+            #      (#1579 / #1592 wrap pattern), so jump; if outer is a
+            #      hollow wrapper (`current_text == ""`) pop it
+            #      immediately.
             #
-            #   3. `post_expand` nested. The action ran *after* our
-            #      append, so the inner sits on top of us. The nested
-            #      `_do_snippet` already jumped to its own first tabstop;
-            #      a second jump here would skip it. Drop ourselves from
-            #      the stack so the inner is the live snippet.
+            #   3. `post_expand` nested and the inner is still live. The
+            #      action ran *after* our append, so the inner sits on
+            #      top of us. The nested `_do_snippet` already jumped to
+            #      its own first tabstop; a second jump here would skip
+            #      it. Drop ourselves from the stack so the inner is the
+            #      live snippet.
+            #
+            #   4. `post_expand` nested an inner that finished its own
+            #      jumps inside the action (e.g. anon body with only `$0`
+            #      or plain text — `_jump` selects `$0` and pops it).
+            #      Outer's `$0` tabstop was stretched by
+            #      `_child_has_moved` to span the inner's text; jumping
+            #      into it now would re-select the entire inner body and
+            #      derail the buffer state. Outer has nothing left to
+            #      offer, so finish it cleanly. See #1688.
+            post_expand_nested_and_popped = (
+                self._snip_expanded_in_action
+                and not pre_expand_nested
+                and self._active_snippets
+                and self._active_snippets[-1] is snippet_instance
+            )
             if (
                 self._snip_expanded_in_action
                 and self._active_snippets
                 and self._active_snippets[-1] is not snippet_instance
             ):
-                # Shape 3 — post_expand nested an inner snippet.
+                # Shape 3 — inner is still on the stack.
                 self._active_snippets.remove(snippet_instance)
                 if not self._active_snippets:
                     self._teardown_inner_state()
+            elif post_expand_nested_and_popped:
+                # Shape 4 — post_expand nested an inner that already
+                # finished. Pop outer; jumping would re-select the
+                # inner body that outer's `$0` now wraps.
+                self._current_snippet_is_done()
             elif (
                 not self._snip_expanded_in_action
                 or self._current_snippet.current_text != ""

--- a/test/test_Issue1688.py
+++ b/test/test_Issue1688.py
@@ -1,0 +1,49 @@
+"""Regression tests for #1688.
+
+`post_expand` action's `snip.expand_anon` silently drops the expansion
+when the anon body has no `$N` (only `$0`, or plain text).
+
+Sibling of #1434 (`test_Issue1434.py`), which only covered bodies that
+contain a `$1` tabstop.
+"""
+
+from test.constant import EX, JF
+from test.vim_test_case import VimTestCase as _VimTest
+
+
+class Issue1688_PostExpandAnonPlainText(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        post_expand "snip.expand_anon('plain text result')"
+        snippet noTab "no tabstop"
+        endsnippet
+        """
+    }
+    keys = "noTab" + EX
+    wanted = "plain text result"
+
+
+class Issue1688_PostExpandAnonOnlyZeroTabstop(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        post_expand "snip.expand_anon('result-with-$0-tabstop')"
+        snippet justZero "with just \$0"
+        endsnippet
+        """
+    }
+    keys = "justZero" + EX + "MID"
+    wanted = "result-with-MID-tabstop"
+
+
+class Issue1688_PostExpandAnonWithFirstTabstop(_VimTest):
+    """Sanity check: ${1:...} already worked before — keep it passing."""
+
+    files = {
+        "us/all.snippets": r"""
+        post_expand "snip.expand_anon('${1:result}')"
+        snippet withTab "with \$1 tabstop"
+        endsnippet
+        """
+    }
+    keys = "withTab" + EX + JF + "after"
+    wanted = "resultafter"


### PR DESCRIPTION
When a `post_expand` action called `snip.expand_anon` with a body that had no `$N` tabstop (plain text or just `$0`), the inner's `_jump` selected `$0` immediately and popped the inner. Control returned to outer's `_do_snippet`, where the existing branch chose `_jump` based on `current_text != ""` - but outer's `$0` had been stretched by `_child_has_moved` to span the inner's text, so jumping re-selected the entire inner body and the buffer state ended up reverted.

Track whether `pre_expand` (not `post_expand`) was responsible for any nested expansion, then add a fourth branch in the post-expand book-keeping that pops outer cleanly when `post_expand` nested an inner that finished its own jumps inside the action. Sibling of #1434 / #1652, which only covered bodies that contain a `$1` tabstop.

Fixes #1688.