### PR TITLE
Ignore hidden files during snippet file discovery

### DIFF
--- a/pythonx/UltiSnips/snippet/source/file/snipmate.py
+++ b/pythonx/UltiSnips/snippet/source/file/snipmate.py
@@ -32,6 +32,10 @@ def _snipmate_files_for(ft):
         path = Path(rtp, "snippets").expanduser()
         for pattern in patterns:
             for fn in path.glob(pattern):
+                # Unlike glob.glob, Path.glob matches hidden files; skip
+                # them so editor droppings are not parsed as snippets.
+                if fn.name.startswith("."):
+                    continue
                 ret.add(normalize_file_path(str(fn)))
     return ret
 

--- a/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
+++ b/pythonx/UltiSnips/snippet/source/file/ulti_snips.py
@@ -25,6 +25,11 @@ def find_snippet_files(ft, directory: str) -> set[str]:
     directory_path = Path(directory).expanduser()
     for pattern in patterns:
         for fn in directory_path.glob(pattern % ft):
+            # Unlike glob.glob, Path.glob matches hidden files, so the
+            # "ft/*" pattern would pick up Vim's undo/swap files (e.g.
+            # ".foo.snippets.un~") and choke parsing them.
+            if fn.name.startswith("."):
+                continue
             ret.add(normalize_file_path(str(fn)))
     return ret
 

--- a/test/test_Fixes.py
+++ b/test/test_Fixes.py
@@ -510,3 +510,45 @@ class Issue1311_PairTabAfterModeRoundTrip(_VimTest):
         vim_config.append('let g:UltiSnipsExpandTrigger="<tab>"')
         vim_config.append('let g:UltiSnipsJumpForwardTrigger="<tab>"')
         vim_config.append('let g:UltiSnipsJumpBackwardTrigger="<s-tab>"')
+
+
+# Regression tests for #1691 — the migration from glob.glob to Path.glob
+# (#1606) silently changed hidden-file semantics: glob.glob never matches
+# names starting with a dot, Path.glob does. Vim drops undo files like
+# ".foo.snippets.un~" next to edited snippet files (with 'undofile' set and
+# 'undodir' containing "."), and the "ft/*" lookup pattern then picked them
+# up and crashed with a UnicodeDecodeError on their binary content. Pin the
+# restored pre-#1606 behaviour: hidden files are never snippet sources.
+
+
+class Issue1691_UndoFileInSnippetSubdirectoryIsIgnored(_VimTest):
+    files = {
+        "us/all/real.snippets": r"""
+        snippet works "from the real file"
+        expanded fine
+        endsnippet
+        """
+    }
+    keys = "works" + EX
+    wanted = "expanded fine"
+
+    def _before_test(self):
+        # What Vim writes for real.snippets with 'undodir' set to ".":
+        # hidden and not valid UTF-8 (0x9f, the byte from the issue).
+        undo_file = self.name_temp("us/all/.real.snippets.un~")
+        undo_file.write_bytes(b"Vim\x9f\x00\x01 undo file")
+
+
+class Issue1691_HiddenSnippetFileIsIgnored(_VimTest):
+    """Even a parseable hidden file in ft/* must stay invisible, as it
+    was before the Path.glob migration."""
+
+    files = {
+        "us/all/.hidden.snippets": r"""
+        snippet spooky "from a hidden file"
+        BOO
+        endsnippet
+        """
+    }
+    keys = "spooky" + EX
+    wanted = "spooky" + EX

--- a/test/test_SnipMate.py
+++ b/test/test_SnipMate.py
@@ -297,3 +297,16 @@ endglobal
         r"'global' is UltiSnips syntax, but this file lives in a "
         r"'snippets/' directory which is reserved for snipMate"
     )
+
+
+class snipMate_HiddenFileIsIgnored(_VimTest):
+    """Regression test for #1691: Path.glob (unlike the glob.glob used
+    before #1606) matches hidden files; they must stay invisible."""
+
+    files = {
+        "snippets/_/.hidden.snippets": """
+snippet spooky
+\tBOO"""
+    }
+    keys = "spooky" + EX
+    wanted = "spooky" + EX


### PR DESCRIPTION
Opening a buffer crashed with a UnicodeDecodeError when a Vim undo file (e.g. `.templates.snippets.un~`, written when 'undofile' is set and 'undodir' contains ".") sat in a filetype subdirectory of a snippet directory: the `ft/*` lookup pattern picked it up and tried to parse the binary content as a snippet file.

This is a regression from the pathlib migration cleanup (#1606): `glob.glob` never matches names starting with a dot, but its replacement `Path.glob` does, so dot-prefixed undo and swap files suddenly became visible to snippet discovery. Skip hidden files in the glob results of both the UltiSnips and snipMate lookups, restoring the pre-#1606 semantics. This covers undo files, swap files, `.DS_Store` and similar droppings in one place, while keeping the documented `ft/*` behaviour for regular files unchanged.

Fixes #1691.